### PR TITLE
Implement PR-12 audio cues and local result saving

### DIFF
--- a/apps/client/src-tauri/src/commands/local_result.rs
+++ b/apps/client/src-tauri/src/commands/local_result.rs
@@ -1,0 +1,89 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use tauri::{AppHandle, Manager};
+
+use crate::models::{SaveLocalResultRequest, SaveLocalResultResponse};
+
+const RESULT_DIRECTORY_NAME: &str = "room-results";
+
+#[tauri::command]
+pub fn save_local_result_json(
+    app: AppHandle,
+    request: SaveLocalResultRequest,
+) -> Result<SaveLocalResultResponse, String> {
+    let base_dir = app
+        .path()
+        .app_local_data_dir()
+        .map_err(|error| format!("Failed to resolve app local data directory: {error}"))?;
+
+    let result_dir = base_dir.join(RESULT_DIRECTORY_NAME);
+    fs::create_dir_all(&result_dir)
+        .map_err(|error| format!("Failed to create result directory: {error}"))?;
+
+    let file_path = result_dir.join(build_result_file_name(&request));
+    write_json_atomic(&file_path, &request.json_text)?;
+
+    Ok(SaveLocalResultResponse {
+        file_path: file_path.to_string_lossy().into_owned(),
+    })
+}
+
+fn build_result_file_name(request: &SaveLocalResultRequest) -> String {
+    let room_id = sanitize_file_component(&request.room_id);
+    let created_at = sanitize_file_component(
+        request
+            .created_at
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or("unspecified"),
+    );
+
+    format!("{created_at}-{room_id}.json")
+}
+
+fn sanitize_file_component(value: &str) -> String {
+    let sanitized: String = value
+        .chars()
+        .map(|character| match character {
+            'a'..='z' | 'A'..='Z' | '0'..='9' => character,
+            _ => '-',
+        })
+        .collect();
+
+    let trimmed = sanitized.trim_matches('-');
+    if trimmed.is_empty() {
+        "result".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn write_json_atomic(file_path: &Path, json_text: &str) -> Result<(), String> {
+    let temp_path = build_temp_path(file_path);
+    let normalized = json_text.replace("\r\n", "\n");
+
+    fs::write(&temp_path, normalized.as_bytes())
+        .map_err(|error| format!("Failed to write temp result file: {error}"))?;
+
+    if file_path.exists() {
+        fs::remove_file(file_path)
+            .map_err(|error| format!("Failed to replace result file: {error}"))?;
+    }
+
+    fs::rename(&temp_path, file_path)
+        .map_err(|error| format!("Failed to finalize result file: {error}"))?;
+
+    Ok(())
+}
+
+fn build_temp_path(file_path: &Path) -> PathBuf {
+    let file_name = file_path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("result.json");
+
+    file_path.with_file_name(format!("{file_name}.tmp"))
+}

--- a/apps/client/src-tauri/src/commands/mod.rs
+++ b/apps/client/src-tauri/src/commands/mod.rs
@@ -1,5 +1,7 @@
+mod local_result;
 mod source_watcher;
 
+pub use local_result::save_local_result_json;
 pub use source_watcher::{
     get_source_watcher_state, start_source_watcher, stop_source_watcher,
 };

--- a/apps/client/src-tauri/src/lib.rs
+++ b/apps/client/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod parsers;
 mod watchers;
 
 use commands::{get_source_watcher_state, start_source_watcher, stop_source_watcher};
+use commands::save_local_result_json;
 use watchers::SourceWatcherManager;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -12,6 +13,7 @@ pub fn run() {
         .manage(SourceWatcherManager::default())
         .invoke_handler(tauri::generate_handler![
             get_source_watcher_state,
+            save_local_result_json,
             start_source_watcher,
             stop_source_watcher
         ])

--- a/apps/client/src-tauri/src/models/local_result.rs
+++ b/apps/client/src-tauri/src/models/local_result.rs
@@ -1,0 +1,15 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SaveLocalResultRequest {
+    pub room_id: String,
+    pub created_at: Option<String>,
+    pub json_text: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SaveLocalResultResponse {
+    pub file_path: String,
+}

--- a/apps/client/src-tauri/src/models/mod.rs
+++ b/apps/client/src-tauri/src/models/mod.rs
@@ -1,5 +1,7 @@
+mod local_result;
 mod source_watcher;
 
+pub use local_result::{SaveLocalResultRequest, SaveLocalResultResponse};
 pub use source_watcher::{
     now_ms, ParsedSourceChange, ParsedSourceObservation, SourcePathsConfig, SourceType,
     SourceWatcherEventKind, SourceWatcherEventPayload, SourceWatcherStatePayload,

--- a/apps/client/src/app/App.tsx
+++ b/apps/client/src/app/App.tsx
@@ -2,6 +2,8 @@ import { startTransition, useEffect, useState } from "react";
 import { ErrorDialog } from "../components/ErrorDialog";
 import { LobbyPage } from "../pages/LobbyPage";
 import { RoomPage } from "../pages/RoomPage";
+import { localResultArchiveService } from "../services/result-archive";
+import { voiceAnnouncerService } from "../services/voice-announcer";
 import { SettingsPage } from "../pages/SettingsPage";
 import { roomStore, useRoomStore } from "../stores/room-store";
 import { sourceStore } from "../stores/source-store";
@@ -46,8 +48,12 @@ export function App() {
 
   useEffect(() => {
     void sourceStore.attach();
+    localResultArchiveService.start();
+    voiceAnnouncerService.start();
 
     return () => {
+      voiceAnnouncerService.stop();
+      localResultArchiveService.stop();
       sourceStore.detach();
     };
   }, []);
@@ -60,7 +66,7 @@ export function App() {
     <main className="app-shell">
       <header className="app-header">
         <div>
-          <p className="eyebrow">PR-9</p>
+          <p className="eyebrow">PR-12</p>
           <h1>INFINITAS BPL Client</h1>
         </div>
         <div className="header-status">

--- a/apps/client/src/components/ErrorDialog.tsx
+++ b/apps/client/src/components/ErrorDialog.tsx
@@ -1,4 +1,6 @@
 import type { RoomDialogState } from "../stores/room-store";
+import { useLocalResultArchiveStore } from "../services/result-archive";
+import { formatDateTime } from "../utils/format";
 
 interface ErrorDialogProps {
   dialog: RoomDialogState;
@@ -6,6 +8,14 @@ interface ErrorDialogProps {
 }
 
 export function ErrorDialog({ dialog, onClose }: ErrorDialogProps) {
+  const archiveStatus = useLocalResultArchiveStore((state) => state.status);
+  const archiveStorage = useLocalResultArchiveStore((state) => state.storage);
+  const archivePath = useLocalResultArchiveStore((state) => state.filePath);
+  const archiveStorageKey = useLocalResultArchiveStore((state) => state.storageKey);
+  const archiveLastSavedAt = useLocalResultArchiveStore((state) => state.lastSavedAt);
+  const archiveSaveCount = useLocalResultArchiveStore((state) => state.saveCount);
+  const archiveLocation = archivePath ?? archiveStorageKey;
+
   return (
     <div className="dialog-backdrop" role="presentation">
       <div className="dialog-card" role="dialog" aria-modal="true" aria-labelledby="error-dialog-title">
@@ -15,9 +25,25 @@ export function ErrorDialog({ dialog, onClose }: ErrorDialogProps) {
         </div>
         {dialog.code ? <p className="dialog-code">Code: {dialog.code}</p> : null}
         <p className="dialog-description">{dialog.description}</p>
+        {dialog.code === "ROOM_STATE_LOST" ? (
+          <div className="dialog-support">
+            <span className="status-label">Latest local result archive</span>
+            <strong>{archiveStatus}</strong>
+            <span className="status-muted">
+              {archiveStorage === "TAURI_FILE"
+                ? "Saved as a local JSON file."
+                : archiveStorage === "LOCAL_STORAGE"
+                  ? "Saved in localStorage fallback."
+                  : "No local archive has been saved yet."}
+            </span>
+            <span className="status-muted">Entries saved: {archiveSaveCount}</span>
+            <span className="status-muted">Last saved: {formatDateTime(archiveLastSavedAt)}</span>
+            {archiveLocation ? <code className="dialog-code">{archiveLocation}</code> : null}
+          </div>
+        ) : null}
         <div className="dialog-actions">
           <button type="button" className="primary-button" onClick={onClose}>
-            Dismiss
+            {dialog.blocking ? "Acknowledge" : "Dismiss"}
           </button>
           {dialog.blocking ? <span className="dialog-note">Blocking event</span> : null}
         </div>

--- a/apps/client/src/pages/RoomPage.tsx
+++ b/apps/client/src/pages/RoomPage.tsx
@@ -1,5 +1,7 @@
 import { HOST_SKIP_UNLOCK_SECONDS, SKIP_REASONS } from "@infinitas/shared";
 import { useState } from "react";
+import { useLocalResultArchiveStore } from "../services/result-archive";
+import { useVoicePlaybackStore } from "../services/voice-announcer";
 import { roomStore, useRoomStore } from "../stores/room-store";
 import { useSettingsStore } from "../stores/settings-store";
 import { formatDateTime, stringifyJson } from "../utils/format";
@@ -21,6 +23,28 @@ function formatExpectedKey(
   return `${expectedKey.play_style} / ${expectedKey.difficulty} / ${expectedKey.title_search_key}`;
 }
 
+function getArchiveTone(status: string): string {
+  if (status === "READY") {
+    return "ok";
+  }
+  if (status === "ERROR") {
+    return "danger";
+  }
+
+  return "warning";
+}
+
+function getVoiceTone(phase: string): string {
+  if (phase === "UNAVAILABLE") {
+    return "danger";
+  }
+  if (phase === "DISABLED") {
+    return "warning";
+  }
+
+  return phase === "IDLE" ? "warning" : "ok";
+}
+
 export function RoomPage() {
   const snapshot = useRoomStore((state) => state.snapshot);
   const resultReady = useRoomStore((state) => state.resultReady);
@@ -28,6 +52,18 @@ export function RoomPage() {
   const connectionDetail = useRoomStore((state) => state.connectionDetail);
   const eventLog = useRoomStore((state) => state.eventLog);
   const savedSettings = useSettingsStore((state) => state.saved);
+  const archiveStatus = useLocalResultArchiveStore((state) => state.status);
+  const archiveStorage = useLocalResultArchiveStore((state) => state.storage);
+  const archivePath = useLocalResultArchiveStore((state) => state.filePath);
+  const archiveStorageKey = useLocalResultArchiveStore((state) => state.storageKey);
+  const archiveLastSavedAt = useLocalResultArchiveStore((state) => state.lastSavedAt);
+  const archiveSaveCount = useLocalResultArchiveStore((state) => state.saveCount);
+  const archiveLastError = useLocalResultArchiveStore((state) => state.lastError);
+  const archiveLatest = useLocalResultArchiveStore((state) => state.latestArchive);
+  const voicePhase = useVoicePlaybackStore((state) => state.phase);
+  const voiceDetail = useVoicePlaybackStore((state) => state.detail);
+  const voiceLastUpdatedAt = useVoicePlaybackStore((state) => state.lastUpdatedAt);
+  const voicePendingCues = useVoicePlaybackStore((state) => state.pendingCues);
 
   const [pickChartKey, setPickChartKey] = useState("");
   const [metricValue, setMetricValue] = useState("0");
@@ -157,6 +193,50 @@ export function RoomPage() {
               </dl>
             </article>
           ))}
+        </div>
+      </article>
+
+      <article className="panel">
+        <div className="panel-header">
+          <div>
+            <p className="eyebrow">Runtime</p>
+            <h2>Voice and local archive</h2>
+          </div>
+        </div>
+
+        <div className="split-panel">
+          <section className="status-stack support-card">
+            <div className="inline-field">
+              <span className="status-label">Voice playback</span>
+              <span className={`status-pill ${getVoiceTone(voicePhase)}`}>{voicePhase}</span>
+            </div>
+            <strong>{savedSettings.voiceEnabled ? "Voice enabled" : "Voice disabled"}</strong>
+            <span className="status-muted">{voiceDetail}</span>
+            <span className="status-muted">Pending cues: {voicePendingCues}</span>
+            <span className="status-muted">Updated: {formatDateTime(voiceLastUpdatedAt)}</span>
+          </section>
+
+          <section className="status-stack support-card">
+            <div className="inline-field">
+              <span className="status-label">Local archive</span>
+              <span className={`status-pill ${getArchiveTone(archiveStatus)}`}>{archiveStatus}</span>
+            </div>
+            <strong>
+              {archiveStorage === "TAURI_FILE"
+                ? "JSON file output"
+                : archiveStorage === "LOCAL_STORAGE"
+                  ? "localStorage fallback"
+                  : "Awaiting first save"}
+            </strong>
+            <span className="status-muted">Entries saved: {archiveSaveCount}</span>
+            <span className="status-muted">Last saved: {formatDateTime(archiveLastSavedAt)}</span>
+            <span className="status-muted">
+              Latest snapshot state: {archiveLatest?.latest_snapshot.room_state ?? "-"}
+            </span>
+            {archivePath ? <code className="path-chip">{archivePath}</code> : null}
+            {!archivePath && archiveStorageKey ? <code className="path-chip">{archiveStorageKey}</code> : null}
+            {archiveLastError ? <p className="inline-error">{archiveLastError}</p> : null}
+          </section>
         </div>
       </article>
 

--- a/apps/client/src/services/result-archive.ts
+++ b/apps/client/src/services/result-archive.ts
@@ -1,0 +1,212 @@
+import type { ResultReadyPayload, RoomStateSnapshot } from "@infinitas/shared";
+import { createExternalStore, useExternalStore } from "../stores/create-store";
+import { roomStore } from "../stores/room-store";
+import { readJson, writeJson } from "./local-storage";
+import { isTauriRuntime, saveLocalResultJson } from "./tauri-bridge";
+
+const ROOM_RESULT_ARCHIVE_STORAGE_KEY = "infinitas.client.room-results.v1";
+
+export type LocalResultArchiveStatus = "IDLE" | "SAVING" | "READY" | "ERROR";
+export type LocalResultArchiveStorage = "NONE" | "TAURI_FILE" | "LOCAL_STORAGE";
+
+export interface LocalResultArchiveEntry {
+  saved_at: string;
+  room_state_snapshot: RoomStateSnapshot;
+  result_ready: ResultReadyPayload | null;
+}
+
+export interface LocalResultArchive {
+  schema_version: 1;
+  room_id: string;
+  created_at: string | null;
+  updated_at: string;
+  latest_snapshot: RoomStateSnapshot;
+  result_ready: ResultReadyPayload | null;
+  entries: LocalResultArchiveEntry[];
+}
+
+export interface LocalResultArchiveState {
+  status: LocalResultArchiveStatus;
+  storage: LocalResultArchiveStorage;
+  roomId: string | null;
+  filePath: string | null;
+  storageKey: string | null;
+  lastSavedAt: string | null;
+  saveCount: number;
+  lastError: string | null;
+  latestArchive: LocalResultArchive | null;
+}
+
+const internalStore = createExternalStore<LocalResultArchiveState>({
+  status: "IDLE",
+  storage: "NONE",
+  roomId: null,
+  filePath: null,
+  storageKey: null,
+  lastSavedAt: null,
+  saveCount: 0,
+  lastError: null,
+  latestArchive: null,
+});
+
+const archivesByRoom = new Map<string, LocalResultArchive>();
+
+let unsubscribeRoomStore: (() => void) | null = null;
+let persistSequence: Promise<unknown> = Promise.resolve();
+let lastRoomId: string | null = null;
+let lastFingerprint: string | null = null;
+
+function buildFallbackKey(roomId: string): string {
+  return `${ROOM_RESULT_ARCHIVE_STORAGE_KEY}:${roomId}`;
+}
+
+function loadFallbackArchive(roomId: string): LocalResultArchive | null {
+  return readJson<LocalResultArchive | null>(buildFallbackKey(roomId), null);
+}
+
+function buildArchive(
+  snapshot: RoomStateSnapshot,
+  resultReady: ResultReadyPayload | null,
+): LocalResultArchive {
+  const existingArchive = archivesByRoom.get(snapshot.room_id) ?? loadFallbackArchive(snapshot.room_id);
+  const savedAt = new Date().toISOString();
+
+  const nextArchive: LocalResultArchive = {
+    schema_version: 1,
+    room_id: snapshot.room_id,
+    created_at: snapshot.created_at ?? existingArchive?.created_at ?? null,
+    updated_at: savedAt,
+    latest_snapshot: snapshot,
+    result_ready: resultReady,
+    entries: [
+      ...(existingArchive?.entries ?? []),
+      {
+        saved_at: savedAt,
+        room_state_snapshot: snapshot,
+        result_ready: resultReady,
+      },
+    ],
+  };
+
+  archivesByRoom.set(snapshot.room_id, nextArchive);
+  return nextArchive;
+}
+
+function queuePersist(archive: LocalResultArchive): void {
+  persistSequence = persistSequence
+    .catch(() => undefined)
+    .then(async () => {
+      await persistArchive(archive);
+    });
+}
+
+async function persistArchive(archive: LocalResultArchive): Promise<void> {
+  internalStore.setState((state) => ({
+    ...state,
+    status: "SAVING",
+    roomId: archive.room_id,
+    lastError: null,
+    latestArchive: archive,
+    saveCount: archive.entries.length,
+  }));
+
+  const jsonText = JSON.stringify(archive, null, 2);
+
+  try {
+    if (isTauriRuntime()) {
+      const response = await saveLocalResultJson({
+        roomId: archive.room_id,
+        createdAt: archive.created_at,
+        jsonText,
+      });
+
+      internalStore.setState((state) => ({
+        ...state,
+        status: "READY",
+        storage: "TAURI_FILE",
+        roomId: archive.room_id,
+        filePath: response.filePath,
+        storageKey: null,
+        lastSavedAt: archive.updated_at,
+        saveCount: archive.entries.length,
+        lastError: null,
+        latestArchive: archive,
+      }));
+      return;
+    }
+
+    const storageKey = buildFallbackKey(archive.room_id);
+    writeJson(storageKey, archive);
+
+    internalStore.setState((state) => ({
+      ...state,
+      status: "READY",
+      storage: "LOCAL_STORAGE",
+      roomId: archive.room_id,
+      filePath: null,
+      storageKey,
+      lastSavedAt: archive.updated_at,
+      saveCount: archive.entries.length,
+      lastError: null,
+      latestArchive: archive,
+    }));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to save local result archive.";
+    roomStore.noteLocalEvent(`Local result save failed: ${message}`);
+    internalStore.setState((state) => ({
+      ...state,
+      status: "ERROR",
+      roomId: archive.room_id,
+      lastError: message,
+      latestArchive: archive,
+    }));
+  }
+}
+
+function syncFromRoomStore(): void {
+  const { snapshot, resultReady } = roomStore.getState();
+
+  if (snapshot === null) {
+    lastRoomId = null;
+    lastFingerprint = null;
+    return;
+  }
+
+  if (snapshot.room_id !== lastRoomId) {
+    lastRoomId = snapshot.room_id;
+    lastFingerprint = null;
+  }
+
+  const fingerprint = JSON.stringify({
+    snapshot,
+    resultReady,
+  });
+  if (fingerprint === lastFingerprint) {
+    return;
+  }
+
+  lastFingerprint = fingerprint;
+  queuePersist(buildArchive(snapshot, resultReady));
+}
+
+export const localResultArchiveService = {
+  ...internalStore,
+  start(): void {
+    if (unsubscribeRoomStore !== null) {
+      return;
+    }
+
+    unsubscribeRoomStore = roomStore.subscribe(syncFromRoomStore);
+    syncFromRoomStore();
+  },
+  stop(): void {
+    unsubscribeRoomStore?.();
+    unsubscribeRoomStore = null;
+  },
+};
+
+export function useLocalResultArchiveStore<TSelected>(
+  selector: (state: LocalResultArchiveState) => TSelected,
+): TSelected {
+  return useExternalStore(internalStore, selector);
+}

--- a/apps/client/src/services/tauri-bridge.ts
+++ b/apps/client/src/services/tauri-bridge.ts
@@ -45,6 +45,16 @@ interface StartSourceWatcherRequest {
   sourcePaths: SourcePaths;
 }
 
+export interface SaveLocalResultJsonRequest {
+  roomId: string;
+  createdAt: string | null;
+  jsonText: string;
+}
+
+export interface SaveLocalResultJsonResponse {
+  filePath: string;
+}
+
 declare global {
   interface Window {
     __TAURI_INTERNALS__?: unknown;
@@ -95,6 +105,17 @@ export async function listenToSourceWatcherEvents(
   return listen<SourceWatcherEventPayload>(SOURCE_WATCHER_EVENT_NAME, (event) => {
     handler(event.payload);
   });
+}
+
+export async function saveLocalResultJson(
+  request: SaveLocalResultJsonRequest,
+): Promise<SaveLocalResultJsonResponse> {
+  if (!isTauriRuntime()) {
+    throw new Error("Local result save is available only inside the Tauri desktop app.");
+  }
+
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<SaveLocalResultJsonResponse>("save_local_result_json", { request });
 }
 
 function createUnavailableState(): SourceWatcherStatePayload {

--- a/apps/client/src/services/voice-announcer.ts
+++ b/apps/client/src/services/voice-announcer.ts
@@ -6,6 +6,7 @@ import { settingsStore } from "../stores/settings-store";
 const ROUND_STAGE_COUNTDOWN_AT_MS = 40_000;
 const ROUND_START_CALL_AT_MS = 50_000;
 const RECENT_CUE_GRACE_MS = 3_000;
+const VOICE_CUE_INTERVAL_MS = 1_000;
 
 type VoiceCuePhase = "STAGE" | "COUNTDOWN" | "START";
 
@@ -105,6 +106,20 @@ function getStageLabel(roundIndex: number): string {
   }
 }
 
+function createSequentialVoiceCues(
+  phase: VoiceCuePhase,
+  startAtMs: number,
+  texts: readonly string[],
+  roundIndex: number,
+): VoiceCue[] {
+  return texts.map((text, index) => ({
+    phase,
+    dueAtMs: startAtMs + index * VOICE_CUE_INTERVAL_MS,
+    text,
+    detail: `${phase} cue ${index + 1}/${texts.length} for round ${roundIndex + 1}: ${text}`,
+  }));
+}
+
 function createVoiceCues(round: CurrentRoundSnapshot): VoiceCue[] {
   const startedAtMs = Date.parse(round.round_started_at);
   if (Number.isNaN(startedAtMs)) {
@@ -118,18 +133,18 @@ function createVoiceCues(round: CurrentRoundSnapshot): VoiceCue[] {
       text: getStageLabel(round.round_index),
       detail: `Stage cue for round ${round.round_index + 1}.`,
     },
-    {
-      phase: "COUNTDOWN",
-      dueAtMs: startedAtMs + ROUND_STAGE_COUNTDOWN_AT_MS,
-      text: "10, 9, 8, 7, 6, 5, 4. Round begin.",
-      detail: `Countdown cue for round ${round.round_index + 1}.`,
-    },
-    {
-      phase: "START",
-      dueAtMs: startedAtMs + ROUND_START_CALL_AT_MS,
-      text: "3, 2, 1. Let's go.",
-      detail: `Start cue for round ${round.round_index + 1}.`,
-    },
+    ...createSequentialVoiceCues(
+      "COUNTDOWN",
+      startedAtMs + ROUND_STAGE_COUNTDOWN_AT_MS,
+      ["10", "9", "8", "7", "6", "5", "4", "Round begin."],
+      round.round_index,
+    ),
+    ...createSequentialVoiceCues(
+      "START",
+      startedAtMs + ROUND_START_CALL_AT_MS,
+      ["3", "2", "1", "Let's go."],
+      round.round_index,
+    ),
   ];
 }
 

--- a/apps/client/src/services/voice-announcer.ts
+++ b/apps/client/src/services/voice-announcer.ts
@@ -136,7 +136,7 @@ function createVoiceCues(round: CurrentRoundSnapshot): VoiceCue[] {
     ...createSequentialVoiceCues(
       "COUNTDOWN",
       startedAtMs + ROUND_STAGE_COUNTDOWN_AT_MS,
-      ["10", "9", "8", "7", "6", "5", "4", "Round begin."],
+      ["10", "9", "8", "7", "6", "5", "4", "3", "2", "1", "Round begin."],
       round.round_index,
     ),
     ...createSequentialVoiceCues(

--- a/apps/client/src/services/voice-announcer.ts
+++ b/apps/client/src/services/voice-announcer.ts
@@ -1,0 +1,265 @@
+import type { CurrentRoundSnapshot } from "@infinitas/shared";
+import { createExternalStore, useExternalStore } from "../stores/create-store";
+import { roomStore } from "../stores/room-store";
+import { settingsStore } from "../stores/settings-store";
+
+const ROUND_STAGE_COUNTDOWN_AT_MS = 40_000;
+const ROUND_START_CALL_AT_MS = 50_000;
+const RECENT_CUE_GRACE_MS = 3_000;
+
+type VoiceCuePhase = "STAGE" | "COUNTDOWN" | "START";
+
+interface VoiceCue {
+  phase: VoiceCuePhase;
+  dueAtMs: number;
+  text: string;
+  detail: string;
+}
+
+export type VoicePlaybackPhase =
+  | "IDLE"
+  | "DISABLED"
+  | "UNAVAILABLE"
+  | "STAGE"
+  | "COUNTDOWN"
+  | "START";
+
+export interface VoicePlaybackState {
+  phase: VoicePlaybackPhase;
+  enabled: boolean;
+  roundToken: string | null;
+  pendingCues: number;
+  detail: string;
+  lastUpdatedAt: string | null;
+}
+
+const internalStore = createExternalStore<VoicePlaybackState>({
+  phase: "IDLE",
+  enabled: true,
+  roundToken: null,
+  pendingCues: 0,
+  detail: "Voice cues idle.",
+  lastUpdatedAt: null,
+});
+
+let unsubscribeRoomStore: (() => void) | null = null;
+let unsubscribeSettingsStore: (() => void) | null = null;
+let activeRoundToken: string | null = null;
+let activeTimeoutIds: number[] = [];
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function getSpeechSynthesisApi(): SpeechSynthesis | null {
+  if (typeof window === "undefined" || typeof window.speechSynthesis === "undefined") {
+    return null;
+  }
+
+  return window.speechSynthesis;
+}
+
+function setVoiceState(partialState: Partial<VoicePlaybackState>): void {
+  internalStore.setState((state) => ({
+    ...state,
+    ...partialState,
+    lastUpdatedAt: partialState.lastUpdatedAt ?? nowIso(),
+  }));
+}
+
+function clearPlayback(nextPhase: VoicePlaybackPhase, detail: string, enabled: boolean): void {
+  for (const timeoutId of activeTimeoutIds) {
+    window.clearTimeout(timeoutId);
+  }
+  activeTimeoutIds = [];
+
+  getSpeechSynthesisApi()?.cancel();
+  if (nextPhase === "IDLE" || nextPhase === "DISABLED" || nextPhase === "UNAVAILABLE") {
+    activeRoundToken = null;
+  }
+
+  setVoiceState({
+    phase: nextPhase,
+    enabled,
+    pendingCues: 0,
+    detail,
+    roundToken: activeRoundToken,
+  });
+}
+
+function buildRoundToken(roomId: string, round: CurrentRoundSnapshot): string {
+  return `${roomId}:${round.round_index}:${round.round_started_at}`;
+}
+
+function getStageLabel(roundIndex: number): string {
+  const stageNumber = roundIndex + 1;
+  switch (stageNumber) {
+    case 1:
+      return "First stage.";
+    case 2:
+      return "Second stage.";
+    case 3:
+      return "Final stage.";
+    default:
+      return `Stage ${stageNumber}.`;
+  }
+}
+
+function createVoiceCues(round: CurrentRoundSnapshot): VoiceCue[] {
+  const startedAtMs = Date.parse(round.round_started_at);
+  if (Number.isNaN(startedAtMs)) {
+    return [];
+  }
+
+  return [
+    {
+      phase: "STAGE",
+      dueAtMs: startedAtMs,
+      text: getStageLabel(round.round_index),
+      detail: `Stage cue for round ${round.round_index + 1}.`,
+    },
+    {
+      phase: "COUNTDOWN",
+      dueAtMs: startedAtMs + ROUND_STAGE_COUNTDOWN_AT_MS,
+      text: "10, 9, 8, 7, 6, 5, 4. Round begin.",
+      detail: `Countdown cue for round ${round.round_index + 1}.`,
+    },
+    {
+      phase: "START",
+      dueAtMs: startedAtMs + ROUND_START_CALL_AT_MS,
+      text: "3, 2, 1. Let's go.",
+      detail: `Start cue for round ${round.round_index + 1}.`,
+    },
+  ];
+}
+
+function speakCue(roundToken: string, cue: VoiceCue): void {
+  if (roundToken !== activeRoundToken) {
+    return;
+  }
+
+  const speechSynthesisApi = getSpeechSynthesisApi();
+  if (speechSynthesisApi === null) {
+    setVoiceState({
+      phase: "UNAVAILABLE",
+      enabled: settingsStore.getState().saved.voiceEnabled,
+      pendingCues: 0,
+      detail: "Speech synthesis is unavailable in this runtime.",
+      roundToken,
+    });
+    return;
+  }
+
+  const utterance = new SpeechSynthesisUtterance(cue.text);
+  utterance.lang = "en-US";
+  utterance.rate = 1;
+  utterance.pitch = 1;
+  utterance.onstart = () => {
+    setVoiceState({
+      phase: cue.phase,
+      enabled: settingsStore.getState().saved.voiceEnabled,
+      pendingCues: activeTimeoutIds.length,
+      detail: cue.detail,
+      roundToken,
+    });
+  };
+  utterance.onerror = () => {
+    setVoiceState({
+      phase: "UNAVAILABLE",
+      enabled: settingsStore.getState().saved.voiceEnabled,
+      pendingCues: activeTimeoutIds.length,
+      detail: `Voice playback failed during ${cue.phase.toLowerCase()} cue.`,
+      roundToken,
+    });
+  };
+
+  speechSynthesisApi.speak(utterance);
+}
+
+function scheduleRoundPlayback(roomId: string, round: CurrentRoundSnapshot): void {
+  const roundToken = buildRoundToken(roomId, round);
+  const cues = createVoiceCues(round);
+  const nowMs = Date.now();
+
+  let scheduledCount = 0;
+
+  for (const cue of cues) {
+    const delayMs = cue.dueAtMs - nowMs;
+    if (delayMs < -RECENT_CUE_GRACE_MS) {
+      continue;
+    }
+
+    scheduledCount += 1;
+    const timeoutId = window.setTimeout(() => {
+      activeTimeoutIds = activeTimeoutIds.filter((value) => value !== timeoutId);
+      speakCue(roundToken, cue);
+    }, Math.max(0, delayMs));
+    activeTimeoutIds.push(timeoutId);
+  }
+
+  setVoiceState({
+    phase: scheduledCount > 0 ? "IDLE" : "START",
+    enabled: true,
+    pendingCues: scheduledCount,
+    detail:
+      scheduledCount > 0
+        ? `Queued ${scheduledCount} voice cue(s) for round ${round.round_index + 1}.`
+        : `Voice cues already elapsed for round ${round.round_index + 1}.`,
+    roundToken,
+  });
+}
+
+function syncVoicePlayback(): void {
+  const savedSettings = settingsStore.getState().saved;
+  if (!savedSettings.voiceEnabled) {
+    clearPlayback("DISABLED", "Voice notifications are turned off.", false);
+    return;
+  }
+
+  const speechSynthesisApi = getSpeechSynthesisApi();
+  if (speechSynthesisApi === null) {
+    clearPlayback("UNAVAILABLE", "Speech synthesis is unavailable in this runtime.", true);
+    return;
+  }
+
+  const snapshot = roomStore.getState().snapshot;
+  if (snapshot === null || snapshot.room_state !== "PLAYING" || snapshot.current_round === null) {
+    clearPlayback("IDLE", "Voice cues idle.", true);
+    return;
+  }
+
+  const nextRoundToken = buildRoundToken(snapshot.room_id, snapshot.current_round);
+  if (nextRoundToken === activeRoundToken) {
+    return;
+  }
+
+  clearPlayback("IDLE", `Arming voice cues for round ${snapshot.current_round.round_index + 1}.`, true);
+  activeRoundToken = nextRoundToken;
+  scheduleRoundPlayback(snapshot.room_id, snapshot.current_round);
+}
+
+export const voiceAnnouncerService = {
+  ...internalStore,
+  start(): void {
+    if (unsubscribeRoomStore !== null || unsubscribeSettingsStore !== null) {
+      return;
+    }
+
+    unsubscribeRoomStore = roomStore.subscribe(syncVoicePlayback);
+    unsubscribeSettingsStore = settingsStore.subscribe(syncVoicePlayback);
+    syncVoicePlayback();
+  },
+  stop(): void {
+    unsubscribeRoomStore?.();
+    unsubscribeSettingsStore?.();
+    unsubscribeRoomStore = null;
+    unsubscribeSettingsStore = null;
+    clearPlayback("IDLE", "Voice cues idle.", settingsStore.getState().saved.voiceEnabled);
+  },
+};
+
+export function useVoicePlaybackStore<TSelected>(
+  selector: (state: VoicePlaybackState) => TSelected,
+): TSelected {
+  return useExternalStore(internalStore, selector);
+}

--- a/apps/client/src/stores/room-store.ts
+++ b/apps/client/src/stores/room-store.ts
@@ -110,6 +110,10 @@ function buildSourceUnavailableDescription(detail: string, roomState: RoomStateS
   return detail;
 }
 
+function buildRoomStateLostDescription(detail: string): string {
+  return `${detail} The room has been closed locally. Review the latest saved snapshot for partial results.`;
+}
+
 function closeCurrentClient(sendLeaveMessage: boolean): void {
   const client = activeClient;
   activeClient = null;
@@ -231,9 +235,19 @@ function handleServerMessage(client: RoomSocketClient, message: ServerMessage): 
       closeCurrentClient(false);
       internalStore.setState((state) => ({
         ...state,
-        connectionStatus: "ERROR",
-        connectionDetail: "Join rejected.",
+        connectionStatus: payload.reason === "ROOM_STATE_LOST" ? "CLOSED" : "ERROR",
+        connectionDetail: payload.reason === "ROOM_STATE_LOST" ? "Room state lost." : "Join rejected.",
       }));
+      if (payload.reason === "ROOM_STATE_LOST") {
+        setErrorDialog(
+          "Room state lost",
+          buildRoomStateLostDescription("The room could not be recovered."),
+          payload.reason,
+          true,
+        );
+        return;
+      }
+
       setErrorDialog("Join rejected", payload.reason);
       return;
     }
@@ -268,13 +282,28 @@ function handleServerMessage(client: RoomSocketClient, message: ServerMessage): 
     }
     case "ERROR": {
       const payload = message.payload as ServerMessagePayloadMap["ERROR"];
+      const snapshot = internalStore.getState().snapshot;
+      const description =
+        payload.code === "ROOM_STATE_LOST"
+          ? buildRoomStateLostDescription(payload.message)
+          : payload.code === "SOURCE_UNAVAILABLE" && snapshot !== null
+            ? buildSourceUnavailableDescription(payload.message, snapshot.room_state)
+            : payload.message;
+
+      if (payload.code === "ROOM_STATE_LOST") {
+        closeCurrentClient(false);
+        updateClosedSnapshot(payload.code, message.server_time);
+        appendEventLog("Room state lost. Showing the latest local snapshot.");
+      }
+
       internalStore.setState((state) => ({
         ...state,
         connectionStatus: payload.code === "ROOM_STATE_LOST" ? "CLOSED" : state.connectionStatus,
+        connectionDetail: payload.code === "ROOM_STATE_LOST" ? "Room state lost." : state.connectionDetail,
       }));
       setErrorDialog(
         errorTitleFromCode(payload.code),
-        payload.message,
+        description,
         payload.code,
         payload.code === "ROOM_STATE_LOST" || payload.code === "SOURCE_UNAVAILABLE",
       );

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -360,6 +360,10 @@ button {
   gap: 1rem;
 }
 
+.support-card {
+  flex: 1;
+}
+
 .watcher-path-list {
   gap: 0.5rem;
 }
@@ -431,6 +435,15 @@ pre {
   font-size: 0.85rem;
   font-weight: 700;
   color: #8d1224;
+}
+
+.dialog-support {
+  display: grid;
+  gap: 0.35rem;
+  margin: 0 0 1rem;
+  padding: 0.9rem 1rem;
+  border-radius: 18px;
+  background: rgba(255, 244, 238, 0.85);
 }
 
 @media (max-width: 1080px) {

--- a/tasks/codex-pr-12-audio-local-save.md
+++ b/tasks/codex-pr-12-audio-local-save.md
@@ -1,0 +1,75 @@
+# Plan: codex/pr-12-audio-local-save
+
+## 作業宣言
+- worktree: `C:\work\infinitas_arena\infinitas_bpl_pr12`
+- branch: `codex/pr-12-audio-local-save`
+- base branch: `v1`
+- BASE_SHA: `93d12dbd0c77ef2e05854e81a0aef2cd490d13af`
+
+## 目的
+- `docs/design/09_implementation_plan.md` の PR-12（音声通知 / ローカル保存 / 最終仕上げ）を実装する。
+- クライアントで Stage / countdown / START 音声を鳴らし、状態遷移時に再生キューと再生中音声を停止できるようにする。
+- `RoomStateSnapshot` と `RESULT_READY` をローカル JSON として保存し、`ROOM_STATE_LOST` を含む終了系で部分結果を確認しやすくする。
+
+## 非目的
+- Worker / DO / shared の WS 契約変更。
+- watcher/parser の仕様変更。
+- 結果 JSON から別画面を新設して履歴ブラウズする機能。
+- 外部音声素材や追加 npm/crate 依存の導入。
+
+## 変更点
+- `apps/client/src` に音声通知サービスとローカル結果保存サービスを追加し、`roomStore` / `settingsStore` の変化に追従させる。
+- `speechSynthesis` を利用して Stage / countdown / START 音声をスケジュールし、ラウンド変更や `PLAYING` 離脱時に再生中・キュー済み音声を破棄する。
+- Tauri Rust 側に結果 JSON を UTF-8 / LF / atomic write で保存する command を追加し、非Tauri環境では `localStorage` へフォールバックする。
+- Room 画面と ErrorDialog を補強し、保存先・保存回数・直近保存時刻・`ROOM_STATE_LOST` 時の案内を表示する。
+
+## 影響範囲
+- ユーザー:
+  - PLAYING 中に音声通知を受け取れる。
+  - ラウンド進行に応じた snapshot/result がローカル保存される。
+  - `ROOM_STATE_LOST` 時に blocking dialog と保存済み部分結果への導線が出る。
+- データ:
+  - 既存 settings の `voiceEnabled` を継続利用する。
+  - ローカル結果 JSON を Tauri 保存ディレクトリ配下へ書き出し、非Tauriでは `localStorage` に保存する。
+- 互換性:
+  - Worker / shared schema は変更しない。
+  - 保存 JSON は client 内部フォーマットの追加のみで既存通信互換性へ影響しない。
+- Cloudflare:
+  - 影響なし。
+
+## 対象ファイル / 対象レイヤ
+- `apps/client/src/app/App.tsx`
+- `apps/client/src/components/ErrorDialog.tsx`
+- `apps/client/src/pages/RoomPage.tsx`
+- `apps/client/src/services/**`
+- `apps/client/src/stores/**`
+- `apps/client/src/styles.css`
+- `apps/client/src-tauri/src/commands/**`
+- `apps/client/src-tauri/src/lib.rs`
+- `apps/client/src-tauri/src/models/**`
+- `tasks/codex-pr-12-audio-local-save.md`
+
+## テスト観点
+- `PLAYING` の同一 round で Stage / countdown / START が 1 回だけスケジュールされ、ラウンド変更や `RESULT` / `CLOSED` 遷移で停止される。
+- `voiceEnabled=false` では音声をスケジュールしない。
+- snapshot / result payload 更新時にローカル保存状態が更新される。
+- `ROOM_STATE_LOST` で blocking dialog と保存補助表示が出る。
+- `npm --workspace @infinitas/client run typecheck`
+- `npm --workspace @infinitas/client run build`
+- `npm run typecheck`
+- `cargo check`
+
+## ロールバック方針
+- PR-12 差分を revert し、PR-11 時点の client + watcher 実装へ戻す。
+
+## Commit Plan（コミット分割計画）
+1. PR-12 plan 追加（本ファイル）。
+2. Tauri 結果保存 command と TS bridge / persistence service を実装。
+3. 音声通知 service、Room UI、`ROOM_STATE_LOST` ダイアログ補強を実装。
+4. build/typecheck/cargo check を通し、最終調整を行う。
+
+## 検証結果
+- [ ] `npm --workspace @infinitas/client run typecheck`
+- [ ] `npm --workspace @infinitas/client run build`
+- [ ] `npm run typecheck`
+- [ ] `cargo check`

--- a/tasks/codex-pr-12-audio-local-save.md
+++ b/tasks/codex-pr-12-audio-local-save.md
@@ -69,7 +69,7 @@
 4. build/typecheck/cargo check を通し、最終調整を行う。
 
 ## 検証結果
-- [ ] `npm --workspace @infinitas/client run typecheck`
-- [ ] `npm --workspace @infinitas/client run build`
-- [ ] `npm run typecheck`
-- [ ] `cargo check`
+- [x] `npm --workspace @infinitas/client run typecheck`
+- [x] `npm --workspace @infinitas/client run build`
+- [x] `npm run typecheck`
+- [x] `cargo check`


### PR DESCRIPTION
## 目的
- `docs/design/09_implementation_plan.md` の PR-12 を実装し、Ph1 の最終仕上げとして音声通知、ローカル結果保存、`ROOM_STATE_LOST` 時の復旧補助を追加する。

## 変更点
- `speechSynthesis` ベースの Stage / countdown / START 音声通知を追加し、ラウンド変更や `PLAYING` 離脱時に再生中音声とキュー済み音声を停止するようにした。
- `RoomStateSnapshot` と `RESULT_READY` をローカル JSON として保存する経路を追加した。Tauri 環境では app local data 配下へ atomic write し、非Tauri環境では `localStorage` にフォールバックする。
- Room 画面に voice/local archive 状態を表示し、`ROOM_STATE_LOST` や join 時の state loss を blocking dialog と保存済み snapshot 案内で扱えるようにした。

## 非変更点
- Worker / Durable Object / shared の通信契約変更
- watcher/parser の仕様変更
- 結果履歴専用の新規画面追加
- 依存関係追加

## 影響範囲
- ユーザー: PLAYING 中に音声通知を受け取れ、ローカル保存の状態と保存先を Room 画面から確認できる。`ROOM_STATE_LOST` 時も保存済み部分結果を案内できる。
- データ: ローカル結果 JSON を app local data 配下へ保存する。非Tauri実行時は `localStorage` フォールバックを使う。既存 settings 形式は維持する。
- 互換性: Worker / shared schema 変更なし。通信互換性への影響なし。
- Cloudflare: 影響なし。

## テスト内容
- `npm --workspace @infinitas/client run typecheck`
- `npm --workspace @infinitas/client run build`
- `npm run typecheck`
- `cargo check`

## 回帰確認項目
- `voiceEnabled=false` で音声通知が無効化されること
- 同一ラウンドで音声 cue が重複スケジュールされず、状態遷移時に停止されること
- `RoomStateSnapshot` / `RESULT_READY` 更新時にローカル保存状態が更新されること
- `ROOM_STATE_LOST` で blocking dialog と保存済み snapshot 案内が表示されること

## ロールバック方針
- 本PRを revert し、PR-11 時点の client 実装へ戻す。

## 互換性影響の有無
- なし

## Cloudflare resources 影響
- なし

## docs/design 更新有無
- なし