### PR TITLE
PR-10: inf-notebook 自動提出を実装

### DIFF
--- a/apps/client/src-tauri/Cargo.lock
+++ b/apps/client/src-tauri/Cargo.lock
@@ -1468,8 +1468,10 @@ version = "0.1.0"
 dependencies = [
  "notify",
  "serde",
+ "serde_json",
  "tauri",
  "tauri-build",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -3470,6 +3472,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3751,6 +3768,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/apps/client/src-tauri/Cargo.toml
+++ b/apps/client/src-tauri/Cargo.toml
@@ -11,7 +11,9 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 [dependencies]
 notify = "6.1.1"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tauri = { version = "2" }
+unicode-normalization = "0.1"
 
 [build-dependencies]
 tauri-build = { version = "2" }

--- a/apps/client/src-tauri/Cargo.toml
+++ b/apps/client/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 
 [lib]
 name = "infinitas_bpl_client_lib"
-crate-type = ["staticlib", "cdylib", "rlib"]
+crate-type = ["rlib"]
 
 [dependencies]
 notify = "6.1.1"

--- a/apps/client/src-tauri/src/models/mod.rs
+++ b/apps/client/src-tauri/src/models/mod.rs
@@ -1,7 +1,7 @@
 mod source_watcher;
 
 pub use source_watcher::{
-    now_ms, ParsedSourceChange, SourcePathsConfig, SourceType, SourceWatcherEventKind,
-    SourceWatcherEventPayload, SourceWatcherStatePayload, SourceWatcherStatus,
-    StartSourceWatcherRequest, SOURCE_WATCHER_EVENT_NAME,
+    now_ms, ParsedSourceChange, ParsedSourceObservation, SourcePathsConfig, SourceType,
+    SourceWatcherEventKind, SourceWatcherEventPayload, SourceWatcherStatePayload,
+    SourceWatcherStatus, StartSourceWatcherRequest, SOURCE_WATCHER_EVENT_NAME,
 };

--- a/apps/client/src-tauri/src/models/source_watcher.rs
+++ b/apps/client/src-tauri/src/models/source_watcher.rs
@@ -70,10 +70,22 @@ impl Default for SourceWatcherStatePayload {
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ParsedSourceObservation {
+    pub timestamp: String,
+    pub difficulty: String,
+    pub title: String,
+    pub title_search_key: String,
+    pub score: u32,
+    pub misscount: u32,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ParsedSourceChange {
     pub source: SourceType,
     pub file_path: String,
     pub file_size_bytes: u64,
+    pub observations: Vec<ParsedSourceObservation>,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/apps/client/src-tauri/src/parsers/mod.rs
+++ b/apps/client/src-tauri/src/parsers/mod.rs
@@ -1,13 +1,15 @@
+mod notebook;
+
 use std::{fs, path::PathBuf};
 
-use crate::models::{ParsedSourceChange, SourceType};
+use crate::models::{ParsedSourceChange, ParsedSourceObservation, SourcePathsConfig, SourceType};
 
 pub struct ParserInput {
     pub changed_path: PathBuf,
 }
 
 pub trait SourceParser: Send + Sync {
-    fn parse(&self, input: &ParserInput) -> Result<ParsedSourceChange, String>;
+    fn parse(&mut self, input: &ParserInput) -> Result<Option<ParsedSourceChange>, String>;
 }
 
 pub struct FileMetadataParser {
@@ -21,18 +23,25 @@ impl FileMetadataParser {
 }
 
 impl SourceParser for FileMetadataParser {
-    fn parse(&self, input: &ParserInput) -> Result<ParsedSourceChange, String> {
+    fn parse(&mut self, input: &ParserInput) -> Result<Option<ParsedSourceChange>, String> {
         let metadata = fs::metadata(&input.changed_path)
             .map_err(|error| format!("Failed to read {:?}: {error}", input.changed_path))?;
 
-        Ok(ParsedSourceChange {
+        Ok(Some(ParsedSourceChange {
             source: self.source.clone(),
             file_path: input.changed_path.to_string_lossy().into_owned(),
             file_size_bytes: metadata.len(),
-        })
+            observations: Vec::<ParsedSourceObservation>::new(),
+        }))
     }
 }
 
-pub fn create_parser(source: &SourceType) -> Box<dyn SourceParser> {
-    Box::new(FileMetadataParser::new(source.clone()))
+pub fn create_parser(
+    source: &SourceType,
+    source_paths: &SourcePathsConfig,
+) -> Box<dyn SourceParser> {
+    match source {
+        SourceType::InfNotebook => Box::new(notebook::NotebookParser::new(source_paths)),
+        SourceType::InfDakenCounter => Box::new(FileMetadataParser::new(source.clone())),
+    }
 }

--- a/apps/client/src-tauri/src/parsers/notebook.rs
+++ b/apps/client/src-tauri/src/parsers/notebook.rs
@@ -1,0 +1,379 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serde::Deserialize;
+use unicode_normalization::UnicodeNormalization;
+
+use crate::{
+    models::{ParsedSourceChange, ParsedSourceObservation, SourcePathsConfig, SourceType},
+    parsers::{ParserInput, SourceParser},
+};
+
+#[derive(Clone, Debug, Deserialize)]
+struct NotebookExportRecentFile {
+    list: Vec<NotebookRecentEntry>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct NotebookRecentEntry {
+    timestamp: String,
+    difficulty: String,
+    music: String,
+    score: i64,
+    misscount: i64,
+}
+
+pub struct NotebookParser {
+    export_recent_path: PathBuf,
+    export_recent_path_key: String,
+    last_seen_timestamp: Option<String>,
+}
+
+impl NotebookParser {
+    pub fn new(source_paths: &SourcePathsConfig) -> Self {
+        let export_recent_path = PathBuf::from(source_paths.notebook_export_recent_json.trim());
+        let last_seen_timestamp = read_latest_timestamp(&export_recent_path).ok().flatten();
+
+        Self {
+            export_recent_path_key: path_key(&export_recent_path),
+            export_recent_path,
+            last_seen_timestamp,
+        }
+    }
+}
+
+impl SourceParser for NotebookParser {
+    fn parse(&mut self, input: &ParserInput) -> Result<Option<ParsedSourceChange>, String> {
+        let metadata = fs::metadata(&input.changed_path)
+            .map_err(|error| format!("Failed to read {:?}: {error}", input.changed_path))?;
+        let changed_path_key = path_key(&input.changed_path);
+
+        if changed_path_key != self.export_recent_path_key {
+            return Ok(Some(ParsedSourceChange {
+                source: SourceType::InfNotebook,
+                file_path: input.changed_path.to_string_lossy().into_owned(),
+                file_size_bytes: metadata.len(),
+                observations: Vec::new(),
+            }));
+        }
+
+        let export_recent = read_export_recent(&self.export_recent_path)?;
+        let latest_timestamp = export_recent
+            .list
+            .iter()
+            .map(|entry| entry.timestamp.as_str())
+            .max()
+            .map(str::to_string);
+        let previous_last_seen = self.last_seen_timestamp.as_deref();
+
+        let observations = export_recent
+            .list
+            .iter()
+            .rev()
+            .filter(|entry| is_newer_timestamp(entry.timestamp.as_str(), previous_last_seen))
+            .map(parse_observation)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        self.last_seen_timestamp = latest_timestamp;
+
+        Ok(Some(ParsedSourceChange {
+            source: SourceType::InfNotebook,
+            file_path: self.export_recent_path.to_string_lossy().into_owned(),
+            file_size_bytes: metadata.len(),
+            observations,
+        }))
+    }
+}
+
+fn read_latest_timestamp(path: &Path) -> Result<Option<String>, String> {
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let export_recent = read_export_recent(path)?;
+    Ok(export_recent
+        .list
+        .iter()
+        .map(|entry| entry.timestamp.as_str())
+        .max()
+        .map(str::to_string))
+}
+
+fn read_export_recent(path: &Path) -> Result<NotebookExportRecentFile, String> {
+    let raw_json = fs::read_to_string(path)
+        .map_err(|error| format!("Failed to read {}: {error}", path.to_string_lossy()))?;
+    serde_json::from_str::<NotebookExportRecentFile>(&raw_json).map_err(|error| {
+        format!(
+            "Failed to parse {} as inf-notebook recent.json: {error}",
+            path.to_string_lossy()
+        )
+    })
+}
+
+fn parse_observation(entry: &NotebookRecentEntry) -> Result<ParsedSourceObservation, String> {
+    let timestamp = parse_timestamp(entry.timestamp.as_str())?;
+    let difficulty = normalize_difficulty(entry.difficulty.as_str())?;
+    let title = normalize_title(entry.music.as_str())?;
+    let score = parse_metric_value(entry.score, "score", &timestamp)?;
+    let misscount = parse_metric_value(entry.misscount, "misscount", &timestamp)?;
+
+    Ok(ParsedSourceObservation {
+        timestamp,
+        difficulty,
+        title_search_key: title.clone(),
+        title,
+        score,
+        misscount,
+    })
+}
+
+fn parse_timestamp(raw_timestamp: &str) -> Result<String, String> {
+    let trimmed = raw_timestamp.trim();
+    let is_valid = trimmed.len() == 15
+        && trimmed.chars().enumerate().all(|(index, ch)| match index {
+            8 => ch == '-',
+            _ => ch.is_ascii_digit(),
+        });
+
+    if !is_valid {
+        return Err(format!(
+            "inf-notebook entry has an invalid timestamp: {raw_timestamp}"
+        ));
+    }
+
+    Ok(trimmed.to_string())
+}
+
+fn normalize_difficulty(raw_difficulty: &str) -> Result<String, String> {
+    let normalized = raw_difficulty
+        .trim()
+        .nfkc()
+        .collect::<String>()
+        .to_uppercase();
+    if normalized.is_empty() {
+        return Err("inf-notebook entry is missing difficulty.".to_string());
+    }
+
+    Ok(normalized)
+}
+
+fn normalize_title(raw_title: &str) -> Result<String, String> {
+    let normalized = raw_title
+        .trim()
+        .nfkc()
+        .collect::<String>()
+        .replace('\u{3000}', " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .replace(" (", "(")
+        .to_lowercase();
+
+    if normalized.is_empty() {
+        return Err("inf-notebook entry is missing music title.".to_string());
+    }
+
+    Ok(normalized)
+}
+
+fn parse_metric_value(value: i64, field_name: &str, timestamp: &str) -> Result<u32, String> {
+    u32::try_from(value).map_err(|_| {
+        format!("inf-notebook entry at {timestamp} has an invalid {field_name}: {value}")
+    })
+}
+
+fn is_newer_timestamp(timestamp: &str, last_seen_timestamp: Option<&str>) -> bool {
+    match last_seen_timestamp {
+        Some(last_seen_timestamp) => timestamp > last_seen_timestamp,
+        None => true,
+    }
+}
+
+fn path_key(path: &Path) -> String {
+    path.canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .replace('/', "\\")
+        .to_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        env, fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use crate::{
+        models::SourcePathsConfig,
+        parsers::{notebook::NotebookParser, ParserInput, SourceParser},
+    };
+
+    #[test]
+    fn notebook_parser_emits_only_newer_entries_in_newest_first_order() {
+        let temp_dir = create_temp_dir("notebook-parser");
+        let export_recent_path = temp_dir.join("recent.json");
+        write_file(
+            &export_recent_path,
+            r#"{
+  "version": "0.19.0.0",
+  "count": 1,
+  "list": [
+    {
+      "timestamp": "20250729-201348",
+      "difficulty": "ANOTHER",
+      "music": "Old Song",
+      "score": 2000,
+      "misscount": 30
+    }
+  ]
+}"#,
+        );
+
+        let mut parser = NotebookParser::new(&SourcePathsConfig {
+            notebook_export_recent_json: export_recent_path.to_string_lossy().into_owned(),
+            ..SourcePathsConfig::default()
+        });
+
+        write_file(
+            &export_recent_path,
+            r#"{
+  "version": "0.19.0.0",
+  "count": 3,
+  "list": [
+    {
+      "timestamp": "20250729-201348",
+      "difficulty": "ANOTHER",
+      "music": "Old Song",
+      "score": 2000,
+      "misscount": 30
+    },
+    {
+      "timestamp": "20250729-202500",
+      "difficulty": "hyper",
+      "music": "Mismatch Song",
+      "score": 2500,
+      "misscount": 40
+    },
+    {
+      "timestamp": "20250729-203000",
+      "difficulty": "ANOTHER",
+      "music": "Summer Vacation (CU mix)",
+      "score": 2878,
+      "misscount": 13
+    }
+  ]
+}"#,
+        );
+
+        let parsed_change = parser
+            .parse(&ParserInput {
+                changed_path: export_recent_path.clone(),
+            })
+            .expect("parse should succeed")
+            .expect("parser should emit a change");
+
+        assert_eq!(parsed_change.observations.len(), 2);
+        assert_eq!(parsed_change.observations[0].timestamp, "20250729-203000");
+        assert_eq!(parsed_change.observations[0].difficulty, "ANOTHER");
+        assert_eq!(
+            parsed_change.observations[0].title_search_key,
+            "summer vacation(cu mix)"
+        );
+        assert_eq!(parsed_change.observations[0].score, 2878);
+        assert_eq!(parsed_change.observations[0].misscount, 13);
+        assert_eq!(parsed_change.observations[1].timestamp, "20250729-202500");
+
+        let repeated_change = parser
+            .parse(&ParserInput {
+                changed_path: export_recent_path.clone(),
+            })
+            .expect("second parse should succeed")
+            .expect("second parse should still emit a metadata change");
+
+        assert!(repeated_change.observations.is_empty());
+
+        let _ = fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn notebook_parser_ignores_records_recent_changes_for_submission_payloads() {
+        let temp_dir = create_temp_dir("notebook-records");
+        let export_recent_path = temp_dir.join("export-recent.json");
+        let records_recent_path = temp_dir.join("records-recent.json");
+
+        write_file(
+            &export_recent_path,
+            r#"{
+  "version": "0.19.0.0",
+  "count": 1,
+  "list": [
+    {
+      "timestamp": "20250729-201348",
+      "difficulty": "ANOTHER",
+      "music": "Thunderbolt",
+      "score": 2878,
+      "misscount": 13
+    }
+  ]
+}"#,
+        );
+        write_file(&records_recent_path, r#"{"list":[]}"#);
+
+        let mut parser = NotebookParser::new(&SourcePathsConfig {
+            notebook_export_recent_json: export_recent_path.to_string_lossy().into_owned(),
+            notebook_records_recent_json: records_recent_path.to_string_lossy().into_owned(),
+            ..SourcePathsConfig::default()
+        });
+
+        let parsed_change = parser
+            .parse(&ParserInput {
+                changed_path: records_recent_path.clone(),
+            })
+            .expect("parse should succeed")
+            .expect("parser should emit a metadata change");
+
+        assert!(parsed_change.observations.is_empty());
+
+        let _ = fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn notebook_parser_reports_invalid_json() {
+        let temp_dir = create_temp_dir("notebook-invalid");
+        let export_recent_path = temp_dir.join("recent.json");
+        write_file(&export_recent_path, "{invalid json");
+
+        let mut parser = NotebookParser::new(&SourcePathsConfig {
+            notebook_export_recent_json: export_recent_path.to_string_lossy().into_owned(),
+            ..SourcePathsConfig::default()
+        });
+
+        let error = parser
+            .parse(&ParserInput {
+                changed_path: export_recent_path.clone(),
+            })
+            .expect_err("invalid json should fail");
+
+        assert!(error.contains("Failed to parse"));
+
+        let _ = fs::remove_dir_all(temp_dir);
+    }
+
+    fn create_temp_dir(prefix: &str) -> PathBuf {
+        let unique_suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before epoch")
+            .as_nanos();
+        let temp_dir = env::temp_dir().join(format!("infinitas-bpl-{prefix}-{unique_suffix}"));
+        fs::create_dir_all(&temp_dir).expect("temp dir should be created");
+        temp_dir
+    }
+
+    fn write_file(path: &PathBuf, contents: &str) {
+        fs::write(path, contents).expect("fixture file should be written");
+    }
+}

--- a/apps/client/src-tauri/src/watchers/mod.rs
+++ b/apps/client/src-tauri/src/watchers/mod.rs
@@ -41,6 +41,7 @@ struct ActiveWatcher {
 
 struct WatchSpec {
     source: SourceType,
+    source_paths: SourcePathsConfig,
     watched_paths: Vec<String>,
     watched_keys: HashSet<String>,
     parent_directories: Vec<PathBuf>,
@@ -206,6 +207,7 @@ impl WatchSpec {
 
         Ok(Self {
             source: request.source.clone(),
+            source_paths: request.source_paths.clone(),
             watched_paths,
             watched_keys,
             parent_directories,
@@ -219,7 +221,7 @@ fn run_watcher_loop(
     spec: WatchSpec,
     shutdown_rx: mpsc::Receiver<()>,
 ) {
-    let parser = create_parser(&spec.source);
+    let mut parser = create_parser(&spec.source, &spec.source_paths);
     let (event_tx, event_rx) = mpsc::channel::<Result<Event, notify::Error>>();
     let watcher_result = create_recommended_watcher(&spec, event_tx);
 
@@ -236,10 +238,7 @@ fn run_watcher_loop(
             publish_error(
                 &app,
                 &inner,
-                &format!(
-                    "Failed to watch {}: {error}",
-                    directory.to_string_lossy()
-                ),
+                &format!("Failed to watch {}: {error}", directory.to_string_lossy()),
                 None,
             );
             return;
@@ -252,7 +251,7 @@ fn run_watcher_loop(
         }
 
         match event_rx.recv_timeout(Duration::from_millis(250)) {
-            Ok(Ok(event)) => handle_notify_event(&app, &inner, &spec, parser.as_ref(), event),
+            Ok(Ok(event)) => handle_notify_event(&app, &inner, &spec, parser.as_mut(), event),
             Ok(Err(error)) => publish_error(&app, &inner, &error.to_string(), None),
             Err(RecvTimeoutError::Timeout) => continue,
             Err(RecvTimeoutError::Disconnected) => {
@@ -282,7 +281,7 @@ fn handle_notify_event(
     app: &AppHandle,
     inner: &Arc<Mutex<ManagerState>>,
     spec: &WatchSpec,
-    parser: &dyn crate::parsers::SourceParser,
+    parser: &mut dyn crate::parsers::SourceParser,
     event: Event,
 ) {
     if !matches!(event.kind, EventKind::Modify(_) | EventKind::Create(_)) {
@@ -299,12 +298,9 @@ fn handle_notify_event(
         };
 
         match parser.parse(&parser_input) {
-            Ok(parsed_change) => {
+            Ok(Some(parsed_change)) => {
                 let occurred_at_ms = now_ms();
-                let detail = format!(
-                    "Detected file change: {}",
-                    parsed_change.file_path
-                );
+                let detail = format!("Detected file change: {}", parsed_change.file_path);
                 let state = update_state(
                     inner,
                     SourceWatcherStatus::Running,
@@ -324,8 +320,9 @@ fn handle_notify_event(
                     },
                 );
             }
+            Ok(None) => {}
             Err(error) => {
-                publish_error(
+                publish_unavailable(
                     app,
                     inner,
                     &error,
@@ -342,13 +339,33 @@ fn publish_error(
     detail: &str,
     file_path: Option<String>,
 ) {
-    let occurred_at_ms = now_ms();
-    let state = update_state(
+    publish_with_status(app, inner, SourceWatcherStatus::Error, detail, file_path);
+}
+
+fn publish_unavailable(
+    app: &AppHandle,
+    inner: &Arc<Mutex<ManagerState>>,
+    detail: &str,
+    file_path: Option<String>,
+) {
+    publish_with_status(
+        app,
         inner,
-        SourceWatcherStatus::Error,
-        detail.to_string(),
-        Some(occurred_at_ms),
+        SourceWatcherStatus::Unavailable,
+        detail,
+        file_path,
     );
+}
+
+fn publish_with_status(
+    app: &AppHandle,
+    inner: &Arc<Mutex<ManagerState>>,
+    status: SourceWatcherStatus,
+    detail: &str,
+    file_path: Option<String>,
+) {
+    let occurred_at_ms = now_ms();
+    let state = update_state(inner, status, detail.to_string(), Some(occurred_at_ms));
 
     emit_event(
         app,

--- a/apps/client/src/pages/SettingsPage.tsx
+++ b/apps/client/src/pages/SettingsPage.tsx
@@ -215,7 +215,7 @@ export function SettingsPage({ roomJoined }: SettingsPageProps) {
               <strong>{lastWatcherEvent?.filePath ?? "-"}</strong>
               <span className="status-muted">
                 {lastWatcherEvent?.parserOutput
-                  ? `${lastWatcherEvent.parserOutput.fileSizeBytes.toLocaleString()} bytes`
+                  ? `${lastWatcherEvent.parserOutput.fileSizeBytes.toLocaleString()} bytes / ${lastWatcherEvent.parserOutput.observations.length} observation(s)`
                   : "Parser payload not available."}
               </span>
             </div>

--- a/apps/client/src/services/tauri-bridge.ts
+++ b/apps/client/src/services/tauri-bridge.ts
@@ -14,10 +14,20 @@ export interface SourceWatcherStatePayload {
   lastEventAtMs: number | null;
 }
 
+export interface ParsedSourceObservationPayload {
+  timestamp: string;
+  difficulty: string;
+  title: string;
+  titleSearchKey: string;
+  score: number;
+  misscount: number;
+}
+
 export interface ParsedSourceChangePayload {
   source: SourceType;
   filePath: string;
   fileSizeBytes: number;
+  observations: ParsedSourceObservationPayload[];
 }
 
 export interface SourceWatcherEventPayload {

--- a/apps/client/src/stores/room-store.ts
+++ b/apps/client/src/stores/room-store.ts
@@ -102,6 +102,14 @@ function setErrorDialog(title: string, description: string, code?: string, block
   }));
 }
 
+function buildSourceUnavailableDescription(detail: string, roomState: RoomStateSnapshot["room_state"]): string {
+  if (roomState === "PLAYING") {
+    return `${detail} Use TECH skip if this round cannot be auto-submitted.`;
+  }
+
+  return detail;
+}
+
 function closeCurrentClient(sendLeaveMessage: boolean): void {
   const client = activeClient;
   activeClient = null;
@@ -376,6 +384,35 @@ export const roomStore = {
       ...state,
       errorDialog: null,
     }));
+  },
+  noteLocalEvent(message: string): void {
+    if (internalStore.getState().snapshot === null) {
+      return;
+    }
+
+    appendEventLog(message);
+  },
+  reportSourceUnavailable(detail: string): void {
+    const state = internalStore.getState();
+    if (state.snapshot === null || state.snapshot.room_state === "CLOSED") {
+      return;
+    }
+
+    const description = buildSourceUnavailableDescription(detail, state.snapshot.room_state);
+    if (
+      state.errorDialog?.code === "SOURCE_UNAVAILABLE" &&
+      state.errorDialog.description === description
+    ) {
+      return;
+    }
+
+    appendEventLog(`Source unavailable: ${detail}`);
+    setErrorDialog(
+      "Source unavailable",
+      description,
+      "SOURCE_UNAVAILABLE",
+      state.snapshot.room_state === "PLAYING",
+    );
   },
   send<TType extends ClientMessageType>(
     type: TType,

--- a/apps/client/src/stores/source-store.ts
+++ b/apps/client/src/stores/source-store.ts
@@ -1,8 +1,9 @@
-import type { SourceType } from "@infinitas/shared";
+import type { ExpectedKey, SourceType } from "@infinitas/shared";
 import {
   getSourceWatcherState,
   isTauriRuntime,
   listenToSourceWatcherEvents,
+  type ParsedSourceObservationPayload,
   startSourceWatcher,
   stopSourceWatcher,
   type ParsedSourceChangePayload,
@@ -11,8 +12,9 @@ import {
   type SourceWatcherStatePayload,
   type SourceWatcherStatus,
 } from "../services/tauri-bridge";
+import { roomStore } from "./room-store";
 import { createExternalStore, useExternalStore } from "./create-store";
-import type { ClientSettings, SourcePaths } from "./settings-store";
+import { settingsStore, type ClientSettings, type SourcePaths } from "./settings-store";
 
 export interface SourceWatcherState {
   status: SourceWatcherStatus;
@@ -93,6 +95,107 @@ function mapWatcherEvent(payload: SourceWatcherEventPayload): SourceWatcherEvent
   };
 }
 
+function observationMatchesExpected(
+  observation: ParsedSourceObservationPayload,
+  expectedKey: ExpectedKey,
+): boolean {
+  return (
+    observation.difficulty === expectedKey.difficulty &&
+    observation.titleSearchKey === expectedKey.title_search_key
+  );
+}
+
+function handleWatcherError(payload: SourceWatcherEventPayload): void {
+  if (payload.kind !== "ERROR") {
+    return;
+  }
+
+  roomStore.reportSourceUnavailable(payload.detail);
+}
+
+function tryAutoSubmitParsedChange(parsedChange: ParsedSourceChangePayload): void {
+  if (parsedChange.observations.length === 0) {
+    return;
+  }
+
+  const roomState = roomStore.getState();
+  const snapshot = roomState.snapshot;
+  const currentRound = snapshot?.current_round ?? null;
+  if (
+    roomState.connectionStatus !== "CONNECTED" ||
+    snapshot === null ||
+    snapshot.room_state !== "PLAYING" ||
+    currentRound === null
+  ) {
+    return;
+  }
+
+  const savedSettings = settingsStore.getState().saved;
+  if (currentRound.confirmed.some((entry) => entry.player_id === savedSettings.playerId)) {
+    return;
+  }
+
+  const matchedObservation = parsedChange.observations.find((observation) =>
+    observationMatchesExpected(observation, currentRound.expected_key),
+  );
+  if (!matchedObservation) {
+    return;
+  }
+
+  const metricValue =
+    snapshot.settings.win_metric === "SCORE"
+      ? matchedObservation.score
+      : matchedObservation.misscount;
+  if (!Number.isInteger(metricValue) || metricValue < 0) {
+    return;
+  }
+
+  const sent = roomStore.send("RESULT_SUBMIT", {
+    round_index: currentRound.round_index,
+    observed_key: {
+      play_style: currentRound.expected_key.play_style,
+      difficulty: matchedObservation.difficulty,
+      title_search_key: matchedObservation.titleSearchKey,
+    },
+    metric_value: metricValue,
+    source_meta: {
+      source: parsedChange.source,
+      timestamp: matchedObservation.timestamp,
+      difficulty: matchedObservation.difficulty,
+      title: matchedObservation.title,
+      title_search_key: matchedObservation.titleSearchKey,
+      score: matchedObservation.score,
+      misscount: matchedObservation.misscount,
+      file_path: parsedChange.filePath,
+    },
+  });
+
+  if (!sent) {
+    return;
+  }
+
+  roomStore.noteLocalEvent(
+    `Auto-submitted ${snapshot.settings.win_metric} from ${parsedChange.source} (${matchedObservation.timestamp}).`,
+  );
+}
+
+function handleWatcherEvent(payload: SourceWatcherEventPayload): void {
+  internalStore.setState((state) => ({
+    ...state,
+    runtimeReady: true,
+    watcherState: mapWatcherState(payload.state),
+    lastEvent: mapWatcherEvent(payload),
+  }));
+
+  handleWatcherError(payload);
+
+  if (payload.kind !== "FILE_CHANGED" || payload.parserOutput === null) {
+    return;
+  }
+
+  tryAutoSubmitParsedChange(payload.parserOutput);
+}
+
 function getMissingPathMessage(source: SourceType, paths: SourcePaths): string | null {
   if (source === "inf_daken_counter" && paths.dakenTodayUpdateXml.trim().length === 0) {
     return "Set inf_daken_counter / today_update.xml before starting the watcher.";
@@ -131,14 +234,7 @@ async function ensureAttached(): Promise<void> {
       return;
     }
 
-    attachedListener = await listenToSourceWatcherEvents((payload) => {
-      internalStore.setState((state) => ({
-        ...state,
-        runtimeReady: true,
-        watcherState: mapWatcherState(payload.state),
-        lastEvent: mapWatcherEvent(payload),
-      }));
-    });
+    attachedListener = await listenToSourceWatcherEvents(handleWatcherEvent);
 
     const statePayload = await getSourceWatcherState();
     internalStore.setState((state) => ({
@@ -204,6 +300,7 @@ export const sourceStore = {
           lastEventAt: null,
         },
       }));
+      roomStore.reportSourceUnavailable(missingPathMessage);
       return;
     }
 
@@ -225,17 +322,20 @@ export const sourceStore = {
         watcherState: mapWatcherState(payload),
       }));
     } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Failed to start watcher.";
       internalStore.setState((state) => ({
         ...state,
         watcherState: {
           ...state.watcherState,
           status: "ERROR",
           source: settings.source,
-          detail: error instanceof Error ? error.message : "Failed to start watcher.",
+          detail: errorMessage,
           watchedPaths: [],
           lastEventAt: new Date().toISOString(),
         },
       }));
+      roomStore.reportSourceUnavailable(errorMessage);
     }
   },
   async stop(): Promise<void> {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable-x86_64-pc-windows-msvc"

--- a/tasks/codex-pr-10-inf-notebook.md
+++ b/tasks/codex-pr-10-inf-notebook.md
@@ -19,6 +19,7 @@
 - Rust 側に `inf-notebook` の `export/recent.json` parser を追加する。
 - last_seen timestamp と observed_key 生成を実装し、SCORE / MISSCOUNT を抽出する。
 - React 側で watcher event を解釈し、`RESULT_SUBMIT` 自動送信と `SOURCE_UNAVAILABLE` 反映を追加する。
+- desktop-only 前提で Rust crate を `rlib` のみにし、repo 既定 toolchain を MSVC に寄せる。
 
 ## 影響範囲
 - ユーザー:
@@ -62,6 +63,6 @@
 - [x] `npm --workspace @infinitas/client run typecheck`
 - [x] `npm --workspace @infinitas/client run build`
 - [x] `npm run typecheck`
-- [ ] `cargo test -p infinitas-client-tauri notebook` (`x86_64-w64-mingw32-clang` link 時に exported symbols 上限へ到達)
+- [x] `cargo test notebook`
 - [x] `cargo check`
 - [x] `cargo check --tests`

--- a/tasks/codex-pr-10-inf-notebook.md
+++ b/tasks/codex-pr-10-inf-notebook.md
@@ -1,0 +1,66 @@
+# Plan: codex/pr-10-inf-notebook
+
+## 作業宣言
+- worktree: `C:\work\infinitas_arena\infinitas_bpl_pr10`
+- branch: `codex/pr-10-inf-notebook`
+- base branch: `v1`
+- BASE_SHA: `ccc00cba0d902967ce6b31f57aaedd66d83f6f6d`
+
+## 目的
+- `docs/design/09_implementation_plan.md` の PR-10（`inf-notebook` 対応）を実装する。
+- `inf-notebook` の `export/recent.json` から自動提出できる状態を作る。
+
+## 非目的
+- `inf_daken_counter` 対応（PR-11）。
+- Worker / DO / shared の契約変更。
+- watcher 基盤自体の全面再設計。
+
+## 変更点
+- Rust 側に `inf-notebook` の `export/recent.json` parser を追加する。
+- last_seen timestamp と observed_key 生成を実装し、SCORE / MISSCOUNT を抽出する。
+- React 側で watcher event を解釈し、`RESULT_SUBMIT` 自動送信と `SOURCE_UNAVAILABLE` 反映を追加する。
+
+## 影響範囲
+- ユーザー:
+  - `inf-notebook` 利用時にプレー結果の自動提出が行われる。
+  - parse 失敗時は `SOURCE_UNAVAILABLE` として扱われる。
+- データ:
+  - watcher の直近観測情報をメモリ上で扱う。既存保存形式は変更しない。
+- 互換性:
+  - 既存 WS schema と room snapshot schema は維持する。
+- Cloudflare:
+  - 影響なし。
+
+## 対象ファイル / 対象レイヤ
+- `apps/client/src-tauri/src/**`
+- `apps/client/src/services/**`
+- `apps/client/src/stores/**`
+- `apps/client/src/pages/**`（必要最小限）
+- `tasks/codex-pr-10-inf-notebook.md`
+
+## テスト観点
+- `export/recent.json` を正しく parse して SCORE / MISSCOUNT / observed_key を得られる。
+- 同一 timestamp の再通知が重複送信されない。
+- expected 不一致時は client 側で送信されない。
+- parse 失敗時に `SOURCE_UNAVAILABLE` が state に反映される。
+- `npm --workspace @infinitas/client run typecheck`
+- `npm --workspace @infinitas/client run build`
+- `npm run typecheck`
+- `cargo test -p infinitas-client-tauri notebook`
+- `cargo check`
+
+## ロールバック方針
+- PR-10 差分を revert し、PR-9 の watcher 基盤だけの状態へ戻す。
+
+## Commit Plan（コミット分割計画）
+1. PR-10 plan 追加（本ファイル）。
+2. Rust 側に `inf-notebook` parser / テスト / watcher event 拡張を実装。
+3. React 側に自動提出と `SOURCE_UNAVAILABLE` 反映を実装。
+4. build/typecheck/test/cargo check を通し、最終調整する。
+
+## 検証結果
+- [ ] `npm --workspace @infinitas/client run typecheck`
+- [ ] `npm --workspace @infinitas/client run build`
+- [ ] `npm run typecheck`
+- [ ] `cargo test -p infinitas-client-tauri notebook`
+- [ ] `cargo check`

--- a/tasks/codex-pr-10-inf-notebook.md
+++ b/tasks/codex-pr-10-inf-notebook.md
@@ -59,8 +59,9 @@
 4. build/typecheck/test/cargo check を通し、最終調整する。
 
 ## 検証結果
-- [ ] `npm --workspace @infinitas/client run typecheck`
-- [ ] `npm --workspace @infinitas/client run build`
-- [ ] `npm run typecheck`
-- [ ] `cargo test -p infinitas-client-tauri notebook`
-- [ ] `cargo check`
+- [x] `npm --workspace @infinitas/client run typecheck`
+- [x] `npm --workspace @infinitas/client run build`
+- [x] `npm run typecheck`
+- [ ] `cargo test -p infinitas-client-tauri notebook` (`x86_64-w64-mingw32-clang` link 時に exported symbols 上限へ到達)
+- [x] `cargo check`
+- [x] `cargo check --tests`


### PR DESCRIPTION
## 目的
- `docs/design/09_implementation_plan.md` の PR-10 を実装し、`inf-notebook` の `export/recent.json` から自動提出できるようにする。
- desktop-only 前提で Rust 側の test 実行を安定させる。

## 変更点
- Rust watcher に `inf-notebook` parser、`last_seen` timestamp、title 正規化、SCORE / MISSCOUNT 抽出、parser test を追加。
- watcher event payload に notebook 観測結果を載せ、`records/recent.json` 変更は metadata only として扱うようにした。
- client の `sourceStore` / `roomStore` に expected 一致時のみの `RESULT_SUBMIT` 自動送信と、ローカル `SOURCE_UNAVAILABLE` ダイアログ反映を追加。
- Settings 画面に parser observation 件数を表示するようにした。
- repo に `rust-toolchain.toml` を追加し、desktop-only 前提で Tauri crate の `crate-type` を `rlib` のみに絞った。

## 非変更点
- `inf_daken_counter` 対応は含まない。
- Worker / DO / shared の契約変更は行わない。
- `docs/design` の更新は行わない。

## 影響範囲
- ユーザー: `inf-notebook` 利用時に PLAYING 中の expected 一致結果が自動提出される。
- データ: 監視イベントはメモリ上で処理し、`source_meta` に notebook 由来の補助情報を付与する。
- 互換性: 既存 WS schema / room snapshot schema は維持する。desktop-only 前提で mobile 向け crate-type は削る。
- Cloudflare: 影響なし。

## テスト内容
- `npm --workspace @infinitas/client run typecheck`
- `npm --workspace @infinitas/client run build`
- `npm run typecheck`
- `cargo test notebook`
- `cargo check`
- `cargo check --tests`

## 回帰確認項目
- watcher start / stop と既存 Settings UI 反映が維持されること。
- expected mismatch と既確定プレイヤーで自動送信しないこと。
- parse 失敗時にローカル `SOURCE_UNAVAILABLE` が表示され、PLAYING 中は TECH skip を案内すること。
- desktop build / test が `rlib` 構成で継続できること。

## ロールバック方針
- `Prefer MSVC desktop Rust toolchain`
- `Record PR-10 validation results`
- `Wire inf-notebook auto-submit into client`
- `Add inf-notebook Rust parser`

## 互換性影響の有無
- なし。

## Cloudflare resources 影響
- なし。

## docs/design 更新有無
- なし。