### PR TITLE
feat: implement PR-7 skip and result aggregation

### DIFF
--- a/apps/worker/src/durable/room-object.ts
+++ b/apps/worker/src/durable/room-object.ts
@@ -3,6 +3,7 @@ import {
   MAX_PLAYERS_OPTIONS,
   MODES,
   PLAY_STYLES,
+  SKIP_REASONS,
   SOURCE_TYPES,
   VISIBILITIES,
   WIN_METRICS,
@@ -12,6 +13,7 @@ import {
   type JsonObject,
   type RoomJoinPayload,
   type RoomSettings,
+  type SkipReason,
   type ServerMessagePayloadMap,
   type ServerMessageType,
 } from "@infinitas/shared";
@@ -218,6 +220,43 @@ function parseResultSubmitPayload(
   };
 }
 
+function parseSkipPayload(payload: unknown): { round_index: number; reason: SkipReason } | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  const roundIndex = typeof payload.round_index === "number" ? payload.round_index : Number.NaN;
+  const reason = asEnumValue(payload.reason, SKIP_REASONS);
+  if (!Number.isInteger(roundIndex) || roundIndex < 0 || reason === undefined) {
+    return null;
+  }
+
+  return {
+    round_index: roundIndex,
+    reason,
+  };
+}
+
+function parseSkipHostAssignPayload(
+  payload: unknown,
+): { round_index: number; target_player_id: string; reason: SkipReason } | null {
+  const parsedSkip = parseSkipPayload(payload);
+  if (parsedSkip === null || !isRecord(payload)) {
+    return null;
+  }
+
+  const targetPlayerId = asOptionalString(payload.target_player_id)?.trim() ?? "";
+  if (targetPlayerId.length === 0) {
+    return null;
+  }
+
+  return {
+    round_index: parsedSkip.round_index,
+    target_player_id: targetPlayerId,
+    reason: parsedSkip.reason,
+  };
+}
+
 export class RoomDurableObject {
   private readonly roomState = new RoomLobbyState(workerChartMaster);
   private readonly sessionsBySocket = new Map<WebSocket, RoomSocketSession>();
@@ -381,6 +420,15 @@ export class RoomDurableObject {
         case "RESULT_SUBMIT":
           await this.handleResultSubmit(session, message as ClientMessage<"RESULT_SUBMIT">);
           return;
+        case "SKIP_SELF":
+          await this.handleSkipSelf(session, message as ClientMessage<"SKIP_SELF">);
+          return;
+        case "SKIP_HOST_ASSIGN":
+          await this.handleSkipHostAssign(session, message as ClientMessage<"SKIP_HOST_ASSIGN">);
+          return;
+        case "FORCE_ADVANCE":
+          await this.handleForceAdvance(session);
+          return;
         case "STATE_GET":
           this.sendStateSnapshot(socket);
           return;
@@ -457,6 +505,7 @@ export class RoomDurableObject {
     this.send(session.socket, "ROOM_JOIN_ACCEPTED", {
       room_state_snapshot: this.roomState.toSnapshot(),
     });
+    this.sendResultReadyIfAvailable(session.socket);
     this.broadcastRoomUpdated();
   }
 
@@ -659,6 +708,106 @@ export class RoomDurableObject {
     this.broadcastRoomUpdated();
   }
 
+  private async handleSkipSelf(session: RoomSocketSession, message: ClientMessage<"SKIP_SELF">): Promise<void> {
+    if (session.playerId === null) {
+      this.sendError(session.socket, "INVALID_STATE", "Send ROOM_JOIN before this message.");
+      return;
+    }
+
+    const payload = parseSkipPayload(message.payload);
+    if (payload === null) {
+      this.sendError(session.socket, "INVALID_STATE", "SKIP_SELF payload is invalid.");
+      return;
+    }
+
+    const result = this.roomState.skipSelf(session.playerId, payload.round_index, payload.reason, new Date());
+    if (!result.ok) {
+      switch (result.reason) {
+        case "ROUND_ALREADY_CONFIRMED":
+          this.sendError(session.socket, "ROUND_ALREADY_CONFIRMED", "Player already confirmed for this round.");
+          return;
+        default:
+          this.sendError(session.socket, "INVALID_STATE", "SKIP_SELF is unavailable in the current state.");
+          return;
+      }
+    }
+
+    await this.syncAlarm();
+    this.broadcastRoundTransition(result);
+    this.broadcastRoomUpdated();
+  }
+
+  private async handleSkipHostAssign(
+    session: RoomSocketSession,
+    message: ClientMessage<"SKIP_HOST_ASSIGN">,
+  ): Promise<void> {
+    if (session.playerId === null) {
+      this.sendError(session.socket, "INVALID_STATE", "Send ROOM_JOIN before this message.");
+      return;
+    }
+
+    const payload = parseSkipHostAssignPayload(message.payload);
+    if (payload === null) {
+      this.sendError(session.socket, "INVALID_STATE", "SKIP_HOST_ASSIGN payload is invalid.");
+      return;
+    }
+
+    const result = this.roomState.assignHostSkip(
+      session.playerId,
+      payload.round_index,
+      payload.target_player_id,
+      payload.reason,
+      new Date(),
+    );
+    if (!result.ok) {
+      switch (result.reason) {
+        case "NOT_HOST":
+          this.sendError(session.socket, "NOT_HOST", "Only the host can assign a skip.");
+          return;
+        case "HOST_SKIP_LOCKED":
+          this.sendError(session.socket, "HOST_SKIP_LOCKED", "Host skip is locked until the round has been active for 240 seconds.");
+          return;
+        case "ROUND_ALREADY_CONFIRMED":
+          this.sendError(session.socket, "ROUND_ALREADY_CONFIRMED", "Target player already confirmed for this round.");
+          return;
+        default:
+          this.sendError(session.socket, "INVALID_STATE", "SKIP_HOST_ASSIGN is unavailable in the current state.");
+          return;
+      }
+    }
+
+    await this.syncAlarm();
+    this.broadcastRoundTransition(result);
+    this.broadcastRoomUpdated();
+  }
+
+  private async handleForceAdvance(session: RoomSocketSession): Promise<void> {
+    if (session.playerId === null) {
+      this.sendError(session.socket, "INVALID_STATE", "Send ROOM_JOIN before this message.");
+      return;
+    }
+
+    const result = this.roomState.forceAdvance(session.playerId, new Date());
+    if (!result.ok) {
+      switch (result.reason) {
+        case "NOT_HOST":
+          this.sendError(session.socket, "NOT_HOST", "Only the host can force advance.");
+          return;
+        default:
+          this.sendError(
+            session.socket,
+            "INVALID_STATE",
+            "FORCE_ADVANCE is unavailable unless the current round still has unconfirmed players.",
+          );
+          return;
+      }
+    }
+
+    await this.syncAlarm();
+    this.broadcastRoundTransition(result);
+    this.broadcastRoomUpdated();
+  }
+
   private findSessionByPlayerId(playerId: string): RoomSocketSession | null {
     for (const session of this.sessionsBySocket.values()) {
       if (session.playerId === playerId) {
@@ -673,6 +822,7 @@ export class RoomDurableObject {
     this.send(socket, "STATE_SNAPSHOT", {
       room_state_snapshot: this.roomState.toSnapshot(),
     });
+    this.sendResultReadyIfAvailable(socket);
   }
 
   private broadcastRoomUpdated(): void {
@@ -686,12 +836,20 @@ export class RoomDurableObject {
       this.broadcast("PLAYER_ROUND_CONFIRMED", confirmation);
     }
 
+    if (result.force_advance_applied !== undefined) {
+      this.broadcast("FORCE_ADVANCE_APPLIED", result.force_advance_applied);
+    }
+
     if (result.round_ended !== undefined) {
       this.broadcast("ROUND_ENDED", result.round_ended);
     }
 
     if (result.round_begin !== undefined) {
       this.broadcast("ROUND_BEGIN", result.round_begin);
+    }
+
+    if (result.result_ready !== undefined) {
+      this.broadcast("RESULT_READY", result.result_ready);
     }
   }
 
@@ -732,6 +890,15 @@ export class RoomDurableObject {
 
   private sendStartMatchRejected(socket: WebSocket, reason: string): void {
     this.send(socket, "START_MATCH_REJECTED", { reason });
+  }
+
+  private sendResultReadyIfAvailable(socket: WebSocket): void {
+    const payload = this.roomState.getResultReadyPayload();
+    if (payload === null) {
+      return;
+    }
+
+    this.send(socket, "RESULT_READY", payload);
   }
 
   private isDuplicateMessage(playerId: string, clientMessageId: string): boolean {
@@ -783,6 +950,10 @@ export class RoomDurableObject {
       return true;
     }
 
+    if (await this.closeResultOnTimeout(now)) {
+      return true;
+    }
+
     const matchTransition = this.roomState.expireMatchIfNeeded(now);
     if (matchTransition !== null) {
       await this.syncAlarm();
@@ -811,6 +982,19 @@ export class RoomDurableObject {
     this.broadcast("ROOM_CLOSED", { reason: "READY_CHECK_TIMEOUT" }, true);
     await this.cleanupLobbyEntry();
     this.disconnectAll(4001, "Ready check timed out.");
+    return true;
+  }
+
+  private async closeResultOnTimeout(now: Date): Promise<boolean> {
+    const closed = this.roomState.closeResultIfExpired(now);
+    if (!closed) {
+      return false;
+    }
+
+    await this.clearAlarm();
+    this.broadcast("ROOM_CLOSED", { reason: "RESULT_TIMEOUT" }, true);
+    await this.cleanupLobbyEntry();
+    this.disconnectAll(4002, "Result expired.");
     return true;
   }
 

--- a/apps/worker/src/durable/room-state.ts
+++ b/apps/worker/src/durable/room-state.ts
@@ -1,5 +1,6 @@
 import {
   BPL_ROUNDS,
+  HOST_SKIP_UNLOCK_SECONDS,
   MATCH_TTL_MINUTES,
   READY_CHECK_TTL_MINUTES,
   REJOIN_COOLDOWN_SECONDS,
@@ -11,9 +12,11 @@ import {
   type FrozenRound,
   type JsonObject,
   type PlayerRole,
+  type ResultReadyPayload,
   type RoomSettings,
   type RoomState,
   type RoomStateSnapshot,
+  type SkipReason,
   type SourceType,
   type SubmissionReason,
   type SubmissionStatus,
@@ -123,15 +126,37 @@ export interface RoundBeginEvent {
   soft_ttl_seconds: number;
 }
 
+export interface ForceAdvanceAppliedEvent {
+  round_index: number;
+  timed_out_players: string[];
+}
+
 export interface RoundTransitionResult {
   confirmations: RoundConfirmationEvent[];
   round_ended?: RoundEndedEvent;
   round_begin?: RoundBeginEvent;
+  force_advance_applied?: ForceAdvanceAppliedEvent;
+  result_ready?: ResultReadyPayload;
 }
 
 export interface ResultSubmitResult extends RoundTransitionResult {
   ok: boolean;
   reason?: "INVALID_STATE" | "PLAYER_NOT_FOUND" | "RESULT_KEY_MISMATCH" | "ROUND_ALREADY_CONFIRMED";
+}
+
+export interface SkipSelfResult extends RoundTransitionResult {
+  ok: boolean;
+  reason?: "INVALID_STATE" | "PLAYER_NOT_FOUND" | "ROUND_ALREADY_CONFIRMED";
+}
+
+export interface SkipHostAssignResult extends RoundTransitionResult {
+  ok: boolean;
+  reason?: "INVALID_STATE" | "NOT_HOST" | "PLAYER_NOT_FOUND" | "ROUND_ALREADY_CONFIRMED" | "HOST_SKIP_LOCKED";
+}
+
+export interface ForceAdvanceResult extends RoundTransitionResult {
+  ok: boolean;
+  reason?: "INVALID_STATE" | "NOT_HOST";
 }
 
 const DEFAULT_SETTINGS: RoomSettings = {
@@ -220,9 +245,11 @@ export class RoomLobbyState {
   private closeReason: string | null = null;
   private readonly players = new Map<string, InternalPlayer>();
   private readonly picks: InternalPick[] = [];
+  private readonly roundConfirmations = new Map<number, RoundConfirmationEvent[]>();
   private frozenRounds: FrozenRound[] = [];
   private currentRound: CurrentRoundSnapshot | null = null;
   private matchPlayerIds: string[] = [];
+  private resultReadyPayload: ResultReadyPayload | null = null;
 
   constructor(private readonly chartMaster: RoomChartMaster) {}
 
@@ -412,8 +439,10 @@ export class RoomLobbyState {
     this.resultDeadline = null;
     this.matchPlayerIds = this.getPlayersInJoinOrder().map((player) => player.player_id);
     this.picks.length = 0;
+    this.roundConfirmations.clear();
     this.frozenRounds = [];
     this.currentRound = null;
+    this.resultReadyPayload = null;
 
     for (const player of this.players.values()) {
       player.ready = false;
@@ -494,6 +523,10 @@ export class RoomLobbyState {
       return this.matchDeadline;
     }
 
+    if (this.roomState === "RESULT" && this.resultDeadline !== null) {
+      return this.resultDeadline;
+    }
+
     if (this.roomState !== "PLAYING" || this.currentRound === null) {
       return null;
     }
@@ -545,7 +578,7 @@ export class RoomLobbyState {
       submitted_by: "SELF",
       submitted_at: now,
     });
-    const transition = this.applyRoundConfirmations([confirmation], now, false);
+    const transition = this.applyRoundConfirmations([confirmation], now, {});
     if (transition === null) {
       return { ok: false, reason: "INVALID_STATE", confirmations: [] };
     }
@@ -555,7 +588,129 @@ export class RoomLobbyState {
       confirmations: transition.confirmations,
       ...(transition.round_ended === undefined ? {} : { round_ended: transition.round_ended }),
       ...(transition.round_begin === undefined ? {} : { round_begin: transition.round_begin }),
+      ...(transition.result_ready === undefined ? {} : { result_ready: transition.result_ready }),
     };
+  }
+
+  skipSelf(playerId: string, roundIndex: number, reason: SkipReason, now: Date): SkipSelfResult {
+    if (this.roomState !== "PLAYING" || this.currentRound === null) {
+      return { ok: false, reason: "INVALID_STATE", confirmations: [] };
+    }
+
+    if (!this.matchPlayerIds.includes(playerId)) {
+      return { ok: false, reason: "PLAYER_NOT_FOUND", confirmations: [] };
+    }
+
+    if (roundIndex !== this.currentRound.round_index) {
+      return { ok: false, reason: "INVALID_STATE", confirmations: [] };
+    }
+
+    if (this.currentRound.confirmed.some((entry) => entry.player_id === playerId)) {
+      return { ok: false, reason: "ROUND_ALREADY_CONFIRMED", confirmations: [] };
+    }
+
+    const confirmation = this.createSkipConfirmation(roundIndex, playerId, reason, "SELF", now);
+    const transition = this.applyRoundConfirmations([confirmation], now, {});
+    if (transition === null) {
+      return { ok: false, reason: "INVALID_STATE", confirmations: [] };
+    }
+
+    return {
+      ok: true,
+      confirmations: transition.confirmations,
+      ...(transition.round_ended === undefined ? {} : { round_ended: transition.round_ended }),
+      ...(transition.round_begin === undefined ? {} : { round_begin: transition.round_begin }),
+      ...(transition.result_ready === undefined ? {} : { result_ready: transition.result_ready }),
+    };
+  }
+
+  assignHostSkip(
+    playerId: string,
+    roundIndex: number,
+    targetPlayerId: string,
+    reason: SkipReason,
+    now: Date,
+  ): SkipHostAssignResult {
+    if (playerId !== this.hostPlayerId) {
+      return { ok: false, reason: "NOT_HOST", confirmations: [] };
+    }
+
+    if (this.roomState !== "PLAYING" || this.currentRound === null) {
+      return { ok: false, reason: "INVALID_STATE", confirmations: [] };
+    }
+
+    if (roundIndex !== this.currentRound.round_index) {
+      return { ok: false, reason: "INVALID_STATE", confirmations: [] };
+    }
+
+    if (!this.matchPlayerIds.includes(targetPlayerId)) {
+      return { ok: false, reason: "PLAYER_NOT_FOUND", confirmations: [] };
+    }
+
+    if (this.currentRound.confirmed.some((entry) => entry.player_id === targetPlayerId)) {
+      return { ok: false, reason: "ROUND_ALREADY_CONFIRMED", confirmations: [] };
+    }
+
+    if (!this.isHostSkipUnlocked(now)) {
+      return { ok: false, reason: "HOST_SKIP_LOCKED", confirmations: [] };
+    }
+
+    const confirmation = this.createSkipConfirmation(roundIndex, targetPlayerId, reason, "HOST", now);
+    const transition = this.applyRoundConfirmations([confirmation], now, {});
+    if (transition === null) {
+      return { ok: false, reason: "INVALID_STATE", confirmations: [] };
+    }
+
+    return {
+      ok: true,
+      confirmations: transition.confirmations,
+      ...(transition.round_ended === undefined ? {} : { round_ended: transition.round_ended }),
+      ...(transition.round_begin === undefined ? {} : { round_begin: transition.round_begin }),
+      ...(transition.result_ready === undefined ? {} : { result_ready: transition.result_ready }),
+    };
+  }
+
+  forceAdvance(playerId: string, now: Date): ForceAdvanceResult {
+    if (playerId !== this.hostPlayerId) {
+      return { ok: false, reason: "NOT_HOST", confirmations: [] };
+    }
+
+    if (this.roomState !== "PLAYING" || this.currentRound === null) {
+      return { ok: false, reason: "INVALID_STATE", confirmations: [] };
+    }
+
+    const timedOutPlayerIds = this.getUnconfirmedPlayerIds(this.currentRound);
+    if (timedOutPlayerIds.length === 0) {
+      return { ok: false, reason: "INVALID_STATE", confirmations: [] };
+    }
+
+    const confirmations = timedOutPlayerIds.map((targetPlayerId) =>
+      this.createTimeoutConfirmation(this.currentRound?.round_index ?? 0, targetPlayerId, now),
+    );
+    const transition = this.applyRoundConfirmations(confirmations, now, {
+      force_advance_applied: {
+        round_index: this.currentRound.round_index,
+        timed_out_players: [...timedOutPlayerIds],
+      },
+    });
+    if (transition === null) {
+      return { ok: false, reason: "INVALID_STATE", confirmations: [] };
+    }
+
+    return {
+      ok: true,
+      confirmations: transition.confirmations,
+      ...(transition.round_ended === undefined ? {} : { round_ended: transition.round_ended }),
+      ...(transition.round_begin === undefined ? {} : { round_begin: transition.round_begin }),
+      ...(transition.force_advance_applied === undefined
+        ? {}
+        : { force_advance_applied: transition.force_advance_applied }),
+      ...(transition.result_ready === undefined ? {} : { result_ready: transition.result_ready }),
+    };
+  }
+
+  getResultReadyPayload(): ResultReadyPayload | null {
+    return this.resultReadyPayload;
   }
 
   getReadyCheckDeadline(): Date | null {
@@ -575,6 +730,19 @@ export class RoomLobbyState {
     return true;
   }
 
+  closeResultIfExpired(now: Date): boolean {
+    if (
+      this.roomState !== "RESULT" ||
+      this.resultDeadline === null ||
+      now.getTime() < this.resultDeadline.getTime()
+    ) {
+      return false;
+    }
+
+    this.close("RESULT_TIMEOUT", now);
+    return true;
+  }
+
   expireMatchIfNeeded(now: Date): RoundTransitionResult | null {
     if ((this.roomState !== "PICKING" && this.roomState !== "PLAYING") || now.getTime() < this.matchDeadline.getTime()) {
       return null;
@@ -582,13 +750,16 @@ export class RoomLobbyState {
 
     if (this.roomState === "PICKING" || this.currentRound === null) {
       this.enterResult(now);
-      return { confirmations: [] };
+      return {
+        confirmations: [],
+        ...(this.resultReadyPayload === null ? {} : { result_ready: this.resultReadyPayload }),
+      };
     }
 
     const timedOutPlayers = this.getUnconfirmedPlayerIds(this.currentRound).map((playerId) =>
       this.createTimeoutConfirmation(this.currentRound?.round_index ?? 0, playerId, now),
     );
-    return this.applyRoundConfirmations(timedOutPlayers, now, true);
+    return this.applyRoundConfirmations(timedOutPlayers, now, { force_result: true });
   }
 
   expireCurrentRoundIfNeeded(now: Date): RoundTransitionResult | null {
@@ -613,7 +784,7 @@ export class RoomLobbyState {
     const confirmations = unconfirmedPlayerIds.map((playerId) =>
       this.createTimeoutConfirmation(this.currentRound?.round_index ?? 0, playerId, now),
     );
-    return this.applyRoundConfirmations(confirmations, now, false);
+    return this.applyRoundConfirmations(confirmations, now, {});
   }
 
   close(reason: string, now: Date): void {
@@ -711,6 +882,24 @@ export class RoomLobbyState {
     };
   }
 
+  private createSkipConfirmation(
+    roundIndex: number,
+    playerId: string,
+    reason: SkipReason,
+    submittedBy: SubmittedBy,
+    submittedAt: Date,
+  ): RoundConfirmationEvent {
+    return this.createRoundConfirmation({
+      round_index: roundIndex,
+      player_id: playerId,
+      status: "SKIPPED",
+      metric_value: this.getDefaultTerminalMetricValue(this.settings.win_metric),
+      reason,
+      submitted_by: submittedBy,
+      submitted_at: submittedAt,
+    });
+  }
+
   private createTimeoutConfirmation(
     roundIndex: number,
     playerId: string,
@@ -739,30 +928,45 @@ export class RoomLobbyState {
   private applyRoundConfirmations(
     confirmations: RoundConfirmationEvent[],
     now: Date,
-    forceResult: boolean,
+    options: {
+      force_result?: boolean;
+      force_advance_applied?: ForceAdvanceAppliedEvent;
+    },
   ): RoundTransitionResult | null {
     if (this.currentRound === null) {
       return null;
     }
 
+    const clonedConfirmations = confirmations.map(cloneRoundConfirmation);
     this.currentRound.confirmed = [
       ...this.currentRound.confirmed,
-      ...confirmations.map(cloneRoundConfirmation),
+      ...clonedConfirmations,
     ];
 
     const currentRoundIndex = this.currentRound.round_index;
+    const existingRoundConfirmations = this.roundConfirmations.get(currentRoundIndex) ?? [];
+    this.roundConfirmations.set(currentRoundIndex, [...existingRoundConfirmations, ...clonedConfirmations]);
     const result: RoundTransitionResult = {
-      confirmations: confirmations.map(cloneRoundConfirmation),
+      confirmations: clonedConfirmations,
     };
+    if (options.force_advance_applied !== undefined) {
+      result.force_advance_applied = {
+        round_index: options.force_advance_applied.round_index,
+        timed_out_players: [...options.force_advance_applied.timed_out_players],
+      };
+    }
 
-    if (!forceResult && this.currentRound.confirmed.length < this.matchPlayerIds.length) {
+    if (!options.force_result && this.currentRound.confirmed.length < this.matchPlayerIds.length) {
       return result;
     }
 
     result.round_ended = { round_index: currentRoundIndex };
 
-    if (forceResult) {
+    if (options.force_result || this.shouldEnterResultAfterRound(currentRoundIndex)) {
       this.enterResult(now);
+      if (this.resultReadyPayload !== null) {
+        result.result_ready = this.resultReadyPayload;
+      }
       return result;
     }
 
@@ -773,6 +977,9 @@ export class RoomLobbyState {
     }
 
     this.enterResult(now);
+    if (this.resultReadyPayload !== null) {
+      result.result_ready = this.resultReadyPayload;
+    }
     return result;
   }
 
@@ -780,6 +987,7 @@ export class RoomLobbyState {
     this.roomState = "RESULT";
     this.currentRound = null;
     this.resultDeadline = computeResultDeadline(now);
+    this.resultReadyPayload = this.buildResultReadyPayload();
   }
 
   private getPlayersInJoinOrder(): InternalPlayer[] {
@@ -946,5 +1154,284 @@ export class RoomLobbyState {
       confirmed: [],
     };
     return this.currentRound;
+  }
+
+  private isHostSkipUnlocked(now: Date): boolean {
+    if (this.currentRound === null) {
+      return false;
+    }
+
+    const roundStartedAt = new Date(this.currentRound.round_started_at);
+    if (!Number.isFinite(roundStartedAt.getTime())) {
+      return false;
+    }
+
+    return now.getTime() >= roundStartedAt.getTime() + HOST_SKIP_UNLOCK_SECONDS * 1_000;
+  }
+
+  private shouldEnterResultAfterRound(roundIndex: number): boolean {
+    if (this.settings.mode !== "BPL") {
+      return false;
+    }
+
+    const roundWins = this.computeBplWins(roundIndex);
+    return Array.from(roundWins.values()).some((wins) => wins >= 2);
+  }
+
+  private computeBplWins(maxRoundIndex: number): Map<string, number> {
+    const wins = new Map<string, number>();
+    for (const playerId of this.matchPlayerIds) {
+      wins.set(playerId, 0);
+    }
+
+    for (let roundIndex = 0; roundIndex <= maxRoundIndex; roundIndex += 1) {
+      const winnerPlayerId = this.getBplRoundWinnerPlayerId(roundIndex);
+      if (winnerPlayerId === null) {
+        continue;
+      }
+
+      wins.set(winnerPlayerId, (wins.get(winnerPlayerId) ?? 0) + 1);
+    }
+
+    return wins;
+  }
+
+  private getBplRoundWinnerPlayerId(roundIndex: number): string | null {
+    const [firstPlayerId, secondPlayerId] = this.matchPlayerIds;
+    if (firstPlayerId === undefined || secondPlayerId === undefined) {
+      return null;
+    }
+
+    const roundConfirmations = this.roundConfirmations.get(roundIndex) ?? [];
+    const firstResult = roundConfirmations.find((entry) => entry.player_id === firstPlayerId);
+    const secondResult = roundConfirmations.find((entry) => entry.player_id === secondPlayerId);
+    if (firstResult === undefined || secondResult === undefined) {
+      return null;
+    }
+
+    const comparison = this.compareMetricValues(firstResult.metric_value, secondResult.metric_value);
+    if (comparison === 0) {
+      return null;
+    }
+
+    return comparison > 0 ? firstPlayerId : secondPlayerId;
+  }
+
+  private compareMetricValues(left: number, right: number): number {
+    if (left === right) {
+      return 0;
+    }
+
+    if (this.settings.win_metric === "SCORE") {
+      return left > right ? 1 : -1;
+    }
+
+    return left < right ? 1 : -1;
+  }
+
+  private getArenaPointsForRank(rank: number): number {
+    if (rank === 1) {
+      return 2;
+    }
+
+    if (rank === 2) {
+      return 1;
+    }
+
+    return 0;
+  }
+
+  private getPlayerDisplayName(playerId: string): string {
+    return this.players.get(playerId)?.display_name ?? playerId;
+  }
+
+  private buildResultReadyPayload(): ResultReadyPayload {
+    const perPlayerRounds = new Map<string, Array<Record<string, unknown>>>();
+    for (const playerId of this.matchPlayerIds) {
+      perPlayerRounds.set(playerId, []);
+    }
+
+    const completedRounds = this.frozenRounds.filter((round) => round.started_at !== null).length;
+
+    if (this.settings.mode === "ARENA") {
+      const totalPoints = new Map<string, number>();
+      for (const playerId of this.matchPlayerIds) {
+        totalPoints.set(playerId, 0);
+      }
+
+      const rounds = this.frozenRounds.map((round) => {
+        const roundConfirmations = this.roundConfirmations.get(round.round_index) ?? [];
+        const confirmationByPlayer = new Map(roundConfirmations.map((entry) => [entry.player_id, entry]));
+        const rankedPlayers = this.matchPlayerIds
+          .map((playerId) => {
+            const confirmation = confirmationByPlayer.get(playerId);
+            return {
+              player_id: playerId,
+              confirmation,
+            };
+          })
+          .filter(
+            (entry): entry is { player_id: string; confirmation: RoundConfirmationEvent } =>
+              entry.confirmation !== undefined,
+          )
+          .sort((left, right) => {
+            const comparison = this.compareMetricValues(
+              left.confirmation.metric_value,
+              right.confirmation.metric_value,
+            );
+            if (comparison !== 0) {
+              return comparison > 0 ? -1 : 1;
+            }
+
+            return left.player_id.localeCompare(right.player_id);
+          });
+
+        const rankByPlayerId = new Map<string, number>();
+        let previousMetricValue: number | null = null;
+        let previousRank = 0;
+        rankedPlayers.forEach((entry, index) => {
+          if (previousMetricValue !== null && entry.confirmation.metric_value === previousMetricValue) {
+            rankByPlayerId.set(entry.player_id, previousRank);
+            return;
+          }
+
+          const rank = index + 1;
+          previousMetricValue = entry.confirmation.metric_value;
+          previousRank = rank;
+          rankByPlayerId.set(entry.player_id, rank);
+        });
+
+        const results = this.matchPlayerIds.map((playerId) => {
+          const confirmation = confirmationByPlayer.get(playerId);
+          const rank = confirmation === undefined ? null : (rankByPlayerId.get(playerId) ?? null);
+          const arenaPoints = rank === null ? 0 : this.getArenaPointsForRank(rank);
+          totalPoints.set(playerId, (totalPoints.get(playerId) ?? 0) + arenaPoints);
+
+          const roundResult = {
+            round_index: round.round_index,
+            player_id: playerId,
+            display_name: this.getPlayerDisplayName(playerId),
+            status: confirmation?.status ?? null,
+            metric_value: confirmation?.metric_value ?? null,
+            reason: confirmation?.reason ?? null,
+            submitted_at: confirmation?.submitted_at ?? null,
+            submitted_by: confirmation?.submitted_by ?? null,
+            rank,
+            arena_points: arenaPoints,
+          };
+          perPlayerRounds.get(playerId)?.push(roundResult);
+          return roundResult;
+        });
+
+        const winnerPlayerIds = results
+          .filter((entry) => entry.rank === 1)
+          .map((entry) => entry.player_id);
+
+        return {
+          round_index: round.round_index,
+          expected_key: cloneExpectedKey(round.expected_key),
+          display: {
+            title: round.display.title,
+            level: round.display.level,
+          },
+          round_started_at: round.started_at,
+          played: round.started_at !== null,
+          winner_player_ids: winnerPlayerIds,
+          results,
+        };
+      });
+
+      const players = this.matchPlayerIds.map((playerId) => ({
+        player_id: playerId,
+        display_name: this.getPlayerDisplayName(playerId),
+        total_points: totalPoints.get(playerId) ?? 0,
+        rounds: perPlayerRounds.get(playerId) ?? [],
+      }));
+      const highestPoints = players.reduce((maxValue, player) => Math.max(maxValue, player.total_points), 0);
+      const winnerPlayerIds = players
+        .filter((player) => player.total_points === highestPoints)
+        .map((player) => player.player_id);
+
+      return {
+        summary: {
+          mode: this.settings.mode,
+          win_metric: this.settings.win_metric,
+          total_rounds: this.frozenRounds.length,
+          completed_rounds: completedRounds,
+          winner_player_ids: winnerPlayerIds,
+          is_draw: winnerPlayerIds.length !== 1,
+        },
+        per_round: {
+          rounds,
+        },
+        per_player: {
+          players,
+        },
+      };
+    }
+
+    const roundWins = this.computeBplWins(this.frozenRounds.length - 1);
+    const rounds = this.frozenRounds.map((round) => {
+      const roundConfirmations = this.roundConfirmations.get(round.round_index) ?? [];
+      const confirmationByPlayer = new Map(roundConfirmations.map((entry) => [entry.player_id, entry]));
+      const winnerPlayerId = this.getBplRoundWinnerPlayerId(round.round_index);
+      const results = this.matchPlayerIds.map((playerId) => {
+        const confirmation = confirmationByPlayer.get(playerId);
+        const roundResult = {
+          round_index: round.round_index,
+          player_id: playerId,
+          display_name: this.getPlayerDisplayName(playerId),
+          status: confirmation?.status ?? null,
+          metric_value: confirmation?.metric_value ?? null,
+          reason: confirmation?.reason ?? null,
+          submitted_at: confirmation?.submitted_at ?? null,
+          submitted_by: confirmation?.submitted_by ?? null,
+          round_win: winnerPlayerId === playerId,
+        };
+        perPlayerRounds.get(playerId)?.push(roundResult);
+        return roundResult;
+      });
+
+      return {
+        round_index: round.round_index,
+        expected_key: cloneExpectedKey(round.expected_key),
+        display: {
+          title: round.display.title,
+          level: round.display.level,
+        },
+        round_started_at: round.started_at,
+        played: round.started_at !== null,
+        winner_player_ids: winnerPlayerId === null ? [] : [winnerPlayerId],
+        results,
+      };
+    });
+
+    const players = this.matchPlayerIds.map((playerId) => ({
+      player_id: playerId,
+      display_name: this.getPlayerDisplayName(playerId),
+      round_wins: roundWins.get(playerId) ?? 0,
+      rounds: perPlayerRounds.get(playerId) ?? [],
+    }));
+    const highestWins = players.reduce((maxValue, player) => Math.max(maxValue, player.round_wins), 0);
+    const winnerPlayerIds = players
+      .filter((player) => player.round_wins === highestWins)
+      .map((player) => player.player_id);
+
+    return {
+      summary: {
+        mode: this.settings.mode,
+        win_metric: this.settings.win_metric,
+        total_rounds: this.frozenRounds.length,
+        completed_rounds: completedRounds,
+        winner_player_ids: winnerPlayerIds,
+        is_draw: winnerPlayerIds.length !== 1,
+      },
+      per_round: {
+        rounds,
+      },
+      per_player: {
+        players,
+      },
+    };
   }
 }

--- a/tasks/codex-pr-7-skip-force-result.md
+++ b/tasks/codex-pr-7-skip-force-result.md
@@ -1,0 +1,60 @@
+# Plan: codex/pr-7-skip-force-result
+
+## 作業宣言
+- worktree: `C:\work\infinitas_arena\infinitas_bpl_pr7`
+- branch: `codex/pr-7-skip-force-result`
+- base branch: `v1`
+- BASE_SHA: `76d9af1636e4c686f8e9cb7da0e89faad07c9f6f`
+
+## 目的
+- `docs/design/09_implementation_plan.md` の PR-7（SKIP / FORCE_ADVANCE / RESULT 集計）を実装する。
+- Durable Object 上で `SKIP_SELF`、`SKIP_HOST_ASSIGN`、`host_skip_unlock_seconds`、`FORCE_ADVANCE`、ARENA/BPL 集計、`RESULT_READY` を成立させる。
+
+## 非目的
+- クライアント UI / watcher 実装。
+- docs/design の規範仕様変更。
+- PR-8 以降の画面表示詳細やローカル保存強化。
+
+## 変更点
+- `room-state.ts` に自分 SKIP、4分経過後のホスト代理 SKIP、強制進行、ARENA/BPL 集計と RESULT payload 生成を追加する。
+- `room-object.ts` に `SKIP_SELF` / `SKIP_HOST_ASSIGN` / `FORCE_ADVANCE` ハンドラ、`FORCE_ADVANCE_APPLIED` / `RESULT_READY` 配信、alarm の RESULT close を追加する。
+- 必要であれば shared の snapshot / WS 型へ RESULT 表示用の最小構造を追加する。
+
+## 影響範囲
+- ユーザー:
+  - 自分の未確定ラウンドを `UNOWNED | TECH | OTHER` 理由付きで SKIP できる。
+  - ラウンド開始から 240 秒経過後、ホストが未確定プレイヤーへ代理 SKIP を付与できる。
+  - ホストの `FORCE_ADVANCE` で未確定者が `TIMEOUT` となり次ラウンドまたは RESULT へ進む。
+  - RESULT で ARENA/BPL の集計済み結果を受け取れる。
+- データ:
+  - DO メモリ上の round confirmed、submitted_by、result summary が更新される。
+- 互換性:
+  - 既存 FSM / WS schema の範囲で拡張し、破壊的変更は避ける。
+- Cloudflare resources:
+  - Durable Object の WS 制御と alarm 運用のみ変更。
+
+## 対象ファイル / 対象レイヤ
+- `apps/worker/src/durable/room-state.ts`
+- `apps/worker/src/durable/room-object.ts`
+- `packages/shared/src/models/*` または `packages/shared/src/ws/*`（必要時のみ）
+- `tasks/codex-pr-7-skip-force-result.md`
+
+## テスト観点
+- `SKIP_SELF` は PLAYING 中の当該ラウンド未確定本人のみ成功する。
+- `SKIP_HOST_ASSIGN` はホストのみ、4分経過後かつ target 未確定のときのみ成功する。
+- `FORCE_ADVANCE` はホストのみ成功し、未確定者を `TIMEOUT` にする。
+- ARENA は順位に応じて `2/1/0` 配点、同点同順位・順位飛ばしで集計される。
+- BPL は BO3 の各ラウンド勝者に 1 勝を付与し、先に 2 勝または終了時点の勝ち数で結果が決まる。
+- `RESULT_READY` が RESULT 遷移時に返り、`npm --workspace @infinitas/worker run typecheck` と `npm run typecheck` が通る。
+
+## ロールバック方針
+- PR-7 差分を revert し、PR-6 の PLAYING 基本進行に戻す。
+
+## Commit Plan（コミット分割計画）
+1. PR-7 plan 追加（本ファイル）。
+2. `room-state.ts` に skip / force advance / result aggregation を追加。
+3. `room-object.ts` と必要最小限の shared 型を更新。
+4. typecheck 実行と最終調整。
+
+## 検証結果
+- 未実施

--- a/tasks/codex-pr-7-skip-force-result.md
+++ b/tasks/codex-pr-7-skip-force-result.md
@@ -57,4 +57,7 @@
 4. typecheck 実行と最終調整。
 
 ## 検証結果
-- 未実施
+- `npm ci`
+- `npm --workspace @infinitas/worker run typecheck`
+- `npm run typecheck`
+- `npx wrangler deploy --dry-run`


### PR DESCRIPTION
## 目的
- `docs/design/09_implementation_plan.md` の PR-7 を実装し、Durable Object 上で SKIP / FORCE_ADVANCE / RESULT 集計を成立させる。

## 変更点
- `SKIP_SELF`、`SKIP_HOST_ASSIGN`、`FORCE_ADVANCE` の DO ハンドラと payload 検証を追加。
- `host_skip_unlock_seconds`（240秒）経過後のみホスト代理SKIPを許可するガードを追加。
- ラウンド履歴を保持し、ARENA 配点と BPL BO3 集計を `RESULT_READY` payload として返すように変更。
- BPL は 2 勝到達時点で早期に RESULT へ遷移するように変更。
- RESULT 再参加 / `STATE_GET` 時に `RESULT_READY` を再送し、`result_ttl` 超過時は `ROOM_CLOSED` へ遷移するように変更。
- Plan-mode 用 task を追加。

## 非変更点
- client UI / watcher 実装。
- docs/design の規範仕様変更。
- shared schema の大幅な再設計。

## 影響範囲
- ユーザー: 自分 SKIP、4分経過後のホスト代理SKIP、強制進行、ARENA/BPL 結果受信が可能になる。
- データ: DO メモリ上でラウンド確定履歴と result summary を保持する。
- 互換性: 既存 WS message type の範囲内で実装し、破壊的変更はなし。
- Cloudflare: Worker 入口は据え置きで、DO の FSM / alarm / 集計ロジックのみ変更。

## テスト内容
- `npm ci`
- `npm --workspace @infinitas/worker run typecheck`
- `npm run typecheck`
- `npx wrangler deploy --dry-run`

## 回帰確認項目
- `SKIP_SELF` は未確定の本人のみ成功する。
- `SKIP_HOST_ASSIGN` はホストのみ、かつラウンド開始 240 秒後にのみ成功する。
- `FORCE_ADVANCE` で未確定者が `TIMEOUT` になり次ラウンドまたは RESULT へ進む。
- ARENA は 2/1/0 配点、同点同順位で集計される。
- BPL はラウンド勝者を集計し、2 勝到達で早期終了できる。
- RESULT 到達後に `RESULT_READY` が再送可能で、`result_ttl` 超過で `ROOM_CLOSED` になる。

## ロールバック方針
- 本 PR を revert し、PR-6 の PLAYING 基本進行に戻す。

## 互換性影響
- なし。

## Cloudflare resources 影響
- Durable Object の alarm / WS broadcast のみ。
- KV schema や binding 変更なし。

## docs/design 更新有無
- なし。