### PR TITLE
feat(worker): implement PR-3 DO lobby connection management

### DIFF
--- a/apps/worker/src/durable/room-object.ts
+++ b/apps/worker/src/durable/room-object.ts
@@ -1,0 +1,197 @@
+import {
+  LEVEL_FILTERS,
+  MAX_PLAYERS_OPTIONS,
+  MODES,
+  PLAY_STYLES,
+  VISIBILITIES,
+  WIN_METRICS,
+  type ErrorCode,
+  type RoomSettings,
+} from "@infinitas/shared";
+import type { WorkerEnv } from "../types/env";
+import { asEnumValue, asOptionalString, isRecord } from "../utils/validation";
+import { createServerEnvelope } from "./ws-codec";
+import { RoomLobbyState, type RoomInitializationInput } from "./room-state";
+
+interface RoomSocketSession {
+  socket: WebSocket;
+}
+
+const OPEN_WEBSOCKET_STATE = 1;
+const SWITCHING_PROTOCOLS_STATUS = 101;
+
+function isWebSocketUpgradeRequest(request: Request): boolean {
+  const upgrade = request.headers.get("upgrade");
+  return typeof upgrade === "string" && upgrade.toLowerCase() === "websocket";
+}
+
+function jsonResponse(status: number, payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+    },
+  });
+}
+
+function parseRoomSettings(value: unknown): RoomSettings | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const visibility = asEnumValue(value.visibility, VISIBILITIES);
+  const joinCodeRaw = value.join_code;
+  const mode = asEnumValue(value.mode, MODES);
+  const winMetric = asEnumValue(value.win_metric, WIN_METRICS);
+  const playStyle = asEnumValue(value.play_style, PLAY_STYLES);
+  const levelFilter = asEnumValue(value.level_filter, LEVEL_FILTERS);
+  const roomComment = asOptionalString(value.room_comment);
+  const maxPlayers =
+    value.max_players === 2 || value.max_players === 3 || value.max_players === 4
+      ? value.max_players
+      : undefined;
+
+  if (
+    visibility === undefined ||
+    mode === undefined ||
+    winMetric === undefined ||
+    playStyle === undefined ||
+    levelFilter === undefined ||
+    roomComment === undefined ||
+    maxPlayers === undefined ||
+    !MAX_PLAYERS_OPTIONS.includes(maxPlayers)
+  ) {
+    return null;
+  }
+
+  if (joinCodeRaw !== null && typeof joinCodeRaw !== "string") {
+    return null;
+  }
+
+  return {
+    visibility,
+    join_code: joinCodeRaw,
+    mode,
+    win_metric: winMetric,
+    play_style: playStyle,
+    level_filter: levelFilter,
+    room_comment: roomComment,
+    max_players: maxPlayers,
+  };
+}
+
+function parseInitializationInput(payload: unknown): RoomInitializationInput | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  const roomId = asOptionalString(payload.room_id);
+  const createdAt = asOptionalString(payload.created_at);
+  const settings = parseRoomSettings(payload.settings);
+
+  if (!roomId || !createdAt || settings === null) {
+    return null;
+  }
+
+  return {
+    room_id: roomId,
+    settings,
+    created_at: createdAt,
+  };
+}
+
+export class RoomDurableObject {
+  private readonly roomState = new RoomLobbyState();
+  private readonly sessionsBySocket = new Map<WebSocket, RoomSocketSession>();
+
+  constructor(
+    private readonly _state: unknown,
+    private readonly _env: WorkerEnv,
+  ) {}
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/internal/init" && request.method === "POST") {
+      return this.handleInternalInitialize(request);
+    }
+
+    if (!isWebSocketUpgradeRequest(request)) {
+      return new Response("Expected websocket upgrade request.", { status: 426 });
+    }
+
+    const roomIdHeader = request.headers.get("x-room-id");
+    if (this.roomState.isInitialized() && roomIdHeader !== this.roomState.getRoomId()) {
+      return new Response("room_id routing mismatch.", { status: 400 });
+    }
+
+    const socketPairCtor = (globalThis as unknown as {
+      WebSocketPair: new () => { 0: WebSocket; 1: WebSocket };
+    }).WebSocketPair;
+    const socketPair = new socketPairCtor();
+    const clientSocket = socketPair[0];
+    const serverSocket = socketPair[1];
+
+    (serverSocket as unknown as { accept: () => void }).accept();
+    this.attachSocket(serverSocket);
+
+    return new Response(null, {
+      status: SWITCHING_PROTOCOLS_STATUS,
+      webSocket: clientSocket,
+    } as ResponseInit);
+  }
+
+  private async handleInternalInitialize(request: Request): Promise<Response> {
+    let payload: unknown;
+    try {
+      payload = await request.json();
+    } catch {
+      return jsonResponse(400, { error: "Invalid JSON payload." });
+    }
+
+    const parsed = parseInitializationInput(payload);
+    if (parsed === null) {
+      return jsonResponse(400, { error: "Invalid room initialization payload." });
+    }
+
+    try {
+      this.roomState.initialize(parsed);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to initialize room.";
+      return jsonResponse(400, { error: message });
+    }
+
+    return jsonResponse(200, {
+      ok: true,
+      room_id: this.roomState.getRoomId(),
+    });
+  }
+
+  private attachSocket(socket: WebSocket): void {
+    const session: RoomSocketSession = { socket };
+    this.sessionsBySocket.set(socket, session);
+
+    socket.addEventListener("message", () => {
+      this.sendError(socket, "INVALID_STATE", "Room message handlers are not initialized.");
+    });
+    socket.addEventListener("close", () => {
+      this.handleSocketClose(socket);
+    });
+    socket.addEventListener("error", () => {
+      this.handleSocketClose(socket);
+    });
+  }
+
+  private handleSocketClose(socket: WebSocket): void {
+    this.sessionsBySocket.delete(socket);
+  }
+
+  private sendError(socket: WebSocket, code: ErrorCode, message: string): void {
+    if (socket.readyState !== OPEN_WEBSOCKET_STATE) {
+      return;
+    }
+
+    const roomId = this.roomState.isInitialized() ? this.roomState.getRoomId() : "";
+    socket.send(JSON.stringify(createServerEnvelope(roomId, "ERROR", { code, message })));
+  }
+}

--- a/apps/worker/src/durable/room-object.ts
+++ b/apps/worker/src/durable/room-object.ts
@@ -3,20 +3,29 @@ import {
   MAX_PLAYERS_OPTIONS,
   MODES,
   PLAY_STYLES,
+  SOURCE_TYPES,
   VISIBILITIES,
   WIN_METRICS,
+  type ClientMessage,
   type ErrorCode,
+  type RoomJoinPayload,
   type RoomSettings,
+  type ServerMessagePayloadMap,
+  type ServerMessageType,
 } from "@infinitas/shared";
+import { deleteLobbyRoom } from "../kv/lobby-kv";
+import { normalizeJoinCode } from "../services/join-code";
 import type { WorkerEnv } from "../types/env";
 import { asEnumValue, asOptionalString, isRecord } from "../utils/validation";
-import { createServerEnvelope } from "./ws-codec";
+import { createServerEnvelope, decodeClientMessage } from "./ws-codec";
 import { RoomLobbyState, type RoomInitializationInput } from "./room-state";
 
 interface RoomSocketSession {
   socket: WebSocket;
+  playerId: string | null;
 }
 
+const IDEMPOTENCY_LOG_LIMIT = 300;
 const OPEN_WEBSOCKET_STATE = 1;
 const SWITCHING_PROTOCOLS_STATUS = 101;
 
@@ -100,13 +109,35 @@ function parseInitializationInput(payload: unknown): RoomInitializationInput | n
   };
 }
 
+function parseRoomJoinPayload(payload: unknown): RoomJoinPayload | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  const displayNameRaw = asOptionalString(payload.display_name);
+  const source = asEnumValue(payload.source, SOURCE_TYPES);
+  const joinCode = asOptionalString(payload.join_code);
+
+  const displayName = displayNameRaw?.trim() ?? "";
+  if (displayName.length === 0 || source === undefined) {
+    return null;
+  }
+
+  return {
+    display_name: displayName,
+    source,
+    ...(joinCode === undefined ? {} : { join_code: joinCode }),
+  };
+}
+
 export class RoomDurableObject {
   private readonly roomState = new RoomLobbyState();
   private readonly sessionsBySocket = new Map<WebSocket, RoomSocketSession>();
+  private readonly seenClientMessageIds = new Map<string, string[]>();
 
   constructor(
     private readonly _state: unknown,
-    private readonly _env: WorkerEnv,
+    private readonly env: WorkerEnv,
   ) {}
 
   async fetch(request: Request): Promise<Response> {
@@ -168,11 +199,14 @@ export class RoomDurableObject {
   }
 
   private attachSocket(socket: WebSocket): void {
-    const session: RoomSocketSession = { socket };
+    const session: RoomSocketSession = {
+      socket,
+      playerId: null,
+    };
     this.sessionsBySocket.set(socket, session);
 
-    socket.addEventListener("message", () => {
-      this.sendError(socket, "INVALID_STATE", "Room message handlers are not initialized.");
+    socket.addEventListener("message", (event) => {
+      this.handleSocketMessage(socket, event);
     });
     socket.addEventListener("close", () => {
       this.handleSocketClose(socket);
@@ -182,16 +216,259 @@ export class RoomDurableObject {
     });
   }
 
-  private handleSocketClose(socket: WebSocket): void {
-    this.sessionsBySocket.delete(socket);
+  private handleSocketMessage(socket: WebSocket, event: MessageEvent): void {
+    const session = this.sessionsBySocket.get(socket);
+    if (!session) {
+      return;
+    }
+
+    if (typeof event.data !== "string") {
+      this.sendError(socket, "INVALID_STATE", "Only text messages are supported.");
+      return;
+    }
+
+    const decoded = decodeClientMessage(event.data);
+    if (!decoded.ok) {
+      this.sendError(socket, "INVALID_STATE", decoded.error);
+      return;
+    }
+
+    const message = decoded.message;
+    if (
+      message.client_msg_id.trim().length === 0 ||
+      message.player_id.trim().length === 0 ||
+      message.room_id.trim().length === 0
+    ) {
+      this.sendError(socket, "INVALID_STATE", "Envelope fields must not be empty.");
+      return;
+    }
+
+    if (this.roomState.isInitialized() && message.room_id !== this.roomState.getRoomId()) {
+      this.sendError(socket, "INVALID_STATE", "room_id does not match this room.");
+      return;
+    }
+
+    if (session.playerId !== null && session.playerId !== message.player_id) {
+      this.sendError(socket, "INVALID_STATE", "player_id mismatch on this socket.");
+      return;
+    }
+
+    if (this.isDuplicateMessage(message.player_id, message.client_msg_id)) {
+      return;
+    }
+
+    if (message.type !== "ROOM_JOIN" && session.playerId === null) {
+      this.sendError(socket, "INVALID_STATE", "Send ROOM_JOIN before this message.");
+      return;
+    }
+
+    switch (message.type) {
+      case "ROOM_JOIN":
+        this.handleRoomJoin(session, message as ClientMessage<"ROOM_JOIN">);
+        return;
+      case "ROOM_LEAVE":
+        this.handleRoomLeave(session, true);
+        return;
+      case "STATE_GET":
+        this.sendStateSnapshot(socket);
+        return;
+      case "PING":
+        this.send(socket, "PONG", {});
+        return;
+      default:
+        this.sendError(socket, "INVALID_STATE", `Message type ${message.type} is unavailable in LOBBY.`);
+    }
   }
 
-  private sendError(socket: WebSocket, code: ErrorCode, message: string): void {
+  private handleSocketClose(socket: WebSocket): void {
+    const session = this.sessionsBySocket.get(socket);
+    if (!session) {
+      return;
+    }
+
+    this.sessionsBySocket.delete(socket);
+    this.handleRoomLeave(session, false);
+  }
+
+  private handleRoomJoin(session: RoomSocketSession, message: ClientMessage<"ROOM_JOIN">): void {
+    if (!this.roomState.isInitialized()) {
+      this.sendJoinRejected(session.socket, "ROOM_STATE_LOST");
+      return;
+    }
+    if (this.roomState.getRoomState() === "CLOSED") {
+      this.sendJoinRejected(session.socket, "ROOM_CLOSED");
+      return;
+    }
+
+    const payload = parseRoomJoinPayload(message.payload);
+    if (payload === null) {
+      this.sendJoinRejected(session.socket, "INVALID_JOIN_PAYLOAD");
+      return;
+    }
+
+    const existingSession = this.findSessionByPlayerId(message.player_id);
+    if (existingSession && existingSession.socket !== session.socket) {
+      this.sendJoinRejected(session.socket, "PLAYER_ALREADY_CONNECTED");
+      return;
+    }
+
+    const settings = this.roomState.getSettings();
+    if (settings.visibility === "PRIVATE") {
+      const expectedJoinCode = normalizeJoinCode(settings.join_code);
+      const observedJoinCode = normalizeJoinCode(payload.join_code);
+      if (expectedJoinCode === null || observedJoinCode !== expectedJoinCode) {
+        this.sendJoinRejected(session.socket, "JOIN_CODE_INVALID");
+        return;
+      }
+    }
+
+    const joinResult = this.roomState.joinPlayer({
+      player_id: message.player_id,
+      display_name: payload.display_name,
+      source: payload.source,
+      now: new Date(),
+    });
+    if (!joinResult.ok) {
+      this.sendJoinRejected(session.socket, joinResult.reason ?? "ROOM_JOIN_REJECTED");
+      return;
+    }
+
+    session.playerId = message.player_id;
+
+    this.send(session.socket, "ROOM_JOIN_ACCEPTED", {
+      room_state_snapshot: this.roomState.toSnapshot(),
+    });
+    this.broadcastRoomUpdated();
+  }
+
+  private handleRoomLeave(session: RoomSocketSession, closeSocket: boolean): void {
+    const playerId = session.playerId;
+    session.playerId = null;
+
+    if (playerId === null) {
+      if (closeSocket) {
+        this.safeCloseSocket(session.socket, 1000, "Left room.");
+      }
+      return;
+    }
+
+    const leaveResult = this.roomState.leavePlayer(playerId, new Date());
+    if (!leaveResult.removed) {
+      if (closeSocket) {
+        this.safeCloseSocket(session.socket, 1000, "Left room.");
+      }
+      return;
+    }
+
+    if (leaveResult.was_host) {
+      this.broadcast("ROOM_CLOSED", { reason: "HOST_LEFT" }, true);
+      void this.cleanupLobbyEntry();
+      this.disconnectAll(4000, "Host left.");
+      return;
+    }
+
+    this.broadcastRoomUpdated();
+    if (closeSocket) {
+      this.safeCloseSocket(session.socket, 1000, "Left room.");
+    }
+  }
+
+  private findSessionByPlayerId(playerId: string): RoomSocketSession | null {
+    for (const session of this.sessionsBySocket.values()) {
+      if (session.playerId === playerId) {
+        return session;
+      }
+    }
+
+    return null;
+  }
+
+  private sendStateSnapshot(socket: WebSocket): void {
+    this.send(socket, "STATE_SNAPSHOT", {
+      room_state_snapshot: this.roomState.toSnapshot(),
+    });
+  }
+
+  private broadcastRoomUpdated(): void {
+    this.broadcast("ROOM_UPDATED", {
+      room_state_snapshot: this.roomState.toSnapshot(),
+    });
+  }
+
+  private broadcast<TType extends ServerMessageType>(
+    type: TType,
+    payload: ServerMessagePayloadMap[TType],
+    includeUnjoined = false,
+  ): void {
+    for (const session of this.sessionsBySocket.values()) {
+      if (!includeUnjoined && session.playerId === null) {
+        continue;
+      }
+      this.send(session.socket, type, payload);
+    }
+  }
+
+  private send<TType extends ServerMessageType>(
+    socket: WebSocket,
+    type: TType,
+    payload: ServerMessagePayloadMap[TType],
+  ): void {
     if (socket.readyState !== OPEN_WEBSOCKET_STATE) {
       return;
     }
 
     const roomId = this.roomState.isInitialized() ? this.roomState.getRoomId() : "";
-    socket.send(JSON.stringify(createServerEnvelope(roomId, "ERROR", { code, message })));
+    const envelope = createServerEnvelope(roomId, type, payload);
+    socket.send(JSON.stringify(envelope));
+  }
+
+  private sendError(socket: WebSocket, code: ErrorCode, message: string): void {
+    this.send(socket, "ERROR", { code, message });
+  }
+
+  private sendJoinRejected(socket: WebSocket, reason: string): void {
+    this.send(socket, "ROOM_JOIN_REJECTED", { reason });
+  }
+
+  private isDuplicateMessage(playerId: string, clientMessageId: string): boolean {
+    const seenIds = this.seenClientMessageIds.get(playerId) ?? [];
+    if (seenIds.includes(clientMessageId)) {
+      return true;
+    }
+
+    seenIds.push(clientMessageId);
+    if (seenIds.length > IDEMPOTENCY_LOG_LIMIT) {
+      seenIds.shift();
+    }
+    this.seenClientMessageIds.set(playerId, seenIds);
+    return false;
+  }
+
+  private disconnectAll(code: number, reason: string): void {
+    const sessions = Array.from(this.sessionsBySocket.values());
+    this.sessionsBySocket.clear();
+
+    for (const session of sessions) {
+      session.playerId = null;
+      this.safeCloseSocket(session.socket, code, reason);
+    }
+  }
+
+  private safeCloseSocket(socket: WebSocket, code: number, reason: string): void {
+    if (socket.readyState === OPEN_WEBSOCKET_STATE) {
+      socket.close(code, reason);
+    }
+  }
+
+  private async cleanupLobbyEntry(): Promise<void> {
+    if (!this.roomState.isInitialized()) {
+      return;
+    }
+
+    try {
+      await deleteLobbyRoom(this.env, this.roomState.getRoomId());
+    } catch {
+      // no-op: list API has expires_at guard as fallback
+    }
   }
 }

--- a/apps/worker/src/durable/room-state.ts
+++ b/apps/worker/src/durable/room-state.ts
@@ -1,0 +1,229 @@
+import { MATCH_TTL_MINUTES, type PlayerRole, type RoomSettings, type RoomState, type RoomStateSnapshot, type SourceType } from "@infinitas/shared";
+
+interface InternalPlayer {
+  player_id: string;
+  display_name: string;
+  source: SourceType;
+  connected: boolean;
+  ready: boolean;
+  role: PlayerRole;
+  joined_at: Date;
+  left_at: Date | null;
+  rejoin_until: Date | null;
+}
+
+export interface RoomInitializationInput {
+  room_id: string;
+  settings: RoomSettings;
+  created_at: string;
+}
+
+export interface JoinPlayerInput {
+  player_id: string;
+  display_name: string;
+  source: SourceType;
+  now: Date;
+}
+
+export interface JoinPlayerResult {
+  ok: boolean;
+  reason?: "ROOM_CLOSED" | "ROOM_FULL";
+}
+
+export interface LeavePlayerResult {
+  removed: boolean;
+  was_host: boolean;
+}
+
+const DEFAULT_SETTINGS: RoomSettings = {
+  visibility: "PUBLIC",
+  join_code: null,
+  mode: "ARENA",
+  win_metric: "SCORE",
+  play_style: "SP",
+  level_filter: "ANY",
+  room_comment: "",
+  max_players: 4,
+};
+
+function toIsoString(value: Date | null): string | null {
+  return value === null ? null : value.toISOString();
+}
+
+function computeMatchDeadline(createdAt: Date): Date {
+  return new Date(createdAt.getTime() + MATCH_TTL_MINUTES * 60_000);
+}
+
+export class RoomLobbyState {
+  private initialized = false;
+  private roomId = "";
+  private roomState: RoomState = "LOBBY";
+  private settings: RoomSettings = { ...DEFAULT_SETTINGS };
+  private hostPlayerId: string | null = null;
+  private createdAt = new Date();
+  private matchDeadline = computeMatchDeadline(this.createdAt);
+  private resultDeadline: Date | null = null;
+  private closedAt: Date | null = null;
+  private closeReason: string | null = null;
+  private readonly players = new Map<string, InternalPlayer>();
+
+  initialize(input: RoomInitializationInput): void {
+    const createdAt = new Date(input.created_at);
+    if (!Number.isFinite(createdAt.getTime())) {
+      throw new Error("created_at must be ISO8601.");
+    }
+
+    if (this.initialized) {
+      if (this.roomId !== input.room_id) {
+        throw new Error("room_id mismatch on reinitialize.");
+      }
+      return;
+    }
+
+    this.initialized = true;
+    this.roomId = input.room_id;
+    this.settings = { ...input.settings };
+    this.createdAt = createdAt;
+    this.matchDeadline = computeMatchDeadline(createdAt);
+  }
+
+  isInitialized(): boolean {
+    return this.initialized;
+  }
+
+  getRoomId(): string {
+    return this.roomId;
+  }
+
+  getRoomState(): RoomState {
+    return this.roomState;
+  }
+
+  getSettings(): RoomSettings {
+    return this.settings;
+  }
+
+  getHostPlayerId(): string | null {
+    return this.hostPlayerId;
+  }
+
+  hasPlayer(playerId: string): boolean {
+    return this.players.has(playerId);
+  }
+
+  isPlayerConnected(playerId: string): boolean {
+    const player = this.players.get(playerId);
+    return player?.connected === true;
+  }
+
+  canJoin(playerId: string): boolean {
+    if (this.players.has(playerId)) {
+      return true;
+    }
+
+    return this.players.size < this.settings.max_players;
+  }
+
+  joinPlayer(input: JoinPlayerInput): JoinPlayerResult {
+    if (this.roomState === "CLOSED") {
+      return { ok: false, reason: "ROOM_CLOSED" };
+    }
+
+    const existing = this.players.get(input.player_id);
+    if (!existing && this.players.size >= this.settings.max_players) {
+      return { ok: false, reason: "ROOM_FULL" };
+    }
+
+    if (existing) {
+      existing.display_name = input.display_name;
+      existing.source = input.source;
+      existing.connected = true;
+      existing.left_at = null;
+      existing.ready = false;
+      return { ok: true };
+    }
+
+    let role: PlayerRole = "GUEST";
+    if (this.hostPlayerId === null) {
+      this.hostPlayerId = input.player_id;
+      role = "HOST";
+    }
+
+    this.players.set(input.player_id, {
+      player_id: input.player_id,
+      display_name: input.display_name,
+      source: input.source,
+      connected: true,
+      ready: false,
+      role,
+      joined_at: input.now,
+      left_at: null,
+      rejoin_until: null,
+    });
+
+    return { ok: true };
+  }
+
+  leavePlayer(playerId: string, now: Date): LeavePlayerResult {
+    const player = this.players.get(playerId);
+    if (!player) {
+      return { removed: false, was_host: false };
+    }
+
+    const wasHost = this.hostPlayerId === playerId;
+    player.connected = false;
+    player.left_at = now;
+    this.players.delete(playerId);
+
+    if (wasHost) {
+      this.close("HOST_LEFT", now);
+    }
+
+    return { removed: true, was_host: wasHost };
+  }
+
+  close(reason: string, now: Date): void {
+    if (this.roomState === "CLOSED") {
+      return;
+    }
+
+    this.roomState = "CLOSED";
+    this.closeReason = reason;
+    this.closedAt = now;
+  }
+
+  toSnapshot(): RoomStateSnapshot {
+    const players = Array.from(this.players.values())
+      .sort((left, right) => left.joined_at.getTime() - right.joined_at.getTime())
+      .map((player) => ({
+        player_id: player.player_id,
+        display_name: player.display_name,
+        source: player.source,
+        connected: player.connected,
+        ready: player.ready,
+        role: player.role,
+        joined_at: player.joined_at.toISOString(),
+        left_at: toIsoString(player.left_at),
+        rejoin_until: toIsoString(player.rejoin_until),
+      }));
+
+    return {
+      room_id: this.roomId,
+      room_state: this.roomState,
+      settings: this.settings,
+      host_player_id: this.hostPlayerId ?? "",
+      players,
+      picks: [],
+      frozen_rounds: [],
+      current_round: null,
+      timers: {
+        ready_check_deadline: null,
+        match_deadline: this.matchDeadline.toISOString(),
+        result_deadline: toIsoString(this.resultDeadline),
+      },
+      created_at: this.createdAt.toISOString(),
+      closed_at: toIsoString(this.closedAt),
+      close_reason: this.closeReason,
+    };
+  }
+}

--- a/apps/worker/src/durable/ws-codec.ts
+++ b/apps/worker/src/durable/ws-codec.ts
@@ -1,0 +1,78 @@
+import { isClientMessageType, type ClientMessage, type ServerEnvelope, type ServerMessageType } from "@infinitas/shared";
+import { isRecord } from "../utils/validation";
+
+export interface DecodeClientMessageFailure {
+  ok: false;
+  error: string;
+}
+
+export interface DecodeClientMessageSuccess {
+  ok: true;
+  message: ClientMessage;
+}
+
+export type DecodeClientMessageResult = DecodeClientMessageFailure | DecodeClientMessageSuccess;
+
+export function decodeClientMessage(rawData: string): DecodeClientMessageResult {
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(rawData);
+  } catch {
+    return {
+      ok: false,
+      error: "Message must be valid JSON.",
+    };
+  }
+
+  if (!isRecord(decoded)) {
+    return {
+      ok: false,
+      error: "Message must be object.",
+    };
+  }
+
+  const messageType = typeof decoded.type === "string" ? decoded.type : null;
+  const clientMsgId = typeof decoded.client_msg_id === "string" ? decoded.client_msg_id : null;
+  const roomId = typeof decoded.room_id === "string" ? decoded.room_id : null;
+  const playerId = typeof decoded.player_id === "string" ? decoded.player_id : null;
+  const payload = decoded.payload;
+
+  if (
+    messageType === null ||
+    !isClientMessageType(messageType) ||
+    clientMsgId === null ||
+    roomId === null ||
+    playerId === null ||
+    !isRecord(payload)
+  ) {
+    return {
+      ok: false,
+      error: "Message does not match envelope schema.",
+    };
+  }
+
+  return {
+    ok: true,
+    message: {
+      type: messageType,
+      client_msg_id: clientMsgId,
+      room_id: roomId,
+      player_id: playerId,
+      payload,
+    } as ClientMessage,
+  };
+}
+
+export function createServerEnvelope<TType extends ServerMessageType>(
+  roomId: string,
+  type: TType,
+  payload: unknown,
+): ServerEnvelope<TType, unknown> {
+  return {
+    type,
+    server_msg_id: crypto.randomUUID(),
+    server_time: new Date().toISOString(),
+    room_id: roomId,
+    payload,
+  };
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,10 +1,18 @@
-import { handleGetRooms, handlePostRooms } from "./routes/rooms";
+import { handleGetRooms, handlePostRooms, handleRoomWebSocket, matchRoomWebSocketPath } from "./routes/rooms";
+import { RoomDurableObject } from "./durable/room-object";
 import type { WorkerEnv } from "./types/env";
 import { methodNotAllowed, notFound } from "./utils/http";
+
+export { RoomDurableObject };
 
 export default {
   async fetch(request: Request, env: WorkerEnv): Promise<Response> {
     const url = new URL(request.url);
+    const webSocketRoomId = matchRoomWebSocketPath(url.pathname);
+
+    if (webSocketRoomId !== null) {
+      return handleRoomWebSocket(request, env, webSocketRoomId);
+    }
 
     if (url.pathname === "/api/rooms") {
       if (request.method === "POST") {

--- a/apps/worker/src/routes/rooms.ts
+++ b/apps/worker/src/routes/rooms.ts
@@ -1,7 +1,29 @@
 import { createRoom } from "../services/room-create";
 import { listRooms } from "../services/room-list";
 import type { WorkerEnv } from "../types/env";
-import { badRequest, created, ok, parseJsonBody } from "../utils/http";
+import { badRequest, created, methodNotAllowed, ok, parseJsonBody } from "../utils/http";
+
+const ROOM_WS_PATH_PATTERN = /^\/api\/rooms\/([^/]+)\/ws$/;
+const DO_WS_PROXY_URL = "https://room.internal/ws";
+
+function isWebSocketUpgradeRequest(request: Request): boolean {
+  const upgrade = request.headers.get("upgrade");
+  return typeof upgrade === "string" && upgrade.toLowerCase() === "websocket";
+}
+
+export function matchRoomWebSocketPath(pathname: string): string | null {
+  const match = ROOM_WS_PATH_PATTERN.exec(pathname);
+  if (!match) {
+    return null;
+  }
+
+  const [, encodedRoomId] = match;
+  if (!encodedRoomId) {
+    return null;
+  }
+
+  return decodeURIComponent(encodedRoomId);
+}
 
 export async function handlePostRooms(request: Request, env: WorkerEnv): Promise<Response> {
   try {
@@ -23,4 +45,35 @@ export async function handleGetRooms(request: Request, env: WorkerEnv): Promise<
     const message = error instanceof Error ? error.message : "Invalid request.";
     return badRequest(message);
   }
+}
+
+export async function handleRoomWebSocket(
+  request: Request,
+  env: WorkerEnv,
+  roomId: string,
+): Promise<Response> {
+  if (request.method !== "GET") {
+    return methodNotAllowed(["GET"]);
+  }
+  if (!isWebSocketUpgradeRequest(request)) {
+    return new Response("Expected websocket upgrade request.", { status: 426 });
+  }
+
+  const roomDoId = env.ROOM_DO.idFromName(roomId);
+  const roomDoStub = env.ROOM_DO.get(roomDoId);
+
+  const requestUrl = new URL(request.url);
+  const proxyUrl = new URL(DO_WS_PROXY_URL);
+  proxyUrl.search = requestUrl.search;
+
+  const proxyHeaders = new Headers(request.headers);
+  proxyHeaders.set("x-room-id", roomId);
+  proxyHeaders.set("x-room-path", requestUrl.pathname);
+
+  return roomDoStub.fetch(
+    new Request(proxyUrl.toString(), {
+      method: "GET",
+      headers: proxyHeaders,
+    }),
+  );
 }

--- a/apps/worker/src/services/room-create.ts
+++ b/apps/worker/src/services/room-create.ts
@@ -17,6 +17,7 @@ import type { CreateRoomResponse } from "../types/api";
 import type { WorkerEnv } from "../types/env";
 import { putLobbyRoom } from "../kv/lobby-kv";
 import { generateJoinCode, isValidJoinCode, normalizeJoinCode } from "./join-code";
+import { initializeRoomDurableObject } from "./room-do";
 import { asEnumValue, asNullableString, asOptionalString, isRecord } from "../utils/validation";
 
 interface CreateRoomInput {
@@ -136,6 +137,9 @@ export async function createRoom(
 ): Promise<CreateRoomResponse> {
   const parsed = parseCreateRoomPayload(payload);
   const roomId = crypto.randomUUID();
+  const createdAtIso = parsed.createdAt.toISOString();
+
+  await initializeRoomDurableObject(env, roomId, parsed.settings, createdAtIso);
 
   if (parsed.settings.visibility !== "PRIVATE") {
     await putLobbyRoom(env, toLobbyEntry(roomId, parsed));
@@ -143,7 +147,7 @@ export async function createRoom(
 
   return {
     room_id: roomId,
-    created_at: parsed.createdAt.toISOString(),
+    created_at: createdAtIso,
     expires_at: parsed.expiresAt.toISOString(),
     settings: parsed.settings,
   };

--- a/apps/worker/src/services/room-do.ts
+++ b/apps/worker/src/services/room-do.ts
@@ -1,0 +1,41 @@
+import type { RoomSettings } from "@infinitas/shared";
+import type { WorkerEnv } from "../types/env";
+
+const INTERNAL_ROOM_INIT_URL = "https://room.internal/internal/init";
+const JSON_CONTENT_TYPE = "application/json; charset=utf-8";
+
+interface InitializeRoomRequest {
+  room_id: string;
+  settings: RoomSettings;
+  created_at: string;
+}
+
+export async function initializeRoomDurableObject(
+  env: WorkerEnv,
+  roomId: string,
+  settings: RoomSettings,
+  createdAtIso: string,
+): Promise<void> {
+  const doId = env.ROOM_DO.idFromName(roomId);
+  const stub = env.ROOM_DO.get(doId);
+
+  const payload: InitializeRoomRequest = {
+    room_id: roomId,
+    settings,
+    created_at: createdAtIso,
+  };
+
+  const response = await stub.fetch(
+    new Request(INTERNAL_ROOM_INIT_URL, {
+      method: "POST",
+      headers: {
+        "content-type": JSON_CONTENT_TYPE,
+      },
+      body: JSON.stringify(payload),
+    }),
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to initialize room state.");
+  }
+}

--- a/apps/worker/src/types/env.ts
+++ b/apps/worker/src/types/env.ts
@@ -15,6 +15,20 @@ export interface RoomLobbyKvNamespace {
   list(options?: { prefix?: string; cursor?: string; limit?: number }): Promise<KvListResult>;
 }
 
+export interface DurableObjectIdLike {
+  toString(): string;
+}
+
+export interface RoomDurableObjectStub {
+  fetch(request: Request): Promise<Response>;
+}
+
+export interface RoomDurableObjectNamespace {
+  idFromName(name: string): DurableObjectIdLike;
+  get(id: DurableObjectIdLike): RoomDurableObjectStub;
+}
+
 export interface WorkerEnv {
   ROOM_LOBBY_KV: RoomLobbyKvNamespace;
+  ROOM_DO: RoomDurableObjectNamespace;
 }

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -2,7 +2,15 @@ name = "infinitas-bpl-worker"
 main = "src/index.ts"
 compatibility_date = "2025-01-01"
 
+[[durable_objects.bindings]]
+name = "ROOM_DO"
+class_name = "RoomDurableObject"
+
 [[kv_namespaces]]
 binding = "ROOM_LOBBY_KV"
 id = "178977f3a6914369b3afd7d82b6e183b"
 preview_id = "34dd03c3d53e4006b64f57d680076bb2"
+
+[[migrations]]
+tag = "v1-room-do-lobby"
+new_sqlite_classes = ["RoomDurableObject"]

--- a/tasks/feat-pr3-do-lobby.md
+++ b/tasks/feat-pr3-do-lobby.md
@@ -1,0 +1,83 @@
+# Plan: feat/pr3-do-lobby
+
+## 作業宣言
+- worktree: `C:\work\infinitas_arena\infinitas_bpl`
+- branch: `feat/pr3-do-lobby`
+- base branch: `v1`
+- BASE_SHA: `b5c6ca458e07f56c2bb1beeba3dbe91119eefb65`
+
+## 目的
+- `docs/design/09_implementation_plan.md` の PR-3（DO 接続管理 + LOBBY）を実装する。
+- Worker の WS 入口と Durable Object へのルーティングを追加し、複数プレイヤー接続・参加/退出・状態同期を成立させる。
+
+## 非目的
+- READY_CHECK 以降（`READY_CHECK_OPEN`/`READY_SET`/`START_MATCH`）の状態遷移実装（PR-4以降）。
+- PICKING/PLAYING/RESULT のロジック、タイマー、集計実装（PR-5以降）。
+- Client UI 実装（PR-8以降）。
+
+## 変更点
+- `GET /api/rooms/:room_id/ws` の WebSocket upgrade ルートを追加。
+- Worker から `room_id` 由来の DO へ安定ルーティング（`idFromName(room_id)`）を実装。
+- DO 側に接続管理を実装（セッション管理、切断時 cleanup、ブロードキャスト）。
+- LOBBY 最小メッセージを実装:
+  - Client: `ROOM_JOIN` / `ROOM_LEAVE` / `STATE_GET` / `PING`
+  - Server: `ROOM_JOIN_ACCEPTED` / `ROOM_JOIN_REJECTED` / `ROOM_UPDATED` / `STATE_SNAPSHOT` / `PONG` / `ERROR`
+- host 判定・`max_players` 超過拒否・`room_full` 判定を実装。
+- `ROOM_JOIN_ACCEPTED` で `RoomStateSnapshot` を返却し、JOIN/LEAVE 時に `ROOM_UPDATED` を配信。
+- `wrangler.toml` に Durable Object binding/migration を追加し、`WorkerEnv` 型を拡張。
+
+## 影響範囲
+- ユーザー:
+  - 同一 room_id へ複数人が WS 接続し、参加/退出が即時同期される。
+  - 定員超過時は `ROOM_JOIN_REJECTED` を受ける。
+- データ:
+  - PR-3では KV スキーマは変更しない（軽量ロビー形式は PR-2 を維持）。
+  - DO 内メモリでプレイヤー接続状態を保持する（永続化は Ph1 では未対応）。
+- 互換性:
+  - 既存 HTTP API（`POST /api/rooms`/`GET /api/rooms`）との互換性は維持。
+  - WS メッセージ形式は `packages/shared` の schema に準拠し、追加のみで破壊変更なし。
+- Cloudflare resources:
+  - Worker に Durable Object namespace binding を追加。
+  - KV の利用方法・キー形式は変更しない。
+
+## 実装方針（対象ファイル単位）
+- `apps/worker/src/index.ts`:
+  - `/api/rooms/:room_id/ws` のルーティング追加。
+  - HTTP route と WS route の責務を分離。
+- `apps/worker/src/routes/rooms.ts`:
+  - `handleRoomWebSocket` を追加し、upgrade 検証と DO fetch 転送を実装。
+- `apps/worker/src/types/env.ts`:
+  - Durable Object namespace 型と binding（`ROOM_DO`）を追加。
+- `apps/worker/src/durable/room-state.ts`（新規）:
+  - LOBBY 用内部状態（settings, host_player_id, players, timers）と snapshot 組み立てを実装。
+- `apps/worker/src/durable/ws-codec.ts`（新規）:
+  - WS envelope の decode/encode と最小バリデーションを実装。
+- `apps/worker/src/durable/room-object.ts`（新規）:
+  - DO 本体（接続管理、メッセージ処理、broadcast、join/leave）を実装。
+- `apps/worker/wrangler.toml`:
+  - Durable Object namespace と migration を追加。
+
+## テスト観点
+- PR-3内で実施:
+  - `npm run typecheck` 成功。
+  - `wrangler build` 成功。
+  - WS upgrade 経由で同一 room_id に複数接続できる。
+  - `ROOM_JOIN` で参加、`ROOM_LEAVE`/切断で退出が反映され `ROOM_UPDATED` が配信される。
+  - `max_players` 到達時に `ROOM_JOIN_REJECTED`（room full）となる。
+  - 最初の参加者が host として固定される。
+- E2E観点（後続PRで通し検証する項目）:
+  - 2人 ARENA/BPL の通し（create -> ready -> pick -> play -> result）。
+  - 監視2ソース（inf_daken_counter / inf-notebook）の提出通し。
+  - TIMEOUT/強制進行（FORCE_ADVANCE）通し。
+
+## ロールバック方針
+- WS/DO 導入に不具合がある場合は PR-3 コミットを revert して PR-2（HTTP+KV）状態へ戻す。
+- DO binding/migration の設定問題は `wrangler.toml` 差分のみ個別ロールバック可能にする。
+- ルーム参加処理不具合時は DO ロジックを段階 revert し、HTTP API 側への影響を隔離する。
+
+## Commit Plan（コミット分割計画）
+1. PR-3 plan 追加（本ファイル）。
+2. Worker WS route + Env/設定更新（DO binding/migration）。
+3. DO 基盤（state/codec/object）追加。
+4. LOBBY メッセージ処理（JOIN/LEAVE/STATE_GET/PING）と broadcast 実装。
+5. typecheck / wrangler build 実行と最終調整。


### PR DESCRIPTION
- [x] WORKFLOW.md を確認した
- [x] QUALITY.md を満たしている

## 目的
- `docs/design/09_implementation_plan.md` の PR-3 に従い、Durable Object の接続管理と LOBBY を実装する。
- `GET /api/rooms/:room_id/ws` から room_id 単位で DO へ接続し、参加/退出と状態同期を成立させる。

## 変更点
- Worker に WebSocket upgrade ルートを追加し、`room_id` から `ROOM_DO.idFromName(room_id)` で DO へルーティング。
- `wrangler.toml` と `WorkerEnv` に Durable Object binding / migration を追加。
- ルーム作成時に DO を初期化し、`settings` と `created_at` を room state に反映。
- DO 側に LOBBY 用 state / ws codec / room object を追加。
- `ROOM_JOIN` / `ROOM_LEAVE` / `STATE_GET` / `PING` を処理し、`ROOM_JOIN_ACCEPTED` / `ROOM_JOIN_REJECTED` / `ROOM_UPDATED` / `STATE_SNAPSHOT` / `PONG` / `ERROR` を返す。
- host 固定、`max_players` による room full 判定、`PRIVATE` の join_code 照合、`(player_id, client_msg_id)` の重複排除を追加。
- ホスト退出時は `ROOM_CLOSED` を配信し、KV からロビー削除を試行する。

## 非変更点
- READY_CHECK 以降の FSM 遷移。
- PICKING / PLAYING / RESULT / timers / aggregation。
- Client UI / watcher / source I/O。
- KV 一覧 API の仕様。

## 影響範囲
- ユーザー:
  - 同一 room_id へ複数人が WS 接続でき、LOBBY の参加/退出が即時反映される。
- データ:
  - KV スキーマ変更なし。DO 内メモリで接続状態を保持する。
- 互換性:
  - 既存の `POST /api/rooms` / `GET /api/rooms` は維持。
  - WS schema は shared 定義に準拠し、PR-3 範囲のメッセージのみ実装。
- Cloudflare:
  - Durable Object namespace binding と migration を追加。

## テスト内容
- `npm run typecheck`
- `npx wrangler deploy --dry-run`

## 回帰確認項目
- `POST /api/rooms` が DO 初期化込みで成功すること。
- `GET /api/rooms/:room_id/ws` が upgrade されること。
- `ROOM_JOIN` 後に `ROOM_JOIN_ACCEPTED` と `ROOM_UPDATED` が返ること。
- 定員到達時に `ROOM_JOIN_REJECTED` となること。
- ホスト退出時に `ROOM_CLOSED` が返り、ロビー削除を試行すること。