### PR TITLE
Implement PR-6 PLAYING basic progression

### DIFF
--- a/apps/worker/src/durable/room-object.ts
+++ b/apps/worker/src/durable/room-object.ts
@@ -8,6 +8,8 @@ import {
   WIN_METRICS,
   type ClientMessage,
   type ErrorCode,
+  type ExpectedKey,
+  type JsonObject,
   type RoomJoinPayload,
   type RoomSettings,
   type ServerMessagePayloadMap,
@@ -18,7 +20,7 @@ import { normalizeJoinCode } from "../services/join-code";
 import type { WorkerEnv } from "../types/env";
 import { asEnumValue, asOptionalString, isRecord } from "../utils/validation";
 import { createServerEnvelope, decodeClientMessage } from "./ws-codec";
-import { RoomLobbyState, type RoomInitializationInput } from "./room-state";
+import { RoomLobbyState, type RoomInitializationInput, type RoundTransitionResult } from "./room-state";
 import { workerChartMaster } from "../master/chart-master";
 
 interface RoomSocketSession {
@@ -166,6 +168,56 @@ function parsePickSubmitPayload(payload: unknown): { pick_chart_key: string } | 
   };
 }
 
+function parseExpectedKey(value: unknown): ExpectedKey | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const playStyle = asEnumValue(value.play_style, PLAY_STYLES);
+  const difficulty = asOptionalString(value.difficulty)?.trim() ?? "";
+  const titleSearchKey = asOptionalString(value.title_search_key)?.trim() ?? "";
+
+  if (playStyle === undefined || difficulty.length === 0 || titleSearchKey.length === 0) {
+    return null;
+  }
+
+  return {
+    play_style: playStyle,
+    difficulty,
+    title_search_key: titleSearchKey,
+  };
+}
+
+function parseResultSubmitPayload(
+  payload: unknown,
+): { round_index: number; observed_key: ExpectedKey; metric_value: number; source_meta: JsonObject | null } | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  const roundIndex = typeof payload.round_index === "number" ? payload.round_index : Number.NaN;
+  const metricValue = typeof payload.metric_value === "number" ? payload.metric_value : Number.NaN;
+  const observedKey = parseExpectedKey(payload.observed_key);
+  const sourceMeta = payload.source_meta;
+  if (
+    !Number.isInteger(roundIndex) ||
+    roundIndex < 0 ||
+    !Number.isInteger(metricValue) ||
+    metricValue < 0 ||
+    observedKey === null ||
+    (sourceMeta !== undefined && sourceMeta !== null && !isRecord(sourceMeta))
+  ) {
+    return null;
+  }
+
+  return {
+    round_index: roundIndex,
+    observed_key: observedKey,
+    metric_value: metricValue,
+    source_meta: sourceMeta === undefined || sourceMeta === null ? null : (sourceMeta as JsonObject),
+  };
+}
+
 export class RoomDurableObject {
   private readonly roomState = new RoomLobbyState(workerChartMaster);
   private readonly sessionsBySocket = new Map<WebSocket, RoomSocketSession>();
@@ -209,7 +261,7 @@ export class RoomDurableObject {
   }
 
   async alarm(): Promise<void> {
-    await this.closeReadyCheckOnTimeout(new Date());
+    await this.processDueTransitions(new Date());
   }
 
   private async handleInternalInitialize(request: Request): Promise<Response> {
@@ -294,7 +346,7 @@ export class RoomDurableObject {
         return;
       }
 
-      if (await this.closeReadyCheckOnTimeout(new Date())) {
+      if (await this.processDueTransitions(new Date())) {
         return;
       }
 
@@ -324,7 +376,10 @@ export class RoomDurableObject {
           await this.handleStartMatch(session);
           return;
         case "PICK_SUBMIT":
-          this.handlePickSubmit(session, message as ClientMessage<"PICK_SUBMIT">);
+          await this.handlePickSubmit(session, message as ClientMessage<"PICK_SUBMIT">);
+          return;
+        case "RESULT_SUBMIT":
+          await this.handleResultSubmit(session, message as ClientMessage<"RESULT_SUBMIT">);
           return;
         case "STATE_GET":
           this.sendStateSnapshot(socket);
@@ -425,7 +480,7 @@ export class RoomDurableObject {
     }
 
     if (leaveResult.was_host) {
-      await this.clearReadyCheckAlarm();
+      await this.clearAlarm();
       this.broadcast("ROOM_CLOSED", { reason: "HOST_LEFT" }, true);
       await this.cleanupLobbyEntry();
       this.disconnectAll(4000, "Host left.");
@@ -462,7 +517,7 @@ export class RoomDurableObject {
       return;
     }
 
-    await this.setReadyCheckAlarm(deadline);
+    await this.syncAlarm();
     this.broadcast("READY_CHECK_OPENED", {
       ready_check_deadline: deadline.toISOString(),
     });
@@ -518,11 +573,11 @@ export class RoomDurableObject {
       }
     }
 
-    await this.clearReadyCheckAlarm();
+    await this.syncAlarm();
     this.broadcastRoomUpdated();
   }
 
-  private handlePickSubmit(session: RoomSocketSession, message: ClientMessage<"PICK_SUBMIT">): void {
+  private async handlePickSubmit(session: RoomSocketSession, message: ClientMessage<"PICK_SUBMIT">): Promise<void> {
     if (session.playerId === null) {
       this.sendError(session.socket, "INVALID_STATE", "Send ROOM_JOIN before this message.");
       return;
@@ -558,6 +613,49 @@ export class RoomDurableObject {
       this.broadcast("ROUND_BEGIN", result.round_begin);
     }
 
+    await this.syncAlarm();
+    this.broadcastRoomUpdated();
+  }
+
+  private async handleResultSubmit(
+    session: RoomSocketSession,
+    message: ClientMessage<"RESULT_SUBMIT">,
+  ): Promise<void> {
+    if (session.playerId === null) {
+      this.sendError(session.socket, "INVALID_STATE", "Send ROOM_JOIN before this message.");
+      return;
+    }
+
+    const payload = parseResultSubmitPayload(message.payload);
+    if (payload === null) {
+      this.sendError(session.socket, "INVALID_STATE", "RESULT_SUBMIT payload is invalid.");
+      return;
+    }
+
+    const result = this.roomState.submitResult(
+      session.playerId,
+      payload.round_index,
+      payload.observed_key,
+      payload.metric_value,
+      payload.source_meta,
+      new Date(),
+    );
+    if (!result.ok) {
+      switch (result.reason) {
+        case "RESULT_KEY_MISMATCH":
+          this.sendError(session.socket, "RESULT_KEY_MISMATCH", "observed_key does not match current round.");
+          return;
+        case "ROUND_ALREADY_CONFIRMED":
+          this.sendError(session.socket, "ROUND_ALREADY_CONFIRMED", "Player already confirmed for this round.");
+          return;
+        default:
+          this.sendError(session.socket, "INVALID_STATE", "RESULT_SUBMIT is unavailable in the current state.");
+          return;
+      }
+    }
+
+    await this.syncAlarm();
+    this.broadcastRoundTransition(result);
     this.broadcastRoomUpdated();
   }
 
@@ -581,6 +679,20 @@ export class RoomDurableObject {
     this.broadcast("ROOM_UPDATED", {
       room_state_snapshot: this.roomState.toSnapshot(),
     });
+  }
+
+  private broadcastRoundTransition(result: RoundTransitionResult): void {
+    for (const confirmation of result.confirmations) {
+      this.broadcast("PLAYER_ROUND_CONFIRMED", confirmation);
+    }
+
+    if (result.round_ended !== undefined) {
+      this.broadcast("ROUND_ENDED", result.round_ended);
+    }
+
+    if (result.round_begin !== undefined) {
+      this.broadcast("ROUND_BEGIN", result.round_begin);
+    }
   }
 
   private broadcast<TType extends ServerMessageType>(
@@ -652,12 +764,41 @@ export class RoomDurableObject {
     }
   }
 
-  private async setReadyCheckAlarm(deadline: Date): Promise<void> {
-    await this.state.storage.setAlarm(deadline);
+  private async clearAlarm(): Promise<void> {
+    await this.state.storage.deleteAlarm();
   }
 
-  private async clearReadyCheckAlarm(): Promise<void> {
-    await this.state.storage.deleteAlarm();
+  private async syncAlarm(): Promise<void> {
+    const nextAlarmAt = this.roomState.getNextAlarmAt();
+    if (nextAlarmAt === null) {
+      await this.clearAlarm();
+      return;
+    }
+
+    await this.state.storage.setAlarm(nextAlarmAt);
+  }
+
+  private async processDueTransitions(now: Date): Promise<boolean> {
+    if (await this.closeReadyCheckOnTimeout(now)) {
+      return true;
+    }
+
+    const matchTransition = this.roomState.expireMatchIfNeeded(now);
+    if (matchTransition !== null) {
+      await this.syncAlarm();
+      this.broadcastRoundTransition(matchTransition);
+      this.broadcastRoomUpdated();
+      return false;
+    }
+
+    const roundTransition = this.roomState.expireCurrentRoundIfNeeded(now);
+    if (roundTransition !== null) {
+      await this.syncAlarm();
+      this.broadcastRoundTransition(roundTransition);
+      this.broadcastRoomUpdated();
+    }
+
+    return false;
   }
 
   private async closeReadyCheckOnTimeout(now: Date): Promise<boolean> {
@@ -666,7 +807,7 @@ export class RoomDurableObject {
       return false;
     }
 
-    await this.clearReadyCheckAlarm();
+    await this.clearAlarm();
     this.broadcast("ROOM_CLOSED", { reason: "READY_CHECK_TIMEOUT" }, true);
     await this.cleanupLobbyEntry();
     this.disconnectAll(4001, "Ready check timed out.");

--- a/apps/worker/src/durable/room-state.ts
+++ b/apps/worker/src/durable/room-state.ts
@@ -3,16 +3,22 @@ import {
   MATCH_TTL_MINUTES,
   READY_CHECK_TTL_MINUTES,
   REJOIN_COOLDOWN_SECONDS,
+  RESULT_TTL_MINUTES,
   ROUND_SOFT_TTL_SECONDS,
   START_MIN_PLAYERS,
   type CurrentRoundSnapshot,
   type ExpectedKey,
   type FrozenRound,
+  type JsonObject,
   type PlayerRole,
   type RoomSettings,
   type RoomState,
   type RoomStateSnapshot,
   type SourceType,
+  type SubmissionReason,
+  type SubmissionStatus,
+  type SubmittedBy,
+  type WinMetric,
 } from "@infinitas/shared";
 import type { ResolvedMasterChart, RoomChartMaster } from "../master/chart-master";
 
@@ -96,6 +102,38 @@ export interface PickSubmitResult {
   };
 }
 
+export interface RoundConfirmationEvent {
+  round_index: number;
+  player_id: string;
+  status: SubmissionStatus;
+  metric_value: number;
+  reason: SubmissionReason;
+  submitted_at: string;
+  submitted_by: SubmittedBy;
+}
+
+export interface RoundEndedEvent {
+  round_index: number;
+}
+
+export interface RoundBeginEvent {
+  round_index: number;
+  expected_key: ExpectedKey;
+  round_started_at: string;
+  soft_ttl_seconds: number;
+}
+
+export interface RoundTransitionResult {
+  confirmations: RoundConfirmationEvent[];
+  round_ended?: RoundEndedEvent;
+  round_begin?: RoundBeginEvent;
+}
+
+export interface ResultSubmitResult extends RoundTransitionResult {
+  ok: boolean;
+  reason?: "INVALID_STATE" | "PLAYER_NOT_FOUND" | "RESULT_KEY_MISMATCH" | "ROUND_ALREADY_CONFIRMED";
+}
+
 const DEFAULT_SETTINGS: RoomSettings = {
   visibility: "PUBLIC",
   join_code: null,
@@ -117,6 +155,10 @@ function computeMatchDeadline(createdAt: Date): Date {
 
 function computeReadyCheckDeadline(openedAt: Date): Date {
   return new Date(openedAt.getTime() + READY_CHECK_TTL_MINUTES * 60_000);
+}
+
+function computeResultDeadline(startedAt: Date): Date {
+  return new Date(startedAt.getTime() + RESULT_TTL_MINUTES * 60_000);
 }
 
 function computeRejoinUntil(now: Date): Date {
@@ -149,6 +191,18 @@ function cloneFrozenRound(round: FrozenRound): FrozenRound {
     },
     started_at: round.started_at,
     soft_ttl_seconds: round.soft_ttl_seconds,
+  };
+}
+
+function cloneRoundConfirmation(entry: RoundConfirmationEvent): RoundConfirmationEvent {
+  return {
+    round_index: entry.round_index,
+    player_id: entry.player_id,
+    status: entry.status,
+    metric_value: entry.metric_value,
+    reason: entry.reason,
+    submitted_at: entry.submitted_at,
+    submitted_by: entry.submitted_by,
   };
 }
 
@@ -355,6 +409,7 @@ export class RoomLobbyState {
     this.roomState = "PICKING";
     this.readyCheckDeadline = null;
     this.matchDeadline = computeMatchDeadline(now);
+    this.resultDeadline = null;
     this.matchPlayerIds = this.getPlayersInJoinOrder().map((player) => player.player_id);
     this.picks.length = 0;
     this.frozenRounds = [];
@@ -430,6 +485,79 @@ export class RoomLobbyState {
     return result;
   }
 
+  getNextAlarmAt(): Date | null {
+    if (this.roomState === "READY_CHECK" && this.readyCheckDeadline !== null) {
+      return this.readyCheckDeadline;
+    }
+
+    if (this.roomState === "PICKING") {
+      return this.matchDeadline;
+    }
+
+    if (this.roomState !== "PLAYING" || this.currentRound === null) {
+      return null;
+    }
+
+    const currentRoundDeadline = this.getCurrentRoundDeadline();
+    if (currentRoundDeadline === null) {
+      return this.matchDeadline;
+    }
+
+    return currentRoundDeadline.getTime() <= this.matchDeadline.getTime()
+      ? currentRoundDeadline
+      : this.matchDeadline;
+  }
+
+  submitResult(
+    playerId: string,
+    roundIndex: number,
+    observedKey: ExpectedKey,
+    metricValue: number,
+    _sourceMeta: JsonObject | null,
+    now: Date,
+  ): ResultSubmitResult {
+    if (this.roomState !== "PLAYING" || this.currentRound === null) {
+      return { ok: false, reason: "INVALID_STATE", confirmations: [] };
+    }
+
+    if (!this.matchPlayerIds.includes(playerId)) {
+      return { ok: false, reason: "PLAYER_NOT_FOUND", confirmations: [] };
+    }
+
+    if (roundIndex !== this.currentRound.round_index) {
+      return { ok: false, reason: "INVALID_STATE", confirmations: [] };
+    }
+
+    if (this.currentRound.confirmed.some((entry) => entry.player_id === playerId)) {
+      return { ok: false, reason: "ROUND_ALREADY_CONFIRMED", confirmations: [] };
+    }
+
+    if (!this.isSameExpectedKey(this.currentRound.expected_key, observedKey)) {
+      return { ok: false, reason: "RESULT_KEY_MISMATCH", confirmations: [] };
+    }
+
+    const confirmation = this.createRoundConfirmation({
+      round_index: roundIndex,
+      player_id: playerId,
+      status: "PLAYED",
+      metric_value: metricValue,
+      reason: null,
+      submitted_by: "SELF",
+      submitted_at: now,
+    });
+    const transition = this.applyRoundConfirmations([confirmation], now, false);
+    if (transition === null) {
+      return { ok: false, reason: "INVALID_STATE", confirmations: [] };
+    }
+
+    return {
+      ok: true,
+      confirmations: transition.confirmations,
+      ...(transition.round_ended === undefined ? {} : { round_ended: transition.round_ended }),
+      ...(transition.round_begin === undefined ? {} : { round_begin: transition.round_begin }),
+    };
+  }
+
   getReadyCheckDeadline(): Date | null {
     return this.readyCheckDeadline;
   }
@@ -447,6 +575,47 @@ export class RoomLobbyState {
     return true;
   }
 
+  expireMatchIfNeeded(now: Date): RoundTransitionResult | null {
+    if ((this.roomState !== "PICKING" && this.roomState !== "PLAYING") || now.getTime() < this.matchDeadline.getTime()) {
+      return null;
+    }
+
+    if (this.roomState === "PICKING" || this.currentRound === null) {
+      this.enterResult(now);
+      return { confirmations: [] };
+    }
+
+    const timedOutPlayers = this.getUnconfirmedPlayerIds(this.currentRound).map((playerId) =>
+      this.createTimeoutConfirmation(this.currentRound?.round_index ?? 0, playerId, now),
+    );
+    return this.applyRoundConfirmations(timedOutPlayers, now, true);
+  }
+
+  expireCurrentRoundIfNeeded(now: Date): RoundTransitionResult | null {
+    if (this.roomState !== "PLAYING" || this.currentRound === null) {
+      return null;
+    }
+
+    const deadline = this.getCurrentRoundDeadline();
+    if (
+      deadline === null ||
+      now.getTime() < deadline.getTime() ||
+      now.getTime() >= this.matchDeadline.getTime()
+    ) {
+      return null;
+    }
+
+    const unconfirmedPlayerIds = this.getUnconfirmedPlayerIds(this.currentRound);
+    if (unconfirmedPlayerIds.length === 0) {
+      return null;
+    }
+
+    const confirmations = unconfirmedPlayerIds.map((playerId) =>
+      this.createTimeoutConfirmation(this.currentRound?.round_index ?? 0, playerId, now),
+    );
+    return this.applyRoundConfirmations(confirmations, now, false);
+  }
+
   close(reason: string, now: Date): void {
     if (this.roomState === "CLOSED") {
       return;
@@ -454,6 +623,7 @@ export class RoomLobbyState {
 
     this.roomState = "CLOSED";
     this.readyCheckDeadline = null;
+    this.resultDeadline = null;
     this.closeReason = reason;
     this.closedAt = now;
   }
@@ -502,6 +672,114 @@ export class RoomLobbyState {
       closed_at: toIsoString(this.closedAt),
       close_reason: this.closeReason,
     };
+  }
+
+  private getCurrentRoundDeadline(): Date | null {
+    if (this.currentRound === null) {
+      return null;
+    }
+
+    const roundStartedAt = new Date(this.currentRound.round_started_at);
+    if (!Number.isFinite(roundStartedAt.getTime())) {
+      return null;
+    }
+
+    return new Date(roundStartedAt.getTime() + this.currentRound.soft_ttl_seconds * 1_000);
+  }
+
+  private isSameExpectedKey(left: ExpectedKey, right: ExpectedKey): boolean {
+    return expectedKeyId(left) === expectedKeyId(right);
+  }
+
+  private createRoundConfirmation(input: {
+    round_index: number;
+    player_id: string;
+    status: SubmissionStatus;
+    metric_value: number;
+    reason: SubmissionReason;
+    submitted_by: SubmittedBy;
+    submitted_at: Date;
+  }): RoundConfirmationEvent {
+    return {
+      round_index: input.round_index,
+      player_id: input.player_id,
+      status: input.status,
+      metric_value: input.metric_value,
+      reason: input.reason,
+      submitted_by: input.submitted_by,
+      submitted_at: input.submitted_at.toISOString(),
+    };
+  }
+
+  private createTimeoutConfirmation(
+    roundIndex: number,
+    playerId: string,
+    submittedAt: Date,
+  ): RoundConfirmationEvent {
+    return this.createRoundConfirmation({
+      round_index: roundIndex,
+      player_id: playerId,
+      status: "TIMEOUT",
+      metric_value: this.getDefaultTerminalMetricValue(this.settings.win_metric),
+      reason: "UNMAPPED_TIMEOUT",
+      submitted_by: "SYSTEM",
+      submitted_at: submittedAt,
+    });
+  }
+
+  private getDefaultTerminalMetricValue(metric: WinMetric): number {
+    return metric === "MISSCOUNT" ? 9999 : 0;
+  }
+
+  private getUnconfirmedPlayerIds(round: CurrentRoundSnapshot): string[] {
+    const confirmedPlayerIds = new Set(round.confirmed.map((entry) => entry.player_id));
+    return this.matchPlayerIds.filter((playerId) => !confirmedPlayerIds.has(playerId));
+  }
+
+  private applyRoundConfirmations(
+    confirmations: RoundConfirmationEvent[],
+    now: Date,
+    forceResult: boolean,
+  ): RoundTransitionResult | null {
+    if (this.currentRound === null) {
+      return null;
+    }
+
+    this.currentRound.confirmed = [
+      ...this.currentRound.confirmed,
+      ...confirmations.map(cloneRoundConfirmation),
+    ];
+
+    const currentRoundIndex = this.currentRound.round_index;
+    const result: RoundTransitionResult = {
+      confirmations: confirmations.map(cloneRoundConfirmation),
+    };
+
+    if (!forceResult && this.currentRound.confirmed.length < this.matchPlayerIds.length) {
+      return result;
+    }
+
+    result.round_ended = { round_index: currentRoundIndex };
+
+    if (forceResult) {
+      this.enterResult(now);
+      return result;
+    }
+
+    const nextRound = this.beginNextRound(currentRoundIndex + 1, now);
+    if (nextRound !== null) {
+      result.round_begin = nextRound;
+      return result;
+    }
+
+    this.enterResult(now);
+    return result;
+  }
+
+  private enterResult(now: Date): void {
+    this.roomState = "RESULT";
+    this.currentRound = null;
+    this.resultDeadline = computeResultDeadline(now);
   }
 
   private getPlayersInJoinOrder(): InternalPlayer[] {
@@ -615,25 +893,56 @@ export class RoomLobbyState {
   }
 
   private beginFirstRound(now: Date): CurrentRoundSnapshot | null {
+    return this.beginRoundAtIndex(0, now);
+  }
+
+  private beginNextRound(roundIndex: number, now: Date): RoundBeginEvent | null {
+    const nextRound = this.beginRoundAtIndex(roundIndex, now);
+    if (nextRound === null) {
+      return null;
+    }
+
+    return {
+      round_index: nextRound.round_index,
+      expected_key: cloneExpectedKey(nextRound.expected_key),
+      round_started_at: nextRound.round_started_at,
+      soft_ttl_seconds: nextRound.soft_ttl_seconds,
+    };
+  }
+
+  private beginRoundAtIndex(roundIndex: number, now: Date): CurrentRoundSnapshot | null {
     if (this.frozenRounds.length === 0) {
       return null;
     }
 
     const roundStartedAt = now.toISOString();
-    const firstRoundSource = this.frozenRounds[0];
-    if (firstRoundSource === undefined) {
+    const roundSource = this.frozenRounds.find((round) => round.round_index === roundIndex);
+    if (roundSource === undefined) {
       return null;
     }
 
-    const firstRound = cloneFrozenRound(firstRoundSource);
-    firstRound.started_at = roundStartedAt;
-    this.frozenRounds = [firstRound, ...this.frozenRounds.slice(1).map(cloneFrozenRound)];
+    this.frozenRounds = this.frozenRounds.map((round) => {
+      if (round.round_index !== roundIndex) {
+        return cloneFrozenRound(round);
+      }
+
+      return {
+        ...cloneFrozenRound(round),
+        started_at: roundStartedAt,
+      };
+    });
+
+    const startedRound = this.frozenRounds.find((round) => round.round_index === roundIndex);
+    if (startedRound === undefined) {
+      return null;
+    }
+
     this.roomState = "PLAYING";
     this.currentRound = {
-      round_index: firstRound.round_index,
-      expected_key: cloneExpectedKey(firstRound.expected_key),
+      round_index: startedRound.round_index,
+      expected_key: cloneExpectedKey(startedRound.expected_key),
       round_started_at: roundStartedAt,
-      soft_ttl_seconds: firstRound.soft_ttl_seconds,
+      soft_ttl_seconds: startedRound.soft_ttl_seconds,
       confirmed: [],
     };
     return this.currentRound;

--- a/tasks/codex-pr-6-playing-basic.md
+++ b/tasks/codex-pr-6-playing-basic.md
@@ -1,0 +1,63 @@
+# Plan: codex/pr-6-playing-basic
+
+## 作業宣言
+- worktree: `C:\work\infinitas_arena\infinitas_bpl_pr6_playing_basic`
+- branch: `codex/pr-6-playing-basic`
+- base branch: `v1`
+- BASE_SHA: `26995f726b66736c25ce25b9d97f0973a46b88dc`
+
+## 目的
+- `docs/design/09_implementation_plan.md` の PR-6（PLAYING 基本進行）を実装する。
+- Durable Object 上で `RESULT_SUBMIT`、`current_round`、`round_soft_ttl`、`match_ttl`、`accept_window=0`、初回採用のみを成立させる。
+
+## 非目的
+- `SKIP_SELF` / `SKIP_HOST_ASSIGN` / `FORCE_ADVANCE` / `RESULT_READY`（PR-7 以降）。
+- クライアント UI / watcher 実装。
+- docs/design の規範仕様変更。
+
+## 変更点
+- `room-state.ts` に PLAYING 用の提出採用、expected 一致判定、ラウンド完了判定、soft ttl / match ttl の進行ロジックを追加する。
+- `room-object.ts` に `RESULT_SUBMIT` の payload 検証、`PLAYER_ROUND_CONFIRMED` / `ROUND_ENDED` / 次ラウンド `ROUND_BEGIN` / `ROOM_UPDATED` 配信と DO alarm 運用を追加する。
+- PICKING から開始済みの `ROUND_BEGIN` を前提に、PLAYING から RESULT への最小遷移を成立させる。
+
+## 影響範囲
+- ユーザー:
+  - 当該ラウンドの `expected_key` と一致した提出だけが初回採用される。
+  - mismatch や重複提出は拒否される。
+  - `round_soft_ttl` 超過で未提出者が `TIMEOUT` になり次ラウンドへ進む。
+  - `match_ttl` 超過で未確定者を `TIMEOUT` にして `RESULT` へ遷移する。
+- データ:
+  - DO メモリ上の `current_round`、`frozen_rounds.started_at`、確定済み submission 情報、`result_deadline` が更新される。
+- 互換性:
+  - 既存 shared schema の範囲で実装し、破壊的変更は行わない。
+- Cloudflare resources:
+  - Durable Object alarm と PLAYING ロジックのみ変更。
+
+## 対象ファイル / 対象レイヤ
+- `apps/worker/src/durable/room-state.ts`
+- `apps/worker/src/durable/room-object.ts`
+- `tasks/codex-pr-6-playing-basic.md`
+
+## テスト観点
+- `RESULT_SUBMIT` は `room_state=PLAYING` かつ `round_index == current_round_index` のときのみ通る。
+- `observed_key != expected_key` は採用されない。
+- 同一プレイヤーの 2 回目以降の提出は採用されない。
+- 全員確定で `ROUND_ENDED` 後に次ラウンド `ROUND_BEGIN` または `RESULT` へ遷移する。
+- `round_soft_ttl` 超過で未確定者が `TIMEOUT` になる。
+- `match_ttl` 超過で進行中ラウンドも含めて未確定者を `TIMEOUT` にして `RESULT` へ遷移する。
+- `npm --workspace @infinitas/worker run typecheck`
+- `npm run typecheck`
+
+## ロールバック方針
+- PR-6 差分を revert し、PR-5.5 の PICKING -> 初回 `ROUND_BEGIN` 実装へ戻す。
+
+## Commit Plan（コミット分割計画）
+1. PR-6 plan 追加（本ファイル）。
+2. `room-state.ts` に PLAYING 提出とタイマー進行ロジックを追加。
+3. `room-object.ts` に `RESULT_SUBMIT` 処理と alarm 配信を追加。
+4. typecheck 実行と最終調整。
+
+## 検証結果
+- `npm ci`
+- `npm --workspace @infinitas/worker run typecheck`
+- `npm run typecheck`


### PR DESCRIPTION
## 目的
- `docs/design/09_implementation_plan.md` の PR-6 に従い、Durable Object 上で PLAYING の基本進行を実装する。
- `RESULT_SUBMIT`、`current_round`、`round_soft_ttl`、`match_ttl`、`accept_window=0`、初回採用のみを成立させる。

## 変更点
- `apps/worker/src/durable/room-state.ts`
  - `RESULT_SUBMIT` の受理、`observed_key == expected_key` 判定、初回採用のみ、ラウンド終了判定を追加。
  - `round_soft_ttl` 超過時の `TIMEOUT` 確定、次ラウンド開始、`match_ttl` 超過時の `RESULT` 遷移を追加。
  - DO alarm 用の次回 deadline 計算を追加。
- `apps/worker/src/durable/room-object.ts`
  - `RESULT_SUBMIT` payload 検証と `PLAYER_ROUND_CONFIRMED` / `ROUND_ENDED` / `ROUND_BEGIN` 配信を追加。
  - READY_CHECK 専用だった alarm 運用を、READY_CHECK / PLAYING / match timeout を扱う同期方式へ変更。
- `tasks/codex-pr-6-playing-basic.md`
  - Plan Mode 用の task と検証結果を追加。

## 非変更点
- `SKIP_SELF` / `SKIP_HOST_ASSIGN` / `FORCE_ADVANCE` / `RESULT_READY` は未実装。
- client UI / watcher / docs/design の規範仕様変更は行わない。

## 影響範囲
- ユーザー:
  - 当該ラウンドの `expected_key` と一致した提出だけが初回採用される。
  - mismatch と重複提出は拒否される。
  - `round_soft_ttl` 超過で未確定者が `TIMEOUT` になり、次ラウンドへ進む。
  - `match_ttl` 超過で進行中ラウンドを確定して `RESULT` へ遷移する。
- データ:
  - DO メモリ上の `current_round`、`frozen_rounds.started_at`、`result_deadline` が更新される。
- 互換性:
  - shared schema の破壊的変更なし。
- Cloudflare:
  - Durable Object alarm / FSM のみ変更。KV schema 変更なし。

## テスト内容
- `npm ci`
- `npm --workspace @infinitas/worker run typecheck`
- `npm run typecheck`

## 回帰確認項目
- `RESULT_SUBMIT` は `room_state=PLAYING` かつ `round_index == current_round_index` のときのみ採用される。
- `observed_key != expected_key` は `RESULT_KEY_MISMATCH` で拒否される。
- 同一プレイヤーの 2 回目以降の提出は `ROUND_ALREADY_CONFIRMED` で拒否される。
- 全員確定で `ROUND_ENDED` の後に次ラウンド `ROUND_BEGIN`、最終ラウンドでは `RESULT` へ遷移する。
- `round_soft_ttl` / `match_ttl` 超過で DO alarm 経由の遷移が発火する。

## ロールバック方針
- 本PRを revert し、PR-5.5 時点の PICKING -> 初回 `ROUND_BEGIN` 実装へ戻す。

## 互換性影響の有無
- なし

## Cloudflare resources 影響
- Durable Object alarm の使用箇所が増えるが、namespace / KV / route の追加変更はない。

## docs/design 更新有無
- なし
