### PR TITLE
Implement PR-4 ready check flow

### DIFF
--- a/apps/worker/src/durable/room-object.ts
+++ b/apps/worker/src/durable/room-object.ts
@@ -25,6 +25,15 @@ interface RoomSocketSession {
   playerId: string | null;
 }
 
+interface DurableObjectStorageLike {
+  deleteAlarm(): Promise<void>;
+  setAlarm(scheduledTime: number | Date): Promise<void>;
+}
+
+interface DurableObjectStateLike {
+  storage: DurableObjectStorageLike;
+}
+
 const IDEMPOTENCY_LOG_LIMIT = 300;
 const OPEN_WEBSOCKET_STATE = 1;
 const SWITCHING_PROTOCOLS_STATUS = 101;
@@ -130,13 +139,23 @@ function parseRoomJoinPayload(payload: unknown): RoomJoinPayload | null {
   };
 }
 
+function parseReadySetPayload(payload: unknown): { ready: boolean } | null {
+  if (!isRecord(payload) || typeof payload.ready !== "boolean") {
+    return null;
+  }
+
+  return {
+    ready: payload.ready,
+  };
+}
+
 export class RoomDurableObject {
   private readonly roomState = new RoomLobbyState();
   private readonly sessionsBySocket = new Map<WebSocket, RoomSocketSession>();
   private readonly seenClientMessageIds = new Map<string, string[]>();
 
   constructor(
-    private readonly _state: unknown,
+    private readonly state: DurableObjectStateLike,
     private readonly env: WorkerEnv,
   ) {}
 
@@ -170,6 +189,10 @@ export class RoomDurableObject {
       status: SWITCHING_PROTOCOLS_STATUS,
       webSocket: clientSocket,
     } as ResponseInit);
+  }
+
+  async alarm(): Promise<void> {
+    await this.closeReadyCheckOnTimeout(new Date());
   }
 
   private async handleInternalInitialize(request: Request): Promise<Response> {
@@ -206,88 +229,109 @@ export class RoomDurableObject {
     this.sessionsBySocket.set(socket, session);
 
     socket.addEventListener("message", (event) => {
-      this.handleSocketMessage(socket, event);
+      void this.handleSocketMessage(socket, event);
     });
     socket.addEventListener("close", () => {
-      this.handleSocketClose(socket);
+      void this.handleSocketClose(socket);
     });
     socket.addEventListener("error", () => {
-      this.handleSocketClose(socket);
+      void this.handleSocketClose(socket);
     });
   }
 
-  private handleSocketMessage(socket: WebSocket, event: MessageEvent): void {
+  private async handleSocketMessage(socket: WebSocket, event: MessageEvent): Promise<void> {
     const session = this.sessionsBySocket.get(socket);
     if (!session) {
       return;
     }
 
-    if (typeof event.data !== "string") {
-      this.sendError(socket, "INVALID_STATE", "Only text messages are supported.");
-      return;
-    }
-
-    const decoded = decodeClientMessage(event.data);
-    if (!decoded.ok) {
-      this.sendError(socket, "INVALID_STATE", decoded.error);
-      return;
-    }
-
-    const message = decoded.message;
-    if (
-      message.client_msg_id.trim().length === 0 ||
-      message.player_id.trim().length === 0 ||
-      message.room_id.trim().length === 0
-    ) {
-      this.sendError(socket, "INVALID_STATE", "Envelope fields must not be empty.");
-      return;
-    }
-
-    if (this.roomState.isInitialized() && message.room_id !== this.roomState.getRoomId()) {
-      this.sendError(socket, "INVALID_STATE", "room_id does not match this room.");
-      return;
-    }
-
-    if (session.playerId !== null && session.playerId !== message.player_id) {
-      this.sendError(socket, "INVALID_STATE", "player_id mismatch on this socket.");
-      return;
-    }
-
-    if (this.isDuplicateMessage(message.player_id, message.client_msg_id)) {
-      return;
-    }
-
-    if (message.type !== "ROOM_JOIN" && session.playerId === null) {
-      this.sendError(socket, "INVALID_STATE", "Send ROOM_JOIN before this message.");
-      return;
-    }
-
-    switch (message.type) {
-      case "ROOM_JOIN":
-        this.handleRoomJoin(session, message as ClientMessage<"ROOM_JOIN">);
+    try {
+      if (typeof event.data !== "string") {
+        this.sendError(socket, "INVALID_STATE", "Only text messages are supported.");
         return;
-      case "ROOM_LEAVE":
-        this.handleRoomLeave(session, true);
+      }
+
+      const decoded = decodeClientMessage(event.data);
+      if (!decoded.ok) {
+        this.sendError(socket, "INVALID_STATE", decoded.error);
         return;
-      case "STATE_GET":
-        this.sendStateSnapshot(socket);
+      }
+
+      const message = decoded.message;
+      if (
+        message.client_msg_id.trim().length === 0 ||
+        message.player_id.trim().length === 0 ||
+        message.room_id.trim().length === 0
+      ) {
+        this.sendError(socket, "INVALID_STATE", "Envelope fields must not be empty.");
         return;
-      case "PING":
-        this.send(socket, "PONG", {});
+      }
+
+      if (this.roomState.isInitialized() && message.room_id !== this.roomState.getRoomId()) {
+        this.sendError(socket, "INVALID_STATE", "room_id does not match this room.");
         return;
-      default:
-        this.sendError(socket, "INVALID_STATE", `Message type ${message.type} is unavailable in LOBBY.`);
+      }
+
+      if (session.playerId !== null && session.playerId !== message.player_id) {
+        this.sendError(socket, "INVALID_STATE", "player_id mismatch on this socket.");
+        return;
+      }
+
+      if (await this.closeReadyCheckOnTimeout(new Date())) {
+        return;
+      }
+
+      if (this.isDuplicateMessage(message.player_id, message.client_msg_id)) {
+        return;
+      }
+
+      if (message.type !== "ROOM_JOIN" && session.playerId === null) {
+        this.sendError(socket, "INVALID_STATE", "Send ROOM_JOIN before this message.");
+        return;
+      }
+
+      switch (message.type) {
+        case "ROOM_JOIN":
+          this.handleRoomJoin(session, message as ClientMessage<"ROOM_JOIN">);
+          return;
+        case "ROOM_LEAVE":
+          await this.handleRoomLeave(session, true);
+          return;
+        case "READY_CHECK_OPEN":
+          await this.handleReadyCheckOpen(session);
+          return;
+        case "READY_SET":
+          this.handleReadySet(session, message as ClientMessage<"READY_SET">);
+          return;
+        case "START_MATCH":
+          await this.handleStartMatch(session);
+          return;
+        case "STATE_GET":
+          this.sendStateSnapshot(socket);
+          return;
+        case "PING":
+          this.send(socket, "PONG", {});
+          return;
+        default:
+          this.sendError(
+            socket,
+            "INVALID_STATE",
+            `Message type ${message.type} is unavailable in ${this.roomState.getRoomState()}.`,
+          );
+      }
+    } catch {
+      this.sendError(socket, "INVALID_STATE", "Failed to process message.");
     }
   }
 
-  private handleSocketClose(socket: WebSocket): void {
+  private async handleSocketClose(socket: WebSocket): Promise<void> {
     const session = this.sessionsBySocket.get(socket);
     if (!session) {
       return;
     }
 
     this.sessionsBySocket.delete(socket);
-    this.handleRoomLeave(session, false);
+    await this.handleRoomLeave(session, false);
   }
 
   private handleRoomJoin(session: RoomSocketSession, message: ClientMessage<"ROOM_JOIN">): void {
@@ -341,7 +385,7 @@ export class RoomDurableObject {
     this.broadcastRoomUpdated();
   }
 
-  private handleRoomLeave(session: RoomSocketSession, closeSocket: boolean): void {
+  private async handleRoomLeave(session: RoomSocketSession, closeSocket: boolean): Promise<void> {
     const playerId = session.playerId;
     session.playerId = null;
 
@@ -353,7 +397,7 @@ export class RoomDurableObject {
     }
 
     const leaveResult = this.roomState.leavePlayer(playerId, new Date());
-    if (!leaveResult.removed) {
+    if (!leaveResult.changed) {
       if (closeSocket) {
         this.safeCloseSocket(session.socket, 1000, "Left room.");
       }
@@ -361,8 +405,9 @@ export class RoomDurableObject {
     }
 
     if (leaveResult.was_host) {
+      await this.clearReadyCheckAlarm();
       this.broadcast("ROOM_CLOSED", { reason: "HOST_LEFT" }, true);
-      void this.cleanupLobbyEntry();
+      await this.cleanupLobbyEntry();
       this.disconnectAll(4000, "Host left.");
       return;
     }
@@ -371,6 +416,87 @@ export class RoomDurableObject {
     if (closeSocket) {
       this.safeCloseSocket(session.socket, 1000, "Left room.");
     }
+  }
+
+  private async handleReadyCheckOpen(session: RoomSocketSession): Promise<void> {
+    if (session.playerId === null) {
+      this.sendError(session.socket, "INVALID_STATE", "Send ROOM_JOIN before this message.");
+      return;
+    }
+
+    const openedAt = new Date();
+    const result = this.roomState.openReadyCheck(session.playerId, openedAt);
+    if (!result.ok) {
+      if (result.reason === "NOT_HOST") {
+        this.sendError(session.socket, "NOT_HOST", "Only the host can open READY_CHECK.");
+        return;
+      }
+
+      this.sendError(session.socket, "INVALID_STATE", "READY_CHECK can only be opened from LOBBY.");
+      return;
+    }
+
+    const deadline = result.ready_check_deadline;
+    if (deadline === undefined) {
+      this.sendError(session.socket, "INVALID_STATE", "READY_CHECK deadline is unavailable.");
+      return;
+    }
+
+    await this.setReadyCheckAlarm(deadline);
+    this.broadcast("READY_CHECK_OPENED", {
+      ready_check_deadline: deadline.toISOString(),
+    });
+    this.broadcastRoomUpdated();
+  }
+
+  private handleReadySet(session: RoomSocketSession, message: ClientMessage<"READY_SET">): void {
+    if (session.playerId === null) {
+      this.sendError(session.socket, "INVALID_STATE", "Send ROOM_JOIN before this message.");
+      return;
+    }
+
+    const payload = parseReadySetPayload(message.payload);
+    if (payload === null) {
+      this.sendError(session.socket, "INVALID_STATE", "READY_SET payload is invalid.");
+      return;
+    }
+
+    const result = this.roomState.setPlayerReady(session.playerId, payload.ready);
+    if (!result.ok) {
+      this.sendError(session.socket, "INVALID_STATE", "READY_SET is only available during READY_CHECK.");
+      return;
+    }
+
+    this.broadcast("READY_STATUS_CHANGED", {
+      player_id: session.playerId,
+      ready: payload.ready,
+    });
+    this.broadcastRoomUpdated();
+  }
+
+  private async handleStartMatch(session: RoomSocketSession): Promise<void> {
+    if (session.playerId === null) {
+      this.sendError(session.socket, "INVALID_STATE", "Send ROOM_JOIN before this message.");
+      return;
+    }
+
+    const result = this.roomState.startMatch(session.playerId, new Date());
+    if (!result.ok) {
+      switch (result.reason) {
+        case "NOT_HOST":
+          this.sendError(session.socket, "NOT_HOST", "Only the host can start the match.");
+          return;
+        case "START_REQUIRES_MIN_PLAYERS":
+          this.sendStartMatchRejected(session.socket, "START_REQUIRES_MIN_PLAYERS");
+          return;
+        default:
+          this.sendStartMatchRejected(session.socket, "INVALID_STATE");
+          return;
+      }
+    }
+
+    await this.clearReadyCheckAlarm();
+    this.broadcastRoomUpdated();
   }
 
   private findSessionByPlayerId(playerId: string): RoomSocketSession | null {
@@ -430,6 +556,10 @@ export class RoomDurableObject {
     this.send(socket, "ROOM_JOIN_REJECTED", { reason });
   }
 
+  private sendStartMatchRejected(socket: WebSocket, reason: string): void {
+    this.send(socket, "START_MATCH_REJECTED", { reason });
+  }
+
   private isDuplicateMessage(playerId: string, clientMessageId: string): boolean {
     const seenIds = this.seenClientMessageIds.get(playerId) ?? [];
     if (seenIds.includes(clientMessageId)) {
@@ -458,6 +588,27 @@ export class RoomDurableObject {
     if (socket.readyState === OPEN_WEBSOCKET_STATE) {
       socket.close(code, reason);
     }
+  }
+
+  private async setReadyCheckAlarm(deadline: Date): Promise<void> {
+    await this.state.storage.setAlarm(deadline);
+  }
+
+  private async clearReadyCheckAlarm(): Promise<void> {
+    await this.state.storage.deleteAlarm();
+  }
+
+  private async closeReadyCheckOnTimeout(now: Date): Promise<boolean> {
+    const closed = this.roomState.closeReadyCheckIfExpired(now);
+    if (!closed) {
+      return false;
+    }
+
+    await this.clearReadyCheckAlarm();
+    this.broadcast("ROOM_CLOSED", { reason: "READY_CHECK_TIMEOUT" }, true);
+    await this.cleanupLobbyEntry();
+    this.disconnectAll(4001, "Ready check timed out.");
+    return true;
   }
 
   private async cleanupLobbyEntry(): Promise<void> {

--- a/apps/worker/src/durable/room-state.ts
+++ b/apps/worker/src/durable/room-state.ts
@@ -1,4 +1,14 @@
-import { MATCH_TTL_MINUTES, type PlayerRole, type RoomSettings, type RoomState, type RoomStateSnapshot, type SourceType } from "@infinitas/shared";
+import {
+  MATCH_TTL_MINUTES,
+  READY_CHECK_TTL_MINUTES,
+  REJOIN_COOLDOWN_SECONDS,
+  START_MIN_PLAYERS,
+  type PlayerRole,
+  type RoomSettings,
+  type RoomState,
+  type RoomStateSnapshot,
+  type SourceType,
+} from "@infinitas/shared";
 
 interface InternalPlayer {
   player_id: string;
@@ -27,12 +37,28 @@ export interface JoinPlayerInput {
 
 export interface JoinPlayerResult {
   ok: boolean;
-  reason?: "ROOM_CLOSED" | "ROOM_FULL";
+  reason?: "ROOM_CLOSED" | "ROOM_FULL" | "ROOM_JOIN_LOCKED";
 }
 
 export interface LeavePlayerResult {
-  removed: boolean;
+  changed: boolean;
   was_host: boolean;
+}
+
+export interface ReadyCheckOpenResult {
+  ok: boolean;
+  reason?: "INVALID_STATE" | "NOT_HOST";
+  ready_check_deadline?: Date;
+}
+
+export interface ReadySetResult {
+  ok: boolean;
+  reason?: "INVALID_STATE" | "PLAYER_NOT_FOUND";
+}
+
+export interface StartMatchResult {
+  ok: boolean;
+  reason?: "INVALID_STATE" | "NOT_HOST" | "START_REQUIRES_MIN_PLAYERS";
 }
 
 const DEFAULT_SETTINGS: RoomSettings = {
@@ -54,6 +80,18 @@ function computeMatchDeadline(createdAt: Date): Date {
   return new Date(createdAt.getTime() + MATCH_TTL_MINUTES * 60_000);
 }
 
+function computeReadyCheckDeadline(openedAt: Date): Date {
+  return new Date(openedAt.getTime() + READY_CHECK_TTL_MINUTES * 60_000);
+}
+
+function computeRejoinUntil(now: Date): Date {
+  return new Date(now.getTime() + REJOIN_COOLDOWN_SECONDS * 1_000);
+}
+
+function canNewPlayerJoin(roomState: RoomState): roomState is "LOBBY" | "READY_CHECK" {
+  return roomState === "LOBBY" || roomState === "READY_CHECK";
+}
+
 export class RoomLobbyState {
   private initialized = false;
   private roomId = "";
@@ -62,6 +100,7 @@ export class RoomLobbyState {
   private hostPlayerId: string | null = null;
   private createdAt = new Date();
   private matchDeadline = computeMatchDeadline(this.createdAt);
+  private readyCheckDeadline: Date | null = null;
   private resultDeadline: Date | null = null;
   private closedAt: Date | null = null;
   private closeReason: string | null = null;
@@ -121,6 +160,10 @@ export class RoomLobbyState {
       return true;
     }
 
+    if (!canNewPlayerJoin(this.roomState)) {
+      return false;
+    }
+
     return this.players.size < this.settings.max_players;
   }
 
@@ -130,6 +173,10 @@ export class RoomLobbyState {
     }
 
     const existing = this.players.get(input.player_id);
+    if (!existing && !canNewPlayerJoin(this.roomState)) {
+      return { ok: false, reason: "ROOM_JOIN_LOCKED" };
+    }
+
     if (!existing && this.players.size >= this.settings.max_players) {
       return { ok: false, reason: "ROOM_FULL" };
     }
@@ -139,7 +186,7 @@ export class RoomLobbyState {
       existing.source = input.source;
       existing.connected = true;
       existing.left_at = null;
-      existing.ready = false;
+      existing.rejoin_until = null;
       return { ok: true };
     }
 
@@ -167,19 +214,99 @@ export class RoomLobbyState {
   leavePlayer(playerId: string, now: Date): LeavePlayerResult {
     const player = this.players.get(playerId);
     if (!player) {
-      return { removed: false, was_host: false };
+      return { changed: false, was_host: false };
     }
 
     const wasHost = this.hostPlayerId === playerId;
     player.connected = false;
     player.left_at = now;
-    this.players.delete(playerId);
+
+    if (canNewPlayerJoin(this.roomState)) {
+      this.players.delete(playerId);
+    } else {
+      player.rejoin_until = computeRejoinUntil(now);
+    }
 
     if (wasHost) {
       this.close("HOST_LEFT", now);
     }
 
-    return { removed: true, was_host: wasHost };
+    return { changed: true, was_host: wasHost };
+  }
+
+  openReadyCheck(playerId: string, now: Date): ReadyCheckOpenResult {
+    if (playerId !== this.hostPlayerId) {
+      return { ok: false, reason: "NOT_HOST" };
+    }
+
+    if (this.roomState !== "LOBBY") {
+      return { ok: false, reason: "INVALID_STATE" };
+    }
+
+    this.roomState = "READY_CHECK";
+    this.readyCheckDeadline = computeReadyCheckDeadline(now);
+    for (const player of this.players.values()) {
+      player.ready = false;
+    }
+
+    return {
+      ok: true,
+      ready_check_deadline: this.readyCheckDeadline,
+    };
+  }
+
+  setPlayerReady(playerId: string, ready: boolean): ReadySetResult {
+    if (this.roomState !== "READY_CHECK") {
+      return { ok: false, reason: "INVALID_STATE" };
+    }
+
+    const player = this.players.get(playerId);
+    if (!player) {
+      return { ok: false, reason: "PLAYER_NOT_FOUND" };
+    }
+
+    player.ready = ready;
+    return { ok: true };
+  }
+
+  startMatch(playerId: string, now: Date): StartMatchResult {
+    if (playerId !== this.hostPlayerId) {
+      return { ok: false, reason: "NOT_HOST" };
+    }
+
+    if (this.roomState !== "READY_CHECK") {
+      return { ok: false, reason: "INVALID_STATE" };
+    }
+
+    if (this.players.size < START_MIN_PLAYERS) {
+      return { ok: false, reason: "START_REQUIRES_MIN_PLAYERS" };
+    }
+
+    this.roomState = "PICKING";
+    this.readyCheckDeadline = null;
+    this.matchDeadline = computeMatchDeadline(now);
+    for (const player of this.players.values()) {
+      player.ready = false;
+    }
+
+    return { ok: true };
+  }
+
+  getReadyCheckDeadline(): Date | null {
+    return this.readyCheckDeadline;
+  }
+
+  closeReadyCheckIfExpired(now: Date): boolean {
+    if (
+      this.roomState !== "READY_CHECK" ||
+      this.readyCheckDeadline === null ||
+      now.getTime() < this.readyCheckDeadline.getTime()
+    ) {
+      return false;
+    }
+
+    this.close("READY_CHECK_TIMEOUT", now);
+    return true;
   }
 
   close(reason: string, now: Date): void {
@@ -188,6 +315,7 @@ export class RoomLobbyState {
     }
 
     this.roomState = "CLOSED";
+    this.readyCheckDeadline = null;
     this.closeReason = reason;
     this.closedAt = now;
   }
@@ -217,7 +345,7 @@ export class RoomLobbyState {
       frozen_rounds: [],
       current_round: null,
       timers: {
-        ready_check_deadline: null,
+        ready_check_deadline: toIsoString(this.readyCheckDeadline),
         match_deadline: this.matchDeadline.toISOString(),
         result_deadline: toIsoString(this.resultDeadline),
       },

--- a/tasks/codex-pr4-ready-check.md
+++ b/tasks/codex-pr4-ready-check.md
@@ -1,0 +1,63 @@
+# Plan: codex/pr4-ready-check
+
+## 作業宣言
+- worktree: `C:\work\infinitas_arena\infinitas_bpl_pr4_ready_check`
+- branch: `codex/pr4-ready-check`
+- base branch: `v1`
+- BASE_SHA: `076ad15906af181a8cd9e28610a3de200a2596c3`
+
+## 目的
+- `docs/design/09_implementation_plan.md` の PR-4（READY_CHECK）を実装する。
+- Durable Object 上で開始準備フェーズ、開始ガード、READY 状態同期、20分 TTL 解散を成立させる。
+
+## 非目的
+- PICKING/PLAYING/RESULT の進行、ラウンド構築、集計実装（PR-5以降）。
+- WebSocket schema や shared 型の大幅変更。
+- クライアント UI 実装や watcher 実装。
+
+## 変更点
+- DO 内状態に `READY_CHECK` 用の遷移と deadline 管理を追加。
+- `READY_CHECK_OPEN` をホスト限定で受理し、`ready_check_deadline` を設定する。
+- `READY_SET` で参加者の ready 状態を更新し、全員へ反映する。
+- `START_MATCH` をホスト限定かつ `players >= 2` かつ `room_state=READY_CHECK` のときのみ受理する。
+- `ready_check_ttl` 超過時にルームを `CLOSED` へ遷移させ、解散を通知する。
+- READY_CHECK 中の join/leave を維持しつつ、状態スナップショットへ deadline を反映する。
+
+## 影響範囲
+- ユーザー:
+  - ホストが LOBBY から READY_CHECK を開始できる。
+  - READY 状態が全員に同期される。
+  - 2人未満では START が拒否される。
+  - 20分放置でルームが解散する。
+- データ:
+  - KV スキーマ変更なし。
+  - DO メモリ上の room state/timer のみ変更。
+- 互換性:
+  - 既存 HTTP API は変更しない。
+  - shared schema は既存定義の利用に留め、破壊変更は入れない。
+- Cloudflare resources:
+  - 追加リソースなし。
+  - DO ロジックのみ変更。
+
+## 対象ファイル / 対象レイヤ
+- `apps/worker/src/durable/room-state.ts`
+- `apps/worker/src/durable/room-object.ts`
+- 必要最小限で `tasks/codex-pr4-ready-check.md`
+
+## テスト観点
+- `READY_CHECK_OPEN` はホストのみ成功する。
+- `READY_SET` が自分の ready 状態を更新し、`ROOM_UPDATED` と `READY_STATUS_CHANGED` が送られる。
+- `START_MATCH` は READY_CHECK 中かつ 2人以上のときのみ成功する。
+- `players < 2` では `START_MATCH_REJECTED` または `ERROR` で拒否される。
+- READY_CHECK 開始後 20分超過で `ROOM_CLOSED` が配信される。
+- `npm --workspace @infinitas/worker run typecheck`
+
+## ロールバック方針
+- READY_CHECK ロジックに問題がある場合は PR-4 差分を revert し、PR-3 の LOBBY 状態へ戻す。
+- ルーム close 挙動に問題がある場合は timer/close 周りのみ個別切り戻しできるよう局所差分に留める。
+
+## Commit Plan（コミット分割計画）
+1. PR-4 plan 追加（本ファイル）。
+2. `room-state.ts` に READY_CHECK 状態・ガード・deadline 管理を追加。
+3. `room-object.ts` に READY_CHECK メッセージ処理と timeout close を追加。
+4. typecheck 実行と最終調整。


### PR DESCRIPTION
目的
- docs/design/09_implementation_plan.md の PR-4 に従い、READY_CHECK フェーズを Durable Object に実装する。
- ホスト限定の開始準備、READY 同期、START ガード、20分 TTL 解散を成立させる。

変更点
- apps/worker/src/durable/room-state.ts に READY_CHECK の状態遷移、ready_check_deadline、players>=2 ガード、START 後の参加ロックを追加。
- apps/worker/src/durable/room-object.ts に READY_CHECK_OPEN / READY_SET / START_MATCH の WS 処理を追加。
- DO alarm を使って ready_check_ttl 超過時に ROOM_CLOSED(reason=READY_CHECK_TIMEOUT) を配信し、KV ロビー削除まで行うようにした。
- tasks/codex-pr4-ready-check.md を追加し、Plan Mode の実装計画を記録した。

非変更点
- PICKING / PLAYING / RESULT の進行、集計、ラウンド処理。
- shared の WS schema / 定数の新規追加や docs/design の規範更新。
- client UI / watcher / Cloudflare 設定変更。

影響範囲（ユーザー / データ / 互換性 / Cloudflare）
- ユーザー: ホストのみ READY_CHECK を開ける。READY 状態が全員へ同期される。2人未満では START 不可。20分放置で解散する。
- データ: KV スキーマ変更なし。DO メモリ上の room state と timer 管理のみ変更。
- 互換性: 既存 HTTP API は変更なし。shared 既存 schema の範囲内で実装。
- Cloudflare: 既存 Durable Object / KV binding をそのまま利用し、DO alarm を追加利用するのみ。

テスト内容
- `C:\work\infinitas_arena\infinitas_bpl\node_modules\.bin\tsc.cmd --noEmit -p tsconfig.json`
- `C:\work\infinitas_arena\infinitas_bpl\node_modules\.bin\wrangler.cmd deploy --dry-run`

回帰確認項目
- LOBBY 参加/退出が引き続き成立すること。
- READY_CHECK 中の join/leave が成立すること。
- START_MATCH 成功時に room_state が PICKING へ遷移すること。
- READY_CHECK_TIMEOUT / HOST_LEFT で ROOM_CLOSED と KV cleanup が走ること。

ロールバック方針
- PR-4 の 3 コミットを revert して PR-3 の LOBBY 状態へ戻す。

互換性影響の有無
- 破壊的変更なし。

Cloudflare resources 影響
- 追加リソースなし。既存 DO/KV に対するロジック変更のみ。

docs/design 更新有無
- なし。既存設計の範囲内で実装。
