### PR TITLE
PR-9: Rust watcher 基盤を追加

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -11,6 +11,7 @@
     "tauri:build": "tauri build"
   },
   "dependencies": {
+    "@tauri-apps/api": "^2.5.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/apps/client/src-tauri/Cargo.lock
+++ b/apps/client/src-tauri/Cargo.lock
@@ -671,6 +671,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +743,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1446,8 +1466,30 @@ dependencies = [
 name = "infinitas-bpl-client"
 version = "0.1.0"
 dependencies = [
+ "notify",
+ "serde",
  "tauri",
  "tauri-build",
+]
+
+[[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1561,6 +1603,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,7 +1686,10 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -1718,6 +1783,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
@@ -1789,6 +1866,25 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "num-conv"
@@ -2005,7 +2101,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2167,6 +2263,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -2424,6 +2526,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -2861,7 +2972,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -3366,7 +3477,7 @@ checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.1.1",
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
@@ -4175,6 +4286,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -4213,6 +4333,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4274,6 +4409,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4292,6 +4433,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4307,6 +4454,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4340,6 +4493,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4355,6 +4514,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4376,6 +4541,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4391,6 +4562,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/apps/client/src-tauri/Cargo.toml
+++ b/apps/client/src-tauri/Cargo.toml
@@ -9,6 +9,8 @@ name = "infinitas_bpl_client_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [dependencies]
+notify = "6.1.1"
+serde = { version = "1", features = ["derive"] }
 tauri = { version = "2" }
 
 [build-dependencies]

--- a/apps/client/src-tauri/src/commands/mod.rs
+++ b/apps/client/src-tauri/src/commands/mod.rs
@@ -1,0 +1,5 @@
+mod source_watcher;
+
+pub use source_watcher::{
+    get_source_watcher_state, start_source_watcher, stop_source_watcher,
+};

--- a/apps/client/src-tauri/src/commands/source_watcher.rs
+++ b/apps/client/src-tauri/src/commands/source_watcher.rs
@@ -1,0 +1,28 @@
+use tauri::State;
+
+use crate::models::{SourceWatcherStatePayload, StartSourceWatcherRequest};
+use crate::watchers::SourceWatcherManager;
+
+#[tauri::command]
+pub fn get_source_watcher_state(
+    manager: State<'_, SourceWatcherManager>,
+) -> SourceWatcherStatePayload {
+    manager.get_state()
+}
+
+#[tauri::command]
+pub fn start_source_watcher(
+    app: tauri::AppHandle,
+    manager: State<'_, SourceWatcherManager>,
+    request: StartSourceWatcherRequest,
+) -> Result<SourceWatcherStatePayload, String> {
+    manager.start(&app, request)
+}
+
+#[tauri::command]
+pub fn stop_source_watcher(
+    app: tauri::AppHandle,
+    manager: State<'_, SourceWatcherManager>,
+) -> Result<SourceWatcherStatePayload, String> {
+    Ok(manager.stop(&app, "Watcher stopped from client."))
+}

--- a/apps/client/src-tauri/src/lib.rs
+++ b/apps/client/src-tauri/src/lib.rs
@@ -1,6 +1,20 @@
+mod commands;
+mod models;
+mod parsers;
+mod watchers;
+
+use commands::{get_source_watcher_state, start_source_watcher, stop_source_watcher};
+use watchers::SourceWatcherManager;
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .manage(SourceWatcherManager::default())
+        .invoke_handler(tauri::generate_handler![
+            get_source_watcher_state,
+            start_source_watcher,
+            stop_source_watcher
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/apps/client/src-tauri/src/models/mod.rs
+++ b/apps/client/src-tauri/src/models/mod.rs
@@ -1,0 +1,7 @@
+mod source_watcher;
+
+pub use source_watcher::{
+    now_ms, ParsedSourceChange, SourcePathsConfig, SourceType, SourceWatcherEventKind,
+    SourceWatcherEventPayload, SourceWatcherStatePayload, SourceWatcherStatus,
+    StartSourceWatcherRequest, SOURCE_WATCHER_EVENT_NAME,
+};

--- a/apps/client/src-tauri/src/models/source_watcher.rs
+++ b/apps/client/src-tauri/src/models/source_watcher.rs
@@ -1,0 +1,104 @@
+use serde::{Deserialize, Serialize};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub const SOURCE_WATCHER_EVENT_NAME: &str = "source-watcher://event";
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SourceType {
+    #[serde(rename = "inf_daken_counter")]
+    InfDakenCounter,
+    #[serde(rename = "inf-notebook")]
+    InfNotebook,
+}
+
+impl SourceType {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::InfDakenCounter => "inf_daken_counter",
+            Self::InfNotebook => "inf-notebook",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SourcePathsConfig {
+    pub daken_today_update_xml: String,
+    pub notebook_export_recent_json: String,
+    pub notebook_records_recent_json: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartSourceWatcherRequest {
+    pub source: SourceType,
+    pub source_paths: SourcePathsConfig,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum SourceWatcherStatus {
+    #[default]
+    Idle,
+    Running,
+    Stopped,
+    Error,
+    Unavailable,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceWatcherStatePayload {
+    pub status: SourceWatcherStatus,
+    pub source: Option<SourceType>,
+    pub watched_paths: Vec<String>,
+    pub detail: String,
+    pub last_event_at_ms: Option<u64>,
+}
+
+impl Default for SourceWatcherStatePayload {
+    fn default() -> Self {
+        Self {
+            status: SourceWatcherStatus::Idle,
+            source: None,
+            watched_paths: Vec::new(),
+            detail: "Watcher not started.".to_string(),
+            last_event_at_ms: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ParsedSourceChange {
+    pub source: SourceType,
+    pub file_path: String,
+    pub file_size_bytes: u64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum SourceWatcherEventKind {
+    Started,
+    Stopped,
+    FileChanged,
+    Error,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceWatcherEventPayload {
+    pub kind: SourceWatcherEventKind,
+    pub state: SourceWatcherStatePayload,
+    pub file_path: Option<String>,
+    pub detail: String,
+    pub occurred_at_ms: u64,
+    pub parser_output: Option<ParsedSourceChange>,
+}
+
+pub fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().try_into().unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}

--- a/apps/client/src-tauri/src/parsers/mod.rs
+++ b/apps/client/src-tauri/src/parsers/mod.rs
@@ -1,0 +1,38 @@
+use std::{fs, path::PathBuf};
+
+use crate::models::{ParsedSourceChange, SourceType};
+
+pub struct ParserInput {
+    pub changed_path: PathBuf,
+}
+
+pub trait SourceParser: Send + Sync {
+    fn parse(&self, input: &ParserInput) -> Result<ParsedSourceChange, String>;
+}
+
+pub struct FileMetadataParser {
+    source: SourceType,
+}
+
+impl FileMetadataParser {
+    pub fn new(source: SourceType) -> Self {
+        Self { source }
+    }
+}
+
+impl SourceParser for FileMetadataParser {
+    fn parse(&self, input: &ParserInput) -> Result<ParsedSourceChange, String> {
+        let metadata = fs::metadata(&input.changed_path)
+            .map_err(|error| format!("Failed to read {:?}: {error}", input.changed_path))?;
+
+        Ok(ParsedSourceChange {
+            source: self.source.clone(),
+            file_path: input.changed_path.to_string_lossy().into_owned(),
+            file_size_bytes: metadata.len(),
+        })
+    }
+}
+
+pub fn create_parser(source: &SourceType) -> Box<dyn SourceParser> {
+    Box::new(FileMetadataParser::new(source.clone()))
+}

--- a/apps/client/src-tauri/src/watchers/mod.rs
+++ b/apps/client/src-tauri/src/watchers/mod.rs
@@ -1,0 +1,425 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{self, RecvTimeoutError, Sender};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use tauri::{AppHandle, Emitter};
+
+use crate::models::{
+    now_ms, SourcePathsConfig, SourceType, SourceWatcherEventKind, SourceWatcherEventPayload,
+    SourceWatcherStatePayload, SourceWatcherStatus, StartSourceWatcherRequest,
+    SOURCE_WATCHER_EVENT_NAME,
+};
+use crate::parsers::{create_parser, ParserInput};
+
+#[derive(Default)]
+pub struct SourceWatcherManager {
+    inner: Arc<Mutex<ManagerState>>,
+}
+
+struct ManagerState {
+    payload: SourceWatcherStatePayload,
+    active: Option<ActiveWatcher>,
+}
+
+impl Default for ManagerState {
+    fn default() -> Self {
+        Self {
+            payload: SourceWatcherStatePayload::default(),
+            active: None,
+        }
+    }
+}
+
+struct ActiveWatcher {
+    shutdown_tx: Sender<()>,
+    join_handle: JoinHandle<()>,
+}
+
+struct WatchSpec {
+    source: SourceType,
+    watched_paths: Vec<String>,
+    watched_keys: HashSet<String>,
+    parent_directories: Vec<PathBuf>,
+}
+
+impl SourceWatcherManager {
+    pub fn get_state(&self) -> SourceWatcherStatePayload {
+        self.inner
+            .lock()
+            .expect("source watcher state poisoned")
+            .payload
+            .clone()
+    }
+
+    pub fn start(
+        &self,
+        app: &AppHandle,
+        request: StartSourceWatcherRequest,
+    ) -> Result<SourceWatcherStatePayload, String> {
+        let spec = WatchSpec::from_request(&request)?;
+        let watched_paths = spec.watched_paths.clone();
+        let source = spec.source.clone();
+        let has_active_watcher = self
+            .inner
+            .lock()
+            .expect("source watcher state poisoned")
+            .active
+            .is_some();
+
+        if has_active_watcher {
+            self.stop(app, "Watcher restarted with updated source settings.");
+        }
+
+        let (shutdown_tx, shutdown_rx) = mpsc::channel::<()>();
+        let inner = Arc::clone(&self.inner);
+        let thread_inner = Arc::clone(&self.inner);
+        let app_handle = app.clone();
+
+        {
+            let mut guard = inner.lock().expect("source watcher state poisoned");
+            guard.payload = SourceWatcherStatePayload {
+                status: SourceWatcherStatus::Running,
+                source: Some(source),
+                watched_paths,
+                detail: "Watching source files.".to_string(),
+                last_event_at_ms: Some(now_ms()),
+            };
+        }
+
+        let join_handle = thread::spawn(move || {
+            run_watcher_loop(app_handle, thread_inner, spec, shutdown_rx);
+        });
+
+        let payload = {
+            let mut guard = inner.lock().expect("source watcher state poisoned");
+            let payload = guard.payload.clone();
+            guard.active = Some(ActiveWatcher {
+                shutdown_tx,
+                join_handle,
+            });
+            payload
+        };
+
+        emit_event(
+            app,
+            SourceWatcherEventPayload {
+                kind: SourceWatcherEventKind::Started,
+                state: payload.clone(),
+                file_path: None,
+                detail: payload.detail.clone(),
+                occurred_at_ms: now_ms(),
+                parser_output: None,
+            },
+        );
+
+        Ok(payload)
+    }
+
+    pub fn stop(&self, app: &AppHandle, detail: &str) -> SourceWatcherStatePayload {
+        let active = {
+            self.inner
+                .lock()
+                .expect("source watcher state poisoned")
+                .active
+                .take()
+        };
+
+        if let Some(active) = active {
+            let _ = active.shutdown_tx.send(());
+            let _ = active.join_handle.join();
+        }
+
+        let payload = {
+            let mut guard = self.inner.lock().expect("source watcher state poisoned");
+            let previous_source = guard.payload.source.clone();
+            let previous_paths = guard.payload.watched_paths.clone();
+            let status = if previous_source.is_some() {
+                SourceWatcherStatus::Stopped
+            } else {
+                SourceWatcherStatus::Idle
+            };
+
+            guard.payload = SourceWatcherStatePayload {
+                status,
+                source: previous_source,
+                watched_paths: previous_paths,
+                detail: detail.to_string(),
+                last_event_at_ms: Some(now_ms()),
+            };
+            guard.payload.clone()
+        };
+
+        emit_event(
+            app,
+            SourceWatcherEventPayload {
+                kind: SourceWatcherEventKind::Stopped,
+                state: payload.clone(),
+                file_path: None,
+                detail: payload.detail.clone(),
+                occurred_at_ms: now_ms(),
+                parser_output: None,
+            },
+        );
+
+        payload
+    }
+}
+
+impl WatchSpec {
+    fn from_request(request: &StartSourceWatcherRequest) -> Result<Self, String> {
+        let watched_files = resolve_watched_files(&request.source, &request.source_paths)?;
+        let mut watched_paths = Vec::with_capacity(watched_files.len());
+        let mut watched_keys = HashSet::with_capacity(watched_files.len());
+        let mut parent_directories = Vec::new();
+        let mut seen_directories = HashSet::new();
+
+        for watched_file in watched_files {
+            let key = path_key(&watched_file);
+            let display_path = watched_file.to_string_lossy().into_owned();
+            watched_paths.push(display_path);
+            watched_keys.insert(key);
+
+            let parent = watched_file.parent().ok_or_else(|| {
+                format!(
+                    "Cannot watch {} because the parent directory is missing.",
+                    watched_file.to_string_lossy()
+                )
+            })?;
+
+            if !parent.exists() || !parent.is_dir() {
+                return Err(format!(
+                    "Cannot watch {} because {} is not an existing directory.",
+                    watched_file.to_string_lossy(),
+                    parent.to_string_lossy()
+                ));
+            }
+
+            let parent_key = path_key(parent);
+            if seen_directories.insert(parent_key) {
+                parent_directories.push(parent.to_path_buf());
+            }
+        }
+
+        Ok(Self {
+            source: request.source.clone(),
+            watched_paths,
+            watched_keys,
+            parent_directories,
+        })
+    }
+}
+
+fn run_watcher_loop(
+    app: AppHandle,
+    inner: Arc<Mutex<ManagerState>>,
+    spec: WatchSpec,
+    shutdown_rx: mpsc::Receiver<()>,
+) {
+    let parser = create_parser(&spec.source);
+    let (event_tx, event_rx) = mpsc::channel::<Result<Event, notify::Error>>();
+    let watcher_result = create_recommended_watcher(&spec, event_tx);
+
+    let mut watcher = match watcher_result {
+        Ok(watcher) => watcher,
+        Err(error) => {
+            publish_error(&app, &inner, &error, None);
+            return;
+        }
+    };
+
+    for directory in &spec.parent_directories {
+        if let Err(error) = watcher.watch(directory, RecursiveMode::NonRecursive) {
+            publish_error(
+                &app,
+                &inner,
+                &format!(
+                    "Failed to watch {}: {error}",
+                    directory.to_string_lossy()
+                ),
+                None,
+            );
+            return;
+        }
+    }
+
+    loop {
+        if shutdown_rx.try_recv().is_ok() {
+            break;
+        }
+
+        match event_rx.recv_timeout(Duration::from_millis(250)) {
+            Ok(Ok(event)) => handle_notify_event(&app, &inner, &spec, parser.as_ref(), event),
+            Ok(Err(error)) => publish_error(&app, &inner, &error.to_string(), None),
+            Err(RecvTimeoutError::Timeout) => continue,
+            Err(RecvTimeoutError::Disconnected) => {
+                publish_error(&app, &inner, "Watcher event channel disconnected.", None);
+                break;
+            }
+        }
+    }
+}
+
+fn create_recommended_watcher(
+    spec: &WatchSpec,
+    event_tx: Sender<Result<Event, notify::Error>>,
+) -> Result<RecommendedWatcher, String> {
+    let source_label = spec.source.label().to_string();
+
+    RecommendedWatcher::new(
+        move |event| {
+            let _ = event_tx.send(event);
+        },
+        Config::default(),
+    )
+    .map_err(|error| format!("Failed to create {source_label} watcher: {error}"))
+}
+
+fn handle_notify_event(
+    app: &AppHandle,
+    inner: &Arc<Mutex<ManagerState>>,
+    spec: &WatchSpec,
+    parser: &dyn crate::parsers::SourceParser,
+    event: Event,
+) {
+    if !matches!(event.kind, EventKind::Modify(_) | EventKind::Create(_)) {
+        return;
+    }
+
+    for changed_path in event
+        .paths
+        .into_iter()
+        .filter(|path| spec.watched_keys.contains(&path_key(path)))
+    {
+        let parser_input = ParserInput {
+            changed_path: changed_path.clone(),
+        };
+
+        match parser.parse(&parser_input) {
+            Ok(parsed_change) => {
+                let occurred_at_ms = now_ms();
+                let detail = format!(
+                    "Detected file change: {}",
+                    parsed_change.file_path
+                );
+                let state = update_state(
+                    inner,
+                    SourceWatcherStatus::Running,
+                    detail.clone(),
+                    Some(occurred_at_ms),
+                );
+
+                emit_event(
+                    app,
+                    SourceWatcherEventPayload {
+                        kind: SourceWatcherEventKind::FileChanged,
+                        state,
+                        file_path: Some(changed_path.to_string_lossy().into_owned()),
+                        detail,
+                        occurred_at_ms,
+                        parser_output: Some(parsed_change),
+                    },
+                );
+            }
+            Err(error) => {
+                publish_error(
+                    app,
+                    inner,
+                    &error,
+                    Some(changed_path.to_string_lossy().into_owned()),
+                );
+            }
+        }
+    }
+}
+
+fn publish_error(
+    app: &AppHandle,
+    inner: &Arc<Mutex<ManagerState>>,
+    detail: &str,
+    file_path: Option<String>,
+) {
+    let occurred_at_ms = now_ms();
+    let state = update_state(
+        inner,
+        SourceWatcherStatus::Error,
+        detail.to_string(),
+        Some(occurred_at_ms),
+    );
+
+    emit_event(
+        app,
+        SourceWatcherEventPayload {
+            kind: SourceWatcherEventKind::Error,
+            state,
+            file_path,
+            detail: detail.to_string(),
+            occurred_at_ms,
+            parser_output: None,
+        },
+    );
+}
+
+fn update_state(
+    inner: &Arc<Mutex<ManagerState>>,
+    status: SourceWatcherStatus,
+    detail: String,
+    last_event_at_ms: Option<u64>,
+) -> SourceWatcherStatePayload {
+    let mut guard = inner.lock().expect("source watcher state poisoned");
+    guard.payload.status = status;
+    guard.payload.detail = detail;
+    guard.payload.last_event_at_ms = last_event_at_ms;
+    guard.payload.clone()
+}
+
+fn emit_event(app: &AppHandle, payload: SourceWatcherEventPayload) {
+    let _ = app.emit(SOURCE_WATCHER_EVENT_NAME, payload);
+}
+
+fn resolve_watched_files(
+    source: &SourceType,
+    source_paths: &SourcePathsConfig,
+) -> Result<Vec<PathBuf>, String> {
+    match source {
+        SourceType::InfDakenCounter => Ok(vec![require_path(
+            &source_paths.daken_today_update_xml,
+            "inf_daken_counter / today_update.xml",
+        )?]),
+        SourceType::InfNotebook => {
+            let mut paths = vec![require_path(
+                &source_paths.notebook_export_recent_json,
+                "inf-notebook / export/recent.json",
+            )?];
+
+            let optional_path = source_paths.notebook_records_recent_json.trim();
+            if !optional_path.is_empty() {
+                paths.push(PathBuf::from(optional_path));
+            }
+
+            Ok(paths)
+        }
+    }
+}
+
+fn require_path(raw_path: &str, label: &str) -> Result<PathBuf, String> {
+    let trimmed = raw_path.trim();
+    if trimmed.is_empty() {
+        return Err(format!("Set {label} before starting the watcher."));
+    }
+
+    Ok(PathBuf::from(trimmed))
+}
+
+fn path_key(path: &Path) -> String {
+    let normalized = path
+        .canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .replace('/', "\\");
+
+    normalized.to_lowercase()
+}

--- a/apps/client/src/app/App.tsx
+++ b/apps/client/src/app/App.tsx
@@ -4,6 +4,7 @@ import { LobbyPage } from "../pages/LobbyPage";
 import { RoomPage } from "../pages/RoomPage";
 import { SettingsPage } from "../pages/SettingsPage";
 import { roomStore, useRoomStore } from "../stores/room-store";
+import { sourceStore } from "../stores/source-store";
 import { useSettingsStore } from "../stores/settings-store";
 
 type AppView = "lobby" | "settings" | "room";
@@ -43,11 +44,23 @@ export function App() {
     }
   }, [activeView, roomConnectionStatus, roomSnapshot]);
 
+  useEffect(() => {
+    void sourceStore.attach();
+
+    return () => {
+      sourceStore.detach();
+    };
+  }, []);
+
+  useEffect(() => {
+    void sourceStore.start(savedSettings, { force: false });
+  }, [savedSettings]);
+
   return (
     <main className="app-shell">
       <header className="app-header">
         <div>
-          <p className="eyebrow">PR-8</p>
+          <p className="eyebrow">PR-9</p>
           <h1>INFINITAS BPL Client</h1>
         </div>
         <div className="header-status">

--- a/apps/client/src/pages/SettingsPage.tsx
+++ b/apps/client/src/pages/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import { SOURCE_TYPES } from "@infinitas/shared";
+import { sourceStore, useSourceStore } from "../stores/source-store";
 import { settingsStore, useSettingsStore } from "../stores/settings-store";
 import { formatDateTime } from "../utils/format";
 
@@ -23,6 +24,8 @@ export function SettingsPage({ roomJoined }: SettingsPageProps) {
   const draft = useSettingsStore((state) => state.draft);
   const statusMessage = useSettingsStore((state) => state.statusMessage);
   const lastSavedAt = useSettingsStore((state) => state.lastSavedAt);
+  const watcherState = useSourceStore((state) => state.watcherState);
+  const lastWatcherEvent = useSourceStore((state) => state.lastEvent);
 
   return (
     <section className="page-grid">
@@ -147,16 +150,88 @@ export function SettingsPage({ roomJoined }: SettingsPageProps) {
         <div className="panel-footer">
           <div className="status-stack">
             <span className="status-label">Watcher state</span>
-            <strong>PR-9 pending</strong>
-            <span className="status-muted">Watcher / parser integration is not wired yet.</span>
+            <div className="inline-field">
+              <strong>{watcherState.status}</strong>
+              <span className={`status-pill ${getWatcherTone(watcherState.status)}`}>
+                {watcherState.status}
+              </span>
+            </div>
+            <span className="status-muted">{watcherState.detail}</span>
           </div>
           <div className="button-row">
+            <button
+              type="button"
+              className="secondary-button"
+              onClick={() => {
+                void sourceStore.start(draft, { force: true });
+              }}
+            >
+              Restart watcher
+            </button>
+            <button
+              type="button"
+              className="secondary-button"
+              onClick={() => {
+                void sourceStore.stop();
+              }}
+            >
+              Stop watcher
+            </button>
             <button type="button" className="secondary-button" onClick={() => settingsStore.resetDraft()}>
               Reset draft
             </button>
-            <button type="button" className="primary-button" onClick={() => settingsStore.save()}>
+            <button
+              type="button"
+              className="primary-button"
+              onClick={() => {
+                settingsStore.save();
+                void sourceStore.start(settingsStore.getState().saved, { force: true });
+              }}
+            >
               Save settings
             </button>
+          </div>
+        </div>
+
+        <div className="panel-subsection watcher-block">
+          <div className="meta-grid compact">
+            <div className="status-stack">
+              <span className="status-label">Active source</span>
+              <strong>{watcherState.source ?? "-"}</strong>
+              <span className="status-muted">Saved source and path selection.</span>
+            </div>
+            <div className="status-stack">
+              <span className="status-label">Last watcher update</span>
+              <strong>{formatDateTime(watcherState.lastEventAt)}</strong>
+              <span className="status-muted">State transition or file event.</span>
+            </div>
+            <div className="status-stack">
+              <span className="status-label">Last event kind</span>
+              <strong>{lastWatcherEvent?.kind ?? "-"}</strong>
+              <span className="status-muted">{lastWatcherEvent?.detail ?? "No file events yet."}</span>
+            </div>
+            <div className="status-stack">
+              <span className="status-label">Last file</span>
+              <strong>{lastWatcherEvent?.filePath ?? "-"}</strong>
+              <span className="status-muted">
+                {lastWatcherEvent?.parserOutput
+                  ? `${lastWatcherEvent.parserOutput.fileSizeBytes.toLocaleString()} bytes`
+                  : "Parser payload not available."}
+              </span>
+            </div>
+          </div>
+
+          <div className="status-stack watcher-path-list">
+            <span className="status-label">Watched paths</span>
+            {watcherState.watchedPaths.length === 0 ? (
+              <span className="status-muted">No active watch targets.</span>
+            ) : (
+              watcherState.watchedPaths.map((path) => (
+                <code key={path} className="path-chip">
+                  {path}
+                </code>
+              ))
+            )}
           </div>
         </div>
 
@@ -167,4 +242,16 @@ export function SettingsPage({ roomJoined }: SettingsPageProps) {
       </article>
     </section>
   );
+}
+
+function getWatcherTone(status: string): string {
+  if (status === "RUNNING") {
+    return "ok";
+  }
+
+  if (status === "ERROR" || status === "UNAVAILABLE") {
+    return "danger";
+  }
+
+  return "warning";
 }

--- a/apps/client/src/services/tauri-bridge.ts
+++ b/apps/client/src/services/tauri-bridge.ts
@@ -1,0 +1,97 @@
+import type { SourceType } from "@infinitas/shared";
+import type { SourcePaths } from "../stores/settings-store";
+
+const SOURCE_WATCHER_EVENT_NAME = "source-watcher://event";
+
+export type SourceWatcherStatus = "IDLE" | "RUNNING" | "STOPPED" | "ERROR" | "UNAVAILABLE";
+export type SourceWatcherEventKind = "STARTED" | "STOPPED" | "FILE_CHANGED" | "ERROR";
+
+export interface SourceWatcherStatePayload {
+  status: SourceWatcherStatus;
+  source: SourceType | null;
+  watchedPaths: string[];
+  detail: string;
+  lastEventAtMs: number | null;
+}
+
+export interface ParsedSourceChangePayload {
+  source: SourceType;
+  filePath: string;
+  fileSizeBytes: number;
+}
+
+export interface SourceWatcherEventPayload {
+  kind: SourceWatcherEventKind;
+  state: SourceWatcherStatePayload;
+  filePath: string | null;
+  detail: string;
+  occurredAtMs: number;
+  parserOutput: ParsedSourceChangePayload | null;
+}
+
+interface StartSourceWatcherRequest {
+  source: SourceType;
+  sourcePaths: SourcePaths;
+}
+
+declare global {
+  interface Window {
+    __TAURI_INTERNALS__?: unknown;
+  }
+}
+
+export function isTauriRuntime(): boolean {
+  return typeof window !== "undefined" && typeof window.__TAURI_INTERNALS__ !== "undefined";
+}
+
+export async function getSourceWatcherState(): Promise<SourceWatcherStatePayload> {
+  if (!isTauriRuntime()) {
+    return createUnavailableState();
+  }
+
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<SourceWatcherStatePayload>("get_source_watcher_state");
+}
+
+export async function startSourceWatcher(
+  request: StartSourceWatcherRequest,
+): Promise<SourceWatcherStatePayload> {
+  if (!isTauriRuntime()) {
+    return createUnavailableState();
+  }
+
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<SourceWatcherStatePayload>("start_source_watcher", { request });
+}
+
+export async function stopSourceWatcher(): Promise<SourceWatcherStatePayload> {
+  if (!isTauriRuntime()) {
+    return createUnavailableState();
+  }
+
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<SourceWatcherStatePayload>("stop_source_watcher");
+}
+
+export async function listenToSourceWatcherEvents(
+  handler: (payload: SourceWatcherEventPayload) => void,
+): Promise<() => void> {
+  if (!isTauriRuntime()) {
+    return () => {};
+  }
+
+  const { listen } = await import("@tauri-apps/api/event");
+  return listen<SourceWatcherEventPayload>(SOURCE_WATCHER_EVENT_NAME, (event) => {
+    handler(event.payload);
+  });
+}
+
+function createUnavailableState(): SourceWatcherStatePayload {
+  return {
+    status: "UNAVAILABLE",
+    source: null,
+    watchedPaths: [],
+    detail: "Source watcher is available only inside the Tauri desktop app.",
+    lastEventAtMs: null,
+  };
+}

--- a/apps/client/src/stores/source-store.ts
+++ b/apps/client/src/stores/source-store.ts
@@ -1,0 +1,273 @@
+import type { SourceType } from "@infinitas/shared";
+import {
+  getSourceWatcherState,
+  isTauriRuntime,
+  listenToSourceWatcherEvents,
+  startSourceWatcher,
+  stopSourceWatcher,
+  type ParsedSourceChangePayload,
+  type SourceWatcherEventKind,
+  type SourceWatcherEventPayload,
+  type SourceWatcherStatePayload,
+  type SourceWatcherStatus,
+} from "../services/tauri-bridge";
+import { createExternalStore, useExternalStore } from "./create-store";
+import type { ClientSettings, SourcePaths } from "./settings-store";
+
+export interface SourceWatcherState {
+  status: SourceWatcherStatus;
+  source: SourceType | null;
+  watchedPaths: string[];
+  detail: string;
+  lastEventAt: string | null;
+}
+
+export interface SourceWatcherEventLogEntry {
+  kind: SourceWatcherEventKind;
+  filePath: string | null;
+  detail: string;
+  occurredAt: string;
+  parserOutput: ParsedSourceChangePayload | null;
+}
+
+export interface SourceStoreState {
+  watcherState: SourceWatcherState;
+  lastEvent: SourceWatcherEventLogEntry | null;
+  runtimeReady: boolean;
+}
+
+interface StartOptions {
+  force?: boolean;
+}
+
+let attachedListener: (() => void) | null = null;
+let attachPromise: Promise<void> | null = null;
+let appliedConfigKey: string | null = null;
+
+const initialState: SourceStoreState = {
+  watcherState: {
+    status: "IDLE",
+    source: null,
+    watchedPaths: [],
+    detail: "Watcher not attached.",
+    lastEventAt: null,
+  },
+  lastEvent: null,
+  runtimeReady: false,
+};
+
+const internalStore = createExternalStore<SourceStoreState>(initialState);
+
+function createConfigKey(settings: Pick<ClientSettings, "source" | "sourcePaths">): string {
+  return JSON.stringify({
+    source: settings.source,
+    sourcePaths: settings.sourcePaths,
+  });
+}
+
+function toIsoString(value: number | null): string | null {
+  if (value === null) {
+    return null;
+  }
+
+  return new Date(value).toISOString();
+}
+
+function mapWatcherState(payload: SourceWatcherStatePayload): SourceWatcherState {
+  return {
+    status: payload.status,
+    source: payload.source,
+    watchedPaths: payload.watchedPaths,
+    detail: payload.detail,
+    lastEventAt: toIsoString(payload.lastEventAtMs),
+  };
+}
+
+function mapWatcherEvent(payload: SourceWatcherEventPayload): SourceWatcherEventLogEntry {
+  return {
+    kind: payload.kind,
+    filePath: payload.filePath,
+    detail: payload.detail,
+    occurredAt: new Date(payload.occurredAtMs).toISOString(),
+    parserOutput: payload.parserOutput,
+  };
+}
+
+function getMissingPathMessage(source: SourceType, paths: SourcePaths): string | null {
+  if (source === "inf_daken_counter" && paths.dakenTodayUpdateXml.trim().length === 0) {
+    return "Set inf_daken_counter / today_update.xml before starting the watcher.";
+  }
+
+  if (source === "inf-notebook" && paths.notebookExportRecentJson.trim().length === 0) {
+    return "Set inf-notebook / export/recent.json before starting the watcher.";
+  }
+
+  return null;
+}
+
+async function ensureAttached(): Promise<void> {
+  if (attachedListener !== null) {
+    return;
+  }
+
+  if (attachPromise !== null) {
+    await attachPromise;
+    return;
+  }
+
+  attachPromise = (async () => {
+    if (!isTauriRuntime()) {
+      internalStore.setState((state) => ({
+        ...state,
+        runtimeReady: false,
+        watcherState: {
+          status: "UNAVAILABLE",
+          source: null,
+          watchedPaths: [],
+          detail: "Source watcher is available only inside the Tauri desktop app.",
+          lastEventAt: null,
+        },
+      }));
+      return;
+    }
+
+    attachedListener = await listenToSourceWatcherEvents((payload) => {
+      internalStore.setState((state) => ({
+        ...state,
+        runtimeReady: true,
+        watcherState: mapWatcherState(payload.state),
+        lastEvent: mapWatcherEvent(payload),
+      }));
+    });
+
+    const statePayload = await getSourceWatcherState();
+    internalStore.setState((state) => ({
+      ...state,
+      runtimeReady: true,
+      watcherState: mapWatcherState(statePayload),
+    }));
+  })().finally(() => {
+    attachPromise = null;
+  });
+
+  await attachPromise;
+}
+
+export const sourceStore = {
+  ...internalStore,
+  async attach(): Promise<void> {
+    await ensureAttached();
+  },
+  detach(): void {
+    attachedListener?.();
+    attachedListener = null;
+    attachPromise = null;
+    internalStore.setState((state) => ({
+      ...state,
+      runtimeReady: false,
+    }));
+  },
+  async start(
+    settings: Pick<ClientSettings, "source" | "sourcePaths">,
+    options: StartOptions = {},
+  ): Promise<void> {
+    await ensureAttached();
+
+    if (!isTauriRuntime()) {
+      return;
+    }
+
+    const missingPathMessage = getMissingPathMessage(settings.source, settings.sourcePaths);
+    if (missingPathMessage) {
+      appliedConfigKey = null;
+      const currentWatcherState = internalStore.getState().watcherState;
+      if (currentWatcherState.source !== null && currentWatcherState.status !== "IDLE") {
+        try {
+          const stoppedPayload = await stopSourceWatcher();
+          internalStore.setState((state) => ({
+            ...state,
+            watcherState: mapWatcherState(stoppedPayload),
+          }));
+        } catch {
+          // Keep the UI actionable even if the previous watcher has already exited.
+        }
+      }
+
+      internalStore.setState((state) => ({
+        ...state,
+        watcherState: {
+          ...state.watcherState,
+          status: "IDLE",
+          source: settings.source,
+          watchedPaths: [],
+          detail: missingPathMessage,
+          lastEventAt: null,
+        },
+      }));
+      return;
+    }
+
+    const nextConfigKey = createConfigKey(settings);
+    const currentState = internalStore.getState().watcherState;
+    if (!options.force && appliedConfigKey === nextConfigKey && currentState.status === "RUNNING") {
+      return;
+    }
+
+    try {
+      const payload = await startSourceWatcher({
+        source: settings.source,
+        sourcePaths: settings.sourcePaths,
+      });
+
+      appliedConfigKey = nextConfigKey;
+      internalStore.setState((state) => ({
+        ...state,
+        watcherState: mapWatcherState(payload),
+      }));
+    } catch (error) {
+      internalStore.setState((state) => ({
+        ...state,
+        watcherState: {
+          ...state.watcherState,
+          status: "ERROR",
+          source: settings.source,
+          detail: error instanceof Error ? error.message : "Failed to start watcher.",
+          watchedPaths: [],
+          lastEventAt: new Date().toISOString(),
+        },
+      }));
+    }
+  },
+  async stop(): Promise<void> {
+    await ensureAttached();
+
+    if (!isTauriRuntime()) {
+      return;
+    }
+
+    try {
+      const payload = await stopSourceWatcher();
+      appliedConfigKey = null;
+      internalStore.setState((state) => ({
+        ...state,
+        watcherState: mapWatcherState(payload),
+      }));
+    } catch (error) {
+      internalStore.setState((state) => ({
+        ...state,
+        watcherState: {
+          ...state.watcherState,
+          status: "ERROR",
+          detail: error instanceof Error ? error.message : "Failed to stop watcher.",
+          lastEventAt: new Date().toISOString(),
+        },
+      }));
+    }
+  },
+};
+
+export function useSourceStore<TSelected>(
+  selector: (state: SourceStoreState) => TSelected,
+): TSelected {
+  return useExternalStore(internalStore, selector);
+}

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -355,6 +355,26 @@ button {
   margin-top: 1rem;
 }
 
+.watcher-block {
+  display: grid;
+  gap: 1rem;
+}
+
+.watcher-path-list {
+  gap: 0.5rem;
+}
+
+.path-chip {
+  display: inline-flex;
+  max-width: 100%;
+  border-radius: 999px;
+  padding: 0.45rem 0.8rem;
+  background: rgba(22, 32, 50, 0.08);
+  font-family: Consolas, "Courier New", monospace;
+  font-size: 0.84rem;
+  overflow-wrap: anywhere;
+}
+
 .empty-state {
   color: rgba(22, 32, 50, 0.66);
   padding: 0.5rem 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "name": "@infinitas/client",
       "version": "0.1.0",
       "dependencies": {
+        "@tauri-apps/api": "^2.5.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -1904,6 +1905,16 @@
       "integrity": "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/@tauri-apps/api": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
+      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
+      "license": "Apache-2.0 OR MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/tauri"
+      }
     },
     "node_modules/@tauri-apps/cli": {
       "version": "2.10.1",

--- a/tasks/codex-pr-9-rust-watcher-base.md
+++ b/tasks/codex-pr-9-rust-watcher-base.md
@@ -63,8 +63,8 @@
 4. build/typecheck/cargo check を通し、最終調整を行う。
 
 ## 検証結果
-- [ ] `npm install`
-- [ ] `npm --workspace @infinitas/client run typecheck`
-- [ ] `npm --workspace @infinitas/client run build`
-- [ ] `npm run typecheck`
-- [ ] `cargo check`
+- [x] `npm install`
+- [x] `npm --workspace @infinitas/client run typecheck`
+- [x] `npm --workspace @infinitas/client run build`
+- [x] `npm run typecheck`
+- [x] `cargo check`

--- a/tasks/codex-pr-9-rust-watcher-base.md
+++ b/tasks/codex-pr-9-rust-watcher-base.md
@@ -1,0 +1,70 @@
+# Plan: codex/pr-9-rust-watcher-base
+
+## 作業宣言
+- worktree: `C:\work\infinitas_arena\infinitas_bpl_pr9`
+- branch: `codex/pr-9-rust-watcher-base`
+- base branch: `v1`
+- BASE_SHA: `bb1b7ee2a427d9ff4a30730b6e06359d39205e1a`
+
+## 目的
+- `docs/design/09_implementation_plan.md` の PR-9（Rust watcher 基盤）を実装する。
+- Tauri Rust 側で source ごとの file watcher 起動/停止、source path 設定、parser interface、Rust -> React の event bridge を成立させる。
+
+## 非目的
+- `inf-notebook` / `inf_daken_counter` の実データ parser 実装（PR-10/11）。
+- Worker / DO / shared の契約変更。
+- 音声通知、ローカル結果保存、RESULT_SUBMIT 自動送信。
+
+## 変更点
+- `apps/client/src-tauri` に watcher / parser / model / command モジュールを追加し、Tauri command で watcher start/stop/state 取得を提供する。
+- `notify` ベースで source ごとの監視対象パスを解決し、ファイル変更時に React へイベントを emit する。
+- React 側に Tauri bridge と `sourceStore` を追加し、watcher 状態と直近イベントを表示する。
+- Settings 画面から watcher の再起動/停止と source path 適用ができるようにする。
+
+## 影響範囲
+- ユーザー:
+  - 保存済み source 設定を元に watcher を起動できる。
+  - 変更イベントや監視異常が Settings 画面で確認できる。
+- データ:
+  - ローカル設定値は既存 localStorage を継続利用し、watcher 状態はメモリ上でのみ保持する。
+- 互換性:
+  - Worker / shared の既存 schema は変更しない。
+- Cloudflare:
+  - 影響なし。
+
+## 対象ファイル / 対象レイヤ
+- `apps/client/src-tauri/src/**`
+- `apps/client/src/services/**`
+- `apps/client/src/stores/**`
+- `apps/client/src/pages/SettingsPage.tsx`
+- `apps/client/src/app/App.tsx`
+- `apps/client/package.json`
+- `apps/client/src-tauri/Cargo.toml`
+- `apps/client/src-tauri/Cargo.lock`
+- `package-lock.json`
+- `tasks/codex-pr-9-rust-watcher-base.md`
+
+## テスト観点
+- `inf_daken_counter` と `inf-notebook` それぞれで required path を渡して watcher を起動できる。
+- 監視対象ファイル変更時に Rust 側 event が React 側 store へ反映される。
+- パス不備や read 失敗時に error event と detail が出る。
+- `npm --workspace @infinitas/client run typecheck`
+- `npm --workspace @infinitas/client run build`
+- `npm run typecheck`
+- `cargo check`
+
+## ロールバック方針
+- PR-9 差分を revert し、PR-8 の client UI のみの状態へ戻す。
+
+## Commit Plan（コミット分割計画）
+1. PR-9 plan 追加（本ファイル）。
+2. `apps/client/src-tauri` に watcher / parser / command 基盤と依存追加を実装。
+3. React 側の Tauri bridge / `sourceStore` / Settings UI を実装。
+4. build/typecheck/cargo check を通し、最終調整を行う。
+
+## 検証結果
+- [ ] `npm install`
+- [ ] `npm --workspace @infinitas/client run typecheck`
+- [ ] `npm --workspace @infinitas/client run build`
+- [ ] `npm run typecheck`
+- [ ] `cargo check`


### PR DESCRIPTION
## 目的
- docs/design/09_implementation_plan.md の PR-9 に沿って、Tauri Rust 側の watcher start/stop、source path 設定、parser interface、Rust -> React の event bridge を実装する。

## 変更点
- pps/client/src-tauri に commands / models / parsers / watchers を追加し、
otify ベースの source watcher 基盤を実装。
- start_source_watcher / stop_source_watcher / get_source_watcher_state を追加し、source ごとの監視対象 path とイベント配信を Tauri command 化。
- React 側に 	auri-bridge と sourceStore を追加し、watcher 状態と直近イベントを購読できるようにした。
- SettingsPage に watcher の状態表示、restart/stop 操作、監視 path と最終イベント表示を追加。
- @tauri-apps/api と Rust 側依存を追加し、client build / cargo check が通る状態に更新。

## 非変更点
- inf-notebook / inf_daken_counter の実データ parser 実装と RESULT_SUBMIT 自動送信は含めない。
- Worker / Durable Object / shared schema は変更しない。
- 音声通知、ローカル結果保存、ROOM_STATE_LOST 強化は含めない。

## 影響範囲
- ユーザー: source watcher の起動状態、監視 path、直近イベントを Settings 画面で確認できる。
- データ: 既存 localStorage 設定をそのまま使い、watcher 状態は client メモリ上のみ保持する。
- 互換性: Worker / shared の既存契約変更なし。
- Cloudflare: 影響なし。
- docs/design 更新有無: 規範仕様変更なし。実装計画に対応する 	asks/codex-pr-9-rust-watcher-base.md を追加。

## テスト内容
- 
pm install
- 
pm --workspace @infinitas/client run typecheck
- 
pm --workspace @infinitas/client run build
- 
pm run typecheck
- cargo check

## 回帰確認項目
- saved source 設定から watcher が起動できること。
- required path 未設定時に旧 watcher が残らず、UI に detail が出ること。
- 監視対象ファイル変更時に Rust event が React store へ反映されること。
- 非 Tauri 実行時でも client build が通り、watcher UI が UNAVAILABLE として退避すること。

## ロールバック方針
- 本 PR を revert して PR-8 の client UI 状態へ戻す。

## 互換性影響の有無
- なし。

## Cloudflare resources 影響
- なし。