### PR TITLE
Apply mock settings shell and local settings validation

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2.5.1",
+    "lucide-react": "^0.446.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },
@@ -22,6 +23,9 @@
     "@types/react": "^19.1.5",
     "@types/react-dom": "^19.1.5",
     "@vitejs/plugin-react": "^5.0.4",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.39",
+    "tailwindcss": "^3.4.4",
     "vite": "^7.1.7"
   }
 }

--- a/apps/client/postcss.config.js
+++ b/apps/client/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/client/src-tauri/Cargo.lock
+++ b/apps/client/src-tauri/Cargo.lock
@@ -48,6 +48,181 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.2",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +326,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -365,6 +553,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -637,6 +834,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading 0.8.9",
+]
+
+[[package]]
 name = "dlopen2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +864,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -743,6 +955,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,6 +997,43 @@ dependencies = [
  "serde_core",
  "typeid",
 ]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdeflate"
@@ -903,6 +1179,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1290,6 +1579,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1575,6 +1870,7 @@ name = "infinitas-bpl-client"
 version = "0.1.0"
 dependencies = [
  "notify",
+ "rfd",
  "serde",
  "serde_json",
  "tauri",
@@ -1827,6 +2123,12 @@ dependencies = [
  "plain",
  "redox_syscall 0.7.3",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2239,6 +2541,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "oxilangtag"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2271,6 +2583,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2448,6 +2766,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2467,7 +2796,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -2484,6 +2813,26 @@ dependencies = [
  "flate2",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "potential_utf"
@@ -2603,6 +2952,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2649,6 +3007,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2669,6 +3037,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2684,6 +3062,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2823,6 +3210,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "ashpd",
+ "block2",
+ "dispatch2",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "pollster",
+ "raw-window-handle",
+ "urlencoding",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2835,6 +3246,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2902,6 +3326,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -3111,6 +3541,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -3626,6 +4066,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "tendril"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3925,7 +4378,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4023,6 +4488,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unic-char-property"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4102,6 +4578,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"
@@ -4324,6 +4806,66 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa75f400b7f719bcd68b3f47cd939ba654cedeef690f486db71331eec4c6a406"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab51d9f7c071abeee76007e2b742499e535148035bb835f97aaed1338cf516c3"
+dependencies = [
+ "bitflags 2.11.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b23b5df31ceff1328f06ac607591d5ba360cf58f90c8fad4ac8d3a55a3c4aec7"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86287151a309799b821ca709b7345a048a2956af05957c89cb824ab919fa4e3"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.2",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374f6b70e8e0d6bf9461a32988fd553b59ff630964924dad6e4a4eb6bd538d17"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
 ]
 
 [[package]]
@@ -5183,6 +5725,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 0.7.15",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+dependencies = [
+ "serde",
+ "winnow 0.7.15",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5261,3 +5864,44 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "url",
+ "winnow 0.7.15",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 0.7.15",
+]

--- a/apps/client/src-tauri/Cargo.toml
+++ b/apps/client/src-tauri/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 notify = "6.1.1"
+rfd = "0.15.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", features = [] }

--- a/apps/client/src-tauri/capabilities/default.json
+++ b/apps/client/src-tauri/capabilities/default.json
@@ -3,5 +3,5 @@
   "identifier": "main-capability",
   "description": "Capability for the main window",
   "windows": ["main"],
-  "permissions": ["tts:default"]
+  "permissions": ["core:default", "tts:default"]
 }

--- a/apps/client/src-tauri/src/commands/directory_dialog.rs
+++ b/apps/client/src-tauri/src/commands/directory_dialog.rs
@@ -1,0 +1,6 @@
+#[tauri::command]
+pub fn pick_directory() -> Option<String> {
+    rfd::FileDialog::new()
+        .pick_folder()
+        .map(|path| path.to_string_lossy().into_owned())
+}

--- a/apps/client/src-tauri/src/commands/mod.rs
+++ b/apps/client/src-tauri/src/commands/mod.rs
@@ -1,7 +1,11 @@
+mod directory_dialog;
 mod local_result;
+mod source_directory_validation;
 mod source_watcher;
 
+pub use directory_dialog::pick_directory;
 pub use local_result::save_local_result_json;
+pub use source_directory_validation::validate_source_directory;
 pub use source_watcher::{
     get_source_watcher_state, start_source_watcher, stop_source_watcher,
 };

--- a/apps/client/src-tauri/src/commands/source_directory_validation.rs
+++ b/apps/client/src-tauri/src/commands/source_directory_validation.rs
@@ -1,0 +1,53 @@
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+use crate::models::SourceType;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ValidateSourceDirectoryRequest {
+    pub source: SourceType,
+    pub directory_path: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ValidateSourceDirectoryResponse {
+    pub missing_paths: Vec<String>,
+}
+
+#[tauri::command]
+pub fn validate_source_directory(
+    request: ValidateSourceDirectoryRequest,
+) -> Result<ValidateSourceDirectoryResponse, String> {
+    let base_directory = request.directory_path.trim();
+    if base_directory.is_empty() {
+        return Ok(ValidateSourceDirectoryResponse {
+            missing_paths: vec![],
+        });
+    }
+
+    let required_paths = match request.source {
+        SourceType::InfDakenCounter => vec![join_path(base_directory, &["today_update.xml"])],
+        SourceType::InfNotebook => vec![
+            join_path(base_directory, &["export", "recent.json"]),
+            join_path(base_directory, &["records", "recent.json"]),
+        ],
+    };
+
+    let missing_paths = required_paths
+        .into_iter()
+        .filter(|path| !path.is_file())
+        .map(|path| path.to_string_lossy().into_owned())
+        .collect();
+
+    Ok(ValidateSourceDirectoryResponse { missing_paths })
+}
+
+fn join_path(base_directory: &str, segments: &[&str]) -> PathBuf {
+    let mut path = Path::new(base_directory).to_path_buf();
+    for segment in segments {
+        path.push(segment);
+    }
+    path
+}

--- a/apps/client/src-tauri/src/lib.rs
+++ b/apps/client/src-tauri/src/lib.rs
@@ -3,7 +3,10 @@ mod models;
 mod parsers;
 mod watchers;
 
-use commands::{get_source_watcher_state, start_source_watcher, stop_source_watcher};
+use commands::{
+    get_source_watcher_state, pick_directory, start_source_watcher, stop_source_watcher,
+    validate_source_directory,
+};
 use commands::save_local_result_json;
 use watchers::SourceWatcherManager;
 
@@ -14,9 +17,11 @@ pub fn run() {
         .manage(SourceWatcherManager::default())
         .invoke_handler(tauri::generate_handler![
             get_source_watcher_state,
+            pick_directory,
             save_local_result_json,
             start_source_watcher,
-            stop_source_watcher
+            stop_source_watcher,
+            validate_source_directory
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/client/src/app/App.tsx
+++ b/apps/client/src/app/App.tsx
@@ -1,35 +1,21 @@
 import { startTransition, useEffect, useState } from "react";
+import { AppSidebar, type AppView } from "../components/AppSidebar";
 import { ErrorDialog } from "../components/ErrorDialog";
 import { LobbyPage } from "../pages/LobbyPage";
 import { RoomPage } from "../pages/RoomPage";
+import { SettingsPage } from "../pages/SettingsPage";
 import { StatsPage } from "../pages/StatsPage";
-import { runtimeConfig } from "../runtime/runtime-config";
 import { localResultArchiveService } from "../services/result-archive";
 import { statsArchiveService } from "../services/stats-archive";
 import { voiceAnnouncerService } from "../services/voice-announcer";
-import { SettingsPage } from "../pages/SettingsPage";
 import { roomStore, useRoomStore } from "../stores/room-store";
 import { sourceStore } from "../stores/source-store";
 import { useSettingsStore } from "../stores/settings-store";
-
-type AppView = "lobby" | "settings" | "room" | "stats";
-
-function getStatusTone(connectionStatus: string): string {
-  if (connectionStatus === "CONNECTED") {
-    return "ok";
-  }
-  if (connectionStatus === "ERROR" || connectionStatus === "CLOSED") {
-    return "danger";
-  }
-
-  return "warning";
-}
 
 export function App() {
   const savedSettings = useSettingsStore((state) => state.saved);
   const roomSnapshot = useRoomStore((state) => state.snapshot);
   const roomConnectionStatus = useRoomStore((state) => state.connectionStatus);
-  const roomConnectionDetail = useRoomStore((state) => state.connectionDetail);
   const dialog = useRoomStore((state) => state.errorDialog);
   const [activeView, setActiveView] = useState<AppView>("lobby");
 
@@ -67,93 +53,34 @@ export function App() {
     void sourceStore.start(savedSettings, { force: false });
   }, [savedSettings]);
 
+  function navigate(view: AppView): void {
+    startTransition(() => {
+      setActiveView(view);
+    });
+  }
+
   return (
-    <main className="app-shell">
-      <header className="app-header">
-        <div>
-          <p className="eyebrow">PR-12</p>
-          <h1>INFINITAS BPL Client</h1>
-        </div>
-        <div className="header-status">
-          {runtimeConfig.instanceId !== null ? (
-            <div className="status-stack">
-              <span className="status-label">Instance</span>
-              <strong>{runtimeConfig.instanceLabel}</strong>
-              <span className="status-muted">{runtimeConfig.instanceId}</span>
-            </div>
-          ) : null}
-          <div className="status-stack">
-            <span className="status-label">Player</span>
-            <strong>{savedSettings.displayName || "Unnamed player"}</strong>
-            <span className="status-muted">{savedSettings.source}</span>
-          </div>
-          <div className="status-stack">
-            <span className="status-label">Worker API</span>
-            <strong>{savedSettings.apiBaseUrl}</strong>
-            <span className={`status-pill ${getStatusTone(roomConnectionStatus)}`}>{roomConnectionStatus}</span>
-          </div>
-        </div>
-      </header>
+    <main className="flex h-screen w-screen overflow-hidden bg-[#1e1e1e]">
+      <AppSidebar activeView={activeView} hasRoom={roomSnapshot !== null} onNavigate={navigate} />
 
-      <section className="app-layout">
-        <nav className="side-nav">
-          <button
-            type="button"
-            className={activeView === "lobby" ? "nav-button active" : "nav-button"}
-            onClick={() => {
-              setActiveView("lobby");
+      <section className="content-stage custom-scrollbar">
+        {activeView === "lobby" ? (
+          <LobbyPage
+            onEnterRoom={() => {
+              navigate("room");
             }}
-          >
-            Lobby
-          </button>
-          <button
-            type="button"
-            className={activeView === "settings" ? "nav-button active" : "nav-button"}
-            onClick={() => {
-              setActiveView("settings");
+          />
+        ) : null}
+        {activeView === "settings" ? (
+          <SettingsPage
+            roomJoined={roomSnapshot !== null}
+            onNavigateToLobby={() => {
+              navigate("lobby");
             }}
-          >
-            Settings
-          </button>
-          <button
-            type="button"
-            className={activeView === "room" ? "nav-button active" : "nav-button"}
-            disabled={roomSnapshot === null}
-            onClick={() => {
-              setActiveView("room");
-            }}
-          >
-            Room
-          </button>
-          <button
-            type="button"
-            className={activeView === "stats" ? "nav-button active" : "nav-button"}
-            onClick={() => {
-              setActiveView("stats");
-            }}
-          >
-            Stats
-          </button>
-
-          <div className="side-card">
-            <span className="status-label">Room transport</span>
-            <strong>{roomConnectionStatus}</strong>
-            <span className="status-muted">{roomConnectionDetail}</span>
-          </div>
-        </nav>
-
-        <div className="content-stage">
-          {activeView === "lobby" ? (
-            <LobbyPage
-              onEnterRoom={() => {
-                setActiveView("room");
-              }}
-            />
-          ) : null}
-          {activeView === "settings" ? <SettingsPage roomJoined={roomSnapshot !== null} /> : null}
-          {activeView === "room" ? <RoomPage /> : null}
-          {activeView === "stats" ? <StatsPage /> : null}
-        </div>
+          />
+        ) : null}
+        {activeView === "room" ? <RoomPage /> : null}
+        {activeView === "stats" ? <StatsPage /> : null}
       </section>
 
       {dialog ? <ErrorDialog dialog={dialog} onClose={() => roomStore.clearError()} /> : null}

--- a/apps/client/src/components/AppSidebar.tsx
+++ b/apps/client/src/components/AppSidebar.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from "react";
+import { BarChart2, Gamepad2, Home, Settings } from "lucide-react";
+
+export type AppView = "lobby" | "settings" | "room" | "stats";
+
+interface AppSidebarProps {
+  activeView: AppView;
+  hasRoom: boolean;
+  onNavigate: (view: AppView) => void;
+}
+
+export function AppSidebar({ activeView, hasRoom, onNavigate }: AppSidebarProps) {
+  return (
+    <nav className="flex w-[70px] shrink-0 flex-col items-center border-r border-white/5 bg-[#252526] py-6">
+      <div className="flex flex-1 flex-col gap-8">
+        <SidebarButton
+          active={activeView === "lobby"}
+          label="Lobby"
+          onClick={() => onNavigate("lobby")}
+        >
+          <Home size={24} />
+        </SidebarButton>
+        <SidebarButton
+          active={activeView === "stats"}
+          label="Stats"
+          onClick={() => onNavigate("stats")}
+        >
+          <BarChart2 size={24} />
+        </SidebarButton>
+        {hasRoom ? (
+          <SidebarButton
+            active={activeView === "room"}
+            label="Room"
+            onClick={() => onNavigate("room")}
+          >
+            <Gamepad2 size={24} />
+          </SidebarButton>
+        ) : null}
+      </div>
+
+      <SidebarButton
+        active={activeView === "settings"}
+        label="Settings"
+        onClick={() => onNavigate("settings")}
+      >
+        <Settings size={24} />
+      </SidebarButton>
+    </nav>
+  );
+}
+
+interface SidebarButtonProps {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+  children: ReactNode;
+}
+
+function SidebarButton({ active, label, onClick, children }: SidebarButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      title={label}
+      className={`rounded-xl p-3 transition-all ${
+        active
+          ? "border border-cyan-500/30 bg-cyan-500/20 text-cyan-400 shadow-[0_0_15px_rgba(6,182,212,0.2)]"
+          : "text-gray-500 hover:bg-white/5"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/client/src/pages/RoomPage.tsx
+++ b/apps/client/src/pages/RoomPage.tsx
@@ -16,7 +16,7 @@ import { useLocalResultArchiveStore } from "../services/result-archive";
 import { listCharts } from "../services/worker-api-client";
 import { useVoicePlaybackStore } from "../services/voice-announcer";
 import { roomStore, useRoomStore } from "../stores/room-store";
-import { useSettingsStore } from "../stores/settings-store";
+import { isVoicePlaybackEnabled, useSettingsStore } from "../stores/settings-store";
 import { formatDateTime, stringifyJson } from "../utils/format";
 
 function formatExpectedKey(
@@ -490,7 +490,13 @@ export function RoomPage() {
               <span className="status-label">Sound playback</span>
               <span className={`status-pill ${getVoiceTone(voicePhase)}`}>{voicePhase}</span>
             </div>
-            <strong>{savedSettings.voiceEnabled ? "Sound enabled" : "Sound disabled"}</strong>
+            <strong>
+              {savedSettings.voiceMuted
+                ? "Sound muted"
+                : isVoicePlaybackEnabled(savedSettings)
+                  ? `Volume ${savedSettings.voiceVolume}`
+                  : "Sound disabled"}
+            </strong>
             <span className="status-muted">{voiceDetail}</span>
             <span className="status-muted">Pending cues: {voicePendingCues}</span>
             <span className="status-muted">Updated: {formatDateTime(voiceLastUpdatedAt)}</span>

--- a/apps/client/src/pages/SettingsPage.tsx
+++ b/apps/client/src/pages/SettingsPage.tsx
@@ -1,257 +1,304 @@
-import { SOURCE_TYPES } from "@infinitas/shared";
-import { sourceStore, useSourceStore } from "../stores/source-store";
-import { settingsStore, useSettingsStore } from "../stores/settings-store";
+import { useEffect, useState } from "react";
+import { ChevronLeft, Database, FolderOpen, Save, User, Volume2, VolumeX } from "lucide-react";
+import { pickDirectory, validateSourceDirectory } from "../services/tauri-bridge";
+import { sourceStore } from "../stores/source-store";
+import { getActiveSourceDirectory, settingsStore, useSettingsStore } from "../stores/settings-store";
 import { formatDateTime } from "../utils/format";
 
 interface SettingsPageProps {
   roomJoined: boolean;
+  onNavigateToLobby: () => void;
 }
 
-async function copyToClipboard(text: string): Promise<boolean> {
-  if (typeof navigator === "undefined" || !navigator.clipboard) {
-    return false;
-  }
+const SOURCE_OPTIONS = [
+  {
+    id: "inf_daken_counter" as const,
+    name: "打鍵カウンタ",
+    description: "today_update.xml を監視",
+    label: "Daken Counter Directory",
+    placeholder: "C:\\Games\\beatmania IIDX INFINITAS\\data",
+  },
+  {
+    id: "inf-notebook" as const,
+    name: "リザルト手帳",
+    description: "recent.json を監視",
+    label: "Result Notebook Directory",
+    placeholder: "C:\\Users\\you\\Documents\\inf-notebook",
+  },
+];
 
-  try {
-    await navigator.clipboard.writeText(text);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-export function SettingsPage({ roomJoined }: SettingsPageProps) {
+export function SettingsPage({ roomJoined, onNavigateToLobby }: SettingsPageProps) {
   const draft = useSettingsStore((state) => state.draft);
   const statusMessage = useSettingsStore((state) => state.statusMessage);
   const lastSavedAt = useSettingsStore((state) => state.lastSavedAt);
-  const watcherState = useSourceStore((state) => state.watcherState);
-  const lastWatcherEvent = useSourceStore((state) => state.lastEvent);
+  const [displayNameError, setDisplayNameError] = useState<string | null>(null);
+  const [validationMessage, setValidationMessage] = useState<string | null>(null);
+
+  const activeDirectory = getActiveSourceDirectory(draft);
+  const activeOption = getSourceOption(draft.source);
+
+  useEffect(() => {
+    settingsStore.restoreDraftFromSaved();
+    setDisplayNameError(null);
+    setValidationMessage(null);
+  }, []);
+
+  async function handleBrowseDirectory(): Promise<void> {
+    try {
+      const selectedDirectory = await pickDirectory();
+      if (selectedDirectory !== null) {
+        settingsStore.updateSourceDirectory(draft.source, selectedDirectory);
+        setValidationMessage(null);
+      }
+    } catch (error) {
+      settingsStore.setStatusMessage(formatUnknownError(error, "Failed to open the directory picker."));
+    }
+  }
+
+  async function handleSave(): Promise<void> {
+    settingsStore.setStatusMessage(null);
+
+    const nextDisplayNameError = validateDisplayName(draft.displayName);
+    if (nextDisplayNameError !== null) {
+      setDisplayNameError(nextDisplayNameError);
+      return;
+    }
+
+    setDisplayNameError(null);
+
+    if (activeDirectory.trim().length === 0) {
+      setValidationMessage("先に監視元フォルダを指定してください。");
+      return;
+    }
+
+    try {
+      setValidationMessage(null);
+      const validation = await validateSourceDirectory({
+        source: draft.source,
+        directoryPath: activeDirectory,
+      });
+
+      if (validation.missingPaths.length > 0) {
+        setValidationMessage(`必須ファイルが見つかりません: ${validation.missingPaths.join(" / ")}`);
+        return;
+      }
+
+      settingsStore.save();
+      await sourceStore.start(settingsStore.getState().saved, { force: false });
+    } catch (error) {
+      setValidationMessage(formatUnknownError(error, "監視元フォルダの検証に失敗しました。"));
+    }
+  }
 
   return (
-    <section className="page-grid">
-      <article className="panel">
-        <div className="panel-header">
-          <div>
-            <p className="eyebrow">Settings</p>
-            <h2>Local player profile</h2>
-          </div>
-          <span className={`status-pill ${roomJoined ? "warning" : "ok"}`}>
-            {roomJoined ? "Source locked in room" : "Ready to edit"}
-          </span>
-        </div>
+    <main className="mx-auto flex w-full max-w-6xl flex-col gap-12">
+      <header className="mb-2">
+        <button
+          type="button"
+          onClick={onNavigateToLobby}
+          className="group mb-4 flex items-center gap-2 text-sm font-bold text-gray-500 transition-colors hover:text-white"
+        >
+          <ChevronLeft size={18} className="transition-transform group-hover:-translate-x-1" />
+          ロビーに戻る
+        </button>
+        <h1 className="text-4xl font-black uppercase tracking-tighter text-white italic">System Settings</h1>
+      </header>
 
-        <div className="form-grid">
-          <label className="field">
-            <span>Display name</span>
+      <div className="space-y-12">
+        <section className="space-y-6">
+          <div className="flex items-center gap-3 border-b border-white/5 pb-4">
+            <User size={20} className="text-cyan-400" />
+            <h2 className="text-sm font-black uppercase tracking-widest text-gray-400">User Profile</h2>
+          </div>
+
+          <div className="max-w-md space-y-2">
+            <label className="text-[10px] font-black uppercase text-gray-500">Display Name</label>
             <input
               type="text"
               value={draft.displayName}
               onChange={(event) => {
-                settingsStore.update("displayName", event.currentTarget.value);
+                const nextValue = event.currentTarget.value;
+                settingsStore.update("displayName", nextValue);
+                setDisplayNameError(validateDisplayName(nextValue));
               }}
-              placeholder="DJ name"
+              placeholder="PLAYER_NAME"
+              className="w-full rounded-xl border border-white/10 bg-[#252526] p-4 font-bold text-white outline-none transition-all placeholder:text-gray-600 focus:border-cyan-500"
             />
-          </label>
+            {displayNameError ? <p className="text-sm font-semibold text-red-400">{displayNameError}</p> : null}
+          </div>
+        </section>
 
-          <label className="field">
-            <span>Worker API URL</span>
-            <input
-              type="url"
-              value={draft.apiBaseUrl}
-              onChange={(event) => {
-                settingsStore.update("apiBaseUrl", event.currentTarget.value);
-              }}
-              placeholder="http://127.0.0.1:8787"
-            />
-          </label>
+        <section className="space-y-6">
+          <div className="flex items-center gap-3 border-b border-white/5 pb-4">
+            <Database size={20} className="text-cyan-400" />
+            <div className="flex flex-wrap items-center gap-3">
+              <h2 className="text-sm font-black uppercase tracking-widest text-gray-400">Data Source</h2>
+              <span
+                className={`rounded-full px-3 py-1 text-[10px] font-black uppercase tracking-[0.2em] ${
+                  roomJoined ? "bg-amber-500/20 text-amber-300" : "bg-cyan-500/10 text-cyan-300"
+                }`}
+              >
+                {roomJoined ? "Locked In Room" : "Ready"}
+              </span>
+            </div>
+          </div>
 
-          <label className="field">
-            <span>Player ID</span>
-            <div className="inline-field">
-              <input type="text" value={draft.playerId} readOnly />
+          <div className="grid max-w-2xl gap-4 md:grid-cols-2">
+            {SOURCE_OPTIONS.map((option) => (
+              <button
+                key={option.id}
+                type="button"
+                disabled={roomJoined}
+                onClick={() => {
+                  settingsStore.update("source", option.id);
+                  setValidationMessage(null);
+                }}
+                className={`flex flex-col gap-2 rounded-2xl border p-6 text-left transition-all ${
+                  draft.source === option.id
+                    ? "border-cyan-500 bg-cyan-500/10 shadow-[0_0_20px_rgba(6,182,212,0.1)]"
+                    : "border-white/5 bg-[#252526] hover:border-white/20"
+                } ${roomJoined ? "cursor-not-allowed opacity-70" : ""}`}
+              >
+                <span className={`text-lg font-bold ${draft.source === option.id ? "text-cyan-400" : "text-white"}`}>
+                  {option.name}
+                </span>
+                <span className="text-xs text-gray-500">{option.description}</span>
+              </button>
+            ))}
+          </div>
+
+          <div className="space-y-3">
+            <label className="text-[10px] font-black uppercase italic tracking-wider text-gray-500">
+              {activeOption.label}
+            </label>
+            <div className="flex max-w-3xl flex-col gap-3 md:flex-row">
+              <input
+                type="text"
+                value={activeDirectory}
+                disabled={roomJoined}
+                onChange={(event) => {
+                  settingsStore.updateSourceDirectory(draft.source, event.currentTarget.value);
+                  setValidationMessage(null);
+                }}
+                placeholder={activeOption.placeholder}
+                className="flex-1 rounded-xl border border-white/5 bg-[#151515] px-4 py-3 text-sm font-mono text-gray-300 outline-none placeholder:text-gray-600 disabled:cursor-not-allowed disabled:opacity-70"
+              />
               <button
                 type="button"
-                className="secondary-button"
-                onClick={async () => {
-                  const copied = await copyToClipboard(draft.playerId);
-                  settingsStore.setStatusMessage(copied ? "Player ID copied." : "Clipboard unavailable.");
+                disabled={roomJoined}
+                onClick={() => {
+                  void handleBrowseDirectory();
                 }}
+                className="flex items-center justify-center gap-2 rounded-xl border border-white/10 bg-[#2d2d30] px-6 py-3 text-sm font-bold text-white transition-all active:scale-95 hover:bg-[#353538] disabled:cursor-not-allowed disabled:opacity-70"
               >
-                Copy
+                <FolderOpen size={18} />
+                参照
               </button>
             </div>
-          </label>
-
-          <label className="field">
-            <span>Source</span>
-            <select
-              value={draft.source}
-              disabled={roomJoined}
-              onChange={(event) => {
-                settingsStore.update("source", event.currentTarget.value as (typeof SOURCE_TYPES)[number]);
-              }}
-            >
-              {SOURCE_TYPES.map((source) => (
-                <option key={source} value={source}>
-                  {source}
-                </option>
-              ))}
-            </select>
-          </label>
-
-          <label className="field full-width">
-            <span>inf_daken_counter / today_update.xml</span>
-            <input
-              type="text"
-              value={draft.sourcePaths.dakenTodayUpdateXml}
-              onChange={(event) => {
-                settingsStore.updateSourcePath("dakenTodayUpdateXml", event.currentTarget.value);
-              }}
-              placeholder="C:\\path\\to\\today_update.xml"
-            />
-          </label>
-
-          <label className="field full-width">
-            <span>inf-notebook / export/recent.json</span>
-            <input
-              type="text"
-              value={draft.sourcePaths.notebookExportRecentJson}
-              onChange={(event) => {
-                settingsStore.updateSourcePath("notebookExportRecentJson", event.currentTarget.value);
-              }}
-              placeholder="C:\\path\\to\\export\\recent.json"
-            />
-          </label>
-
-          <label className="field full-width">
-            <span>inf-notebook / records/recent.json</span>
-            <input
-              type="text"
-              value={draft.sourcePaths.notebookRecordsRecentJson}
-              onChange={(event) => {
-                settingsStore.updateSourcePath("notebookRecordsRecentJson", event.currentTarget.value);
-              }}
-              placeholder="Optional"
-            />
-          </label>
-
-          <label className="field toggle-field">
-            <span>Sound notifications</span>
-            <input
-              type="checkbox"
-              checked={draft.voiceEnabled}
-              onChange={(event) => {
-                settingsStore.update("voiceEnabled", event.currentTarget.checked);
-              }}
-            />
-          </label>
-        </div>
-
-        <div className="panel-footer">
-          <div className="status-stack">
-            <span className="status-label">Watcher state</span>
-            <div className="inline-field">
-              <strong>{watcherState.status}</strong>
-              <span className={`status-pill ${getWatcherTone(watcherState.status)}`}>
-                {watcherState.status}
-              </span>
-            </div>
-            <span className="status-muted">{watcherState.detail}</span>
+            <p className="text-xs text-gray-500">
+              {draft.source === "inf_daken_counter"
+                ? "選択したフォルダ配下の today_update.xml を自動で監視します。"
+                : "選択したフォルダ配下の export/recent.json と records/recent.json を自動で監視します。"}
+            </p>
+            {validationMessage ? <p className="text-sm font-semibold text-red-400">{validationMessage}</p> : null}
           </div>
-          <div className="button-row">
+
+        </section>
+
+        <section className="space-y-6">
+          <div className="flex items-center gap-3 border-b border-white/5 pb-4">
+            <Volume2 size={20} className="text-cyan-400" />
+            <h2 className="text-sm font-black uppercase tracking-widest text-gray-400">Audio Notice</h2>
+          </div>
+
+          <div className="max-w-md space-y-6 rounded-2xl border border-white/5 bg-[#252526] p-8">
+            <div className="flex items-end justify-between gap-4">
+              <div className="space-y-1">
+                <label className="text-[10px] font-black uppercase text-gray-400">Master Volume</label>
+                <div className="text-3xl font-black italic text-white">
+                  {draft.voiceMuted ? "MUTE" : draft.voiceVolume}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  settingsStore.updateVoiceMuted(!draft.voiceMuted);
+                }}
+                className={`rounded-xl p-3 transition-all ${
+                  draft.voiceMuted
+                    ? "border border-red-500/30 bg-red-500/20 text-red-400"
+                    : "bg-white/5 text-gray-400 hover:text-white"
+                }`}
+              >
+                {draft.voiceMuted ? <VolumeX size={24} /> : <Volume2 size={24} />}
+              </button>
+            </div>
+
+            <input
+              type="range"
+              min="0"
+              max="100"
+              value={draft.voiceVolume}
+              disabled={draft.voiceMuted}
+              onChange={(event) => {
+                settingsStore.updateVoiceVolume(Number(event.currentTarget.value));
+              }}
+              className="h-1.5 w-full cursor-pointer appearance-none rounded-lg bg-[#1e1e1e] accent-cyan-500 disabled:cursor-not-allowed"
+            />
+
+            <div className="flex justify-between text-[10px] font-black uppercase tracking-tighter text-gray-600">
+              <span>Min</span>
+              <span>Max</span>
+            </div>
+          </div>
+        </section>
+
+        <footer className="space-y-3 pt-4">
+          <p className="text-sm text-gray-400">{statusMessage ?? "Ready to save local settings."}</p>
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            
             <button
               type="button"
-              className="secondary-button"
               onClick={() => {
-                void sourceStore.start(draft, { force: true });
+                void handleSave();
               }}
+              className="flex items-center justify-center gap-3 rounded-xl bg-cyan-500 px-10 py-4 font-black text-black shadow-[0_10px_30px_rgba(6,182,212,0.3)] transition-all active:scale-95 hover:bg-cyan-400"
             >
-              Restart watcher
-            </button>
-            <button
-              type="button"
-              className="secondary-button"
-              onClick={() => {
-                void sourceStore.stop();
-              }}
-            >
-              Stop watcher
-            </button>
-            <button type="button" className="secondary-button" onClick={() => settingsStore.resetDraft()}>
-              Reset draft
-            </button>
-            <button
-              type="button"
-              className="primary-button"
-              onClick={() => {
-                settingsStore.save();
-                void sourceStore.start(settingsStore.getState().saved, { force: true });
-              }}
-            >
-              Save settings
+              <Save size={20} />
+              設定を保存して反映
             </button>
           </div>
-        </div>
-
-        <div className="panel-subsection watcher-block">
-          <div className="meta-grid compact">
-            <div className="status-stack">
-              <span className="status-label">Active source</span>
-              <strong>{watcherState.source ?? "-"}</strong>
-              <span className="status-muted">Saved source and path selection.</span>
-            </div>
-            <div className="status-stack">
-              <span className="status-label">Last watcher update</span>
-              <strong>{formatDateTime(watcherState.lastEventAt)}</strong>
-              <span className="status-muted">State transition or file event.</span>
-            </div>
-            <div className="status-stack">
-              <span className="status-label">Last event kind</span>
-              <strong>{lastWatcherEvent?.kind ?? "-"}</strong>
-              <span className="status-muted">{lastWatcherEvent?.detail ?? "No file events yet."}</span>
-            </div>
-            <div className="status-stack">
-              <span className="status-label">Last file</span>
-              <strong>{lastWatcherEvent?.filePath ?? "-"}</strong>
-              <span className="status-muted">
-                {lastWatcherEvent?.parserOutput
-                  ? `${lastWatcherEvent.parserOutput.fileSizeBytes.toLocaleString()} bytes / ${lastWatcherEvent.parserOutput.observations.length} observation(s)`
-                  : "Parser payload not available."}
-              </span>
-            </div>
-          </div>
-
-          <div className="status-stack watcher-path-list">
-            <span className="status-label">Watched paths</span>
-            {watcherState.watchedPaths.length === 0 ? (
-              <span className="status-muted">No active watch targets.</span>
-            ) : (
-              watcherState.watchedPaths.map((path) => (
-                <code key={path} className="path-chip">
-                  {path}
-                </code>
-              ))
-            )}
-          </div>
-        </div>
-
-        <div className="meta-strip">
-          <span>{statusMessage ?? "Idle."}</span>
-          <span>Last saved: {formatDateTime(lastSavedAt)}</span>
-        </div>
-      </article>
-    </section>
+        </footer>
+      </div>
+    </main>
   );
 }
 
-function getWatcherTone(status: string): string {
-  if (status === "RUNNING") {
-    return "ok";
+function getSourceOption(source: "inf_daken_counter" | "inf-notebook") {
+  return SOURCE_OPTIONS.find((option) => option.id === source) ?? SOURCE_OPTIONS[0]!;
+}
+
+function formatUnknownError(error: unknown, fallback: string): string {
+  if (error instanceof Error) {
+    return error.message;
   }
 
-  if (status === "ERROR" || status === "UNAVAILABLE") {
-    return "danger";
+  if (typeof error === "string" && error.trim().length > 0) {
+    return error;
   }
 
-  return "warning";
+  return fallback;
+}
+
+function validateDisplayName(value: string): string | null {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return "Display Name は必須です。";
+  }
+
+  if (Array.from(trimmed).length > 10) {
+    return "Display Name は10文字以内で入力してください。";
+  }
+
+  return null;
 }

--- a/apps/client/src/services/tauri-bridge.ts
+++ b/apps/client/src/services/tauri-bridge.ts
@@ -45,6 +45,15 @@ interface StartSourceWatcherRequest {
   sourcePaths: SourcePaths;
 }
 
+interface ValidateSourceDirectoryRequest {
+  source: SourceType;
+  directoryPath: string;
+}
+
+export interface ValidateSourceDirectoryResponse {
+  missingPaths: string[];
+}
+
 export interface SaveLocalResultJsonRequest {
   roomId: string;
   createdAt: string | null;
@@ -126,6 +135,26 @@ export async function saveLocalResultJson(
 
   const { invoke } = await import("@tauri-apps/api/core");
   return invoke<SaveLocalResultJsonResponse>("save_local_result_json", { request });
+}
+
+export async function pickDirectory(): Promise<string | null> {
+  if (!isTauriRuntime()) {
+    throw new Error("Directory picker is available only inside the Tauri desktop app.");
+  }
+
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<string | null>("pick_directory");
+}
+
+export async function validateSourceDirectory(
+  request: ValidateSourceDirectoryRequest,
+): Promise<ValidateSourceDirectoryResponse> {
+  if (!isTauriRuntime()) {
+    return { missingPaths: [] };
+  }
+
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<ValidateSourceDirectoryResponse>("validate_source_directory", { request });
 }
 
 export async function speakNativeTts(request: NativeTtsSpeakRequest): Promise<void> {

--- a/apps/client/src/services/voice-announcer.ts
+++ b/apps/client/src/services/voice-announcer.ts
@@ -12,7 +12,7 @@ import {
 } from "@infinitas/shared";
 import { createExternalStore, useExternalStore } from "../stores/create-store";
 import { roomStore, type RoomAudioEvent } from "../stores/room-store";
-import { settingsStore } from "../stores/settings-store";
+import { getVoicePlaybackVolume, isVoicePlaybackEnabled, settingsStore } from "../stores/settings-store";
 
 const RECENT_CUE_GRACE_MS = 3_000;
 
@@ -115,13 +115,13 @@ function resetRoomPlayback(roomId: string | null): void {
     return;
   }
 
-  clearPlayback("IDLE", "Sound cues idle.", settingsStore.getState().saved.voiceEnabled);
+  clearPlayback("IDLE", "Sound cues idle.", isVoicePlaybackEnabled(settingsStore.getState().saved));
   activeRoomId = roomId;
   playedEventIds.clear();
   lastPlayedAtByKind.clear();
   setVoiceState({
     phase: "IDLE",
-    enabled: settingsStore.getState().saved.voiceEnabled,
+    enabled: isVoicePlaybackEnabled(settingsStore.getState().saved),
     pendingCues: 0,
     detail: roomId === null ? "Sound cues idle." : `Sound cues reset for room ${roomId}.`,
     roundToken: null,
@@ -201,7 +201,7 @@ function shouldSuppressCue(cue: ScheduledCue): boolean {
 }
 
 async function playCue(cue: ScheduledCue): Promise<void> {
-  if (shouldSuppressCue(cue) || !settingsStore.getState().saved.voiceEnabled) {
+  if (shouldSuppressCue(cue) || !isVoicePlaybackEnabled(settingsStore.getState().saved)) {
     return;
   }
 
@@ -209,6 +209,7 @@ async function playCue(cue: ScheduledCue): Promise<void> {
   lastPlayedAtByKind.set(cue.kind, Date.now());
 
   const audio = new Audio(SOUND_EFFECT_URLS[cue.kind]);
+  audio.volume = getVoicePlaybackVolume(settingsStore.getState().saved);
   activeAudios.add(audio);
   const cleanup = () => {
     activeAudios.delete(audio);
@@ -310,7 +311,7 @@ function syncVoicePlayback(): void {
 
   resetRoomPlayback(snapshot?.room_id ?? null);
 
-  if (!savedSettings.voiceEnabled) {
+  if (!isVoicePlaybackEnabled(savedSettings)) {
     clearPlayback("DISABLED", "Sound notifications are turned off.", false);
     return;
   }
@@ -349,7 +350,7 @@ export const voiceAnnouncerService = {
     unsubscribeSettingsStore?.();
     unsubscribeRoomStore = null;
     unsubscribeSettingsStore = null;
-    clearPlayback("IDLE", "Sound cues idle.", settingsStore.getState().saved.voiceEnabled);
+    clearPlayback("IDLE", "Sound cues idle.", isVoicePlaybackEnabled(settingsStore.getState().saved));
   },
 };
 

--- a/apps/client/src/stores/settings-store.ts
+++ b/apps/client/src/stores/settings-store.ts
@@ -5,11 +5,17 @@ import { createExternalStore, useExternalStore } from "./create-store";
 
 const SETTINGS_STORAGE_KEY = "infinitas.client.settings.v1";
 const DEFAULT_API_BASE_URL = "http://127.0.0.1:8787";
+const DEFAULT_VOICE_VOLUME = 80;
 
 export interface SourcePaths {
   dakenTodayUpdateXml: string;
   notebookExportRecentJson: string;
   notebookRecordsRecentJson: string;
+}
+
+export interface SourceDirectories {
+  dakenDirectory: string;
+  notebookDirectory: string;
 }
 
 export interface ClientSettings {
@@ -18,7 +24,10 @@ export interface ClientSettings {
   displayName: string;
   source: SourceType;
   sourcePaths: SourcePaths;
+  sourceDirectories: SourceDirectories;
   voiceEnabled: boolean;
+  voiceVolume: number;
+  voiceMuted: boolean;
 }
 
 export interface SettingsStoreState {
@@ -34,7 +43,10 @@ interface PartialClientSettings {
   displayName?: string;
   source?: string;
   sourcePaths?: Partial<SourcePaths>;
+  sourceDirectories?: Partial<SourceDirectories>;
   voiceEnabled?: boolean;
+  voiceVolume?: number;
+  voiceMuted?: boolean;
 }
 
 function createDefaultSourcePaths(): SourcePaths {
@@ -42,6 +54,13 @@ function createDefaultSourcePaths(): SourcePaths {
     dakenTodayUpdateXml: "",
     notebookExportRecentJson: "",
     notebookRecordsRecentJson: "",
+  };
+}
+
+function createDefaultSourceDirectories(): SourceDirectories {
+  return {
+    dakenDirectory: "",
+    notebookDirectory: "",
   };
 }
 
@@ -54,41 +73,207 @@ function normalizeBaseUrl(value: string | undefined): string {
   return (trimmed.length === 0 ? DEFAULT_API_BASE_URL : trimmed).replace(/\/+$/, "");
 }
 
+function normalizeDirectory(value: string | undefined): string {
+  const trimmed = value?.trim() ?? "";
+  if (trimmed.length === 0) {
+    return "";
+  }
+
+  if (/^[A-Za-z]:[\\/]?$/.test(trimmed)) {
+    return `${trimmed.slice(0, 2)}\\`;
+  }
+
+  if (/^[\\/]+$/.test(trimmed)) {
+    return "/";
+  }
+
+  return trimmed.replace(/[\\/]+$/, "");
+}
+
+function normalizeVoiceVolume(value: number | undefined): number {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return DEFAULT_VOICE_VOLUME;
+  }
+
+  return Math.min(100, Math.max(0, Math.round(value)));
+}
+
+function inferSeparator(path: string): "/" | "\\" {
+  return path.includes("\\") ? "\\" : "/";
+}
+
+function joinPath(directory: string, segments: string[]): string {
+  const normalizedDirectory = normalizeDirectory(directory);
+  if (normalizedDirectory.length === 0) {
+    return "";
+  }
+
+  if (normalizedDirectory === "/") {
+    return `/${segments.join("/")}`;
+  }
+
+  const separator = inferSeparator(normalizedDirectory);
+  if (normalizedDirectory.endsWith(separator)) {
+    return `${normalizedDirectory}${segments.join(separator)}`;
+  }
+
+  return [normalizedDirectory, ...segments].join(separator);
+}
+
+function extractParentDirectory(filePath: string | undefined): string {
+  const trimmed = filePath?.trim() ?? "";
+  if (trimmed.length === 0) {
+    return "";
+  }
+
+  const parent = trimmed.replace(/[\\/][^\\/]+$/, "");
+  return normalizeDirectory(parent === trimmed ? trimmed : parent);
+}
+
+function extractNotebookDirectory(paths: Partial<SourcePaths>): string {
+  const candidate = paths.notebookExportRecentJson?.trim() || paths.notebookRecordsRecentJson?.trim() || "";
+  if (candidate.length === 0) {
+    return "";
+  }
+
+  const withoutSuffix = candidate
+    .replace(/[\\/]export[\\/]recent\.json$/i, "")
+    .replace(/[\\/]records[\\/]recent\.json$/i, "");
+
+  return normalizeDirectory(withoutSuffix === candidate ? extractParentDirectory(candidate) : withoutSuffix);
+}
+
+function deriveSourceDirectories(paths: Partial<SourcePaths>): SourceDirectories {
+  const dakenCandidate = paths.dakenTodayUpdateXml?.trim() ?? "";
+
+  return {
+    dakenDirectory:
+      dakenCandidate.length === 0
+        ? ""
+        : normalizeDirectory(dakenCandidate.replace(/[\\/]today_update\.xml$/i, "")) || extractParentDirectory(dakenCandidate),
+    notebookDirectory: extractNotebookDirectory(paths),
+  };
+}
+
+export function deriveSourcePaths(sourceDirectories: SourceDirectories): SourcePaths {
+  return {
+    dakenTodayUpdateXml:
+      sourceDirectories.dakenDirectory.length === 0
+        ? ""
+        : joinPath(sourceDirectories.dakenDirectory, ["today_update.xml"]),
+    notebookExportRecentJson:
+      sourceDirectories.notebookDirectory.length === 0
+        ? ""
+        : joinPath(sourceDirectories.notebookDirectory, ["export", "recent.json"]),
+    notebookRecordsRecentJson:
+      sourceDirectories.notebookDirectory.length === 0
+        ? ""
+        : joinPath(sourceDirectories.notebookDirectory, ["records", "recent.json"]),
+  };
+}
+
+function normalizeVoiceSettings(rawSettings: PartialClientSettings | null): Pick<ClientSettings, "voiceEnabled" | "voiceMuted" | "voiceVolume"> {
+  const voiceVolume = normalizeVoiceVolume(rawSettings?.voiceVolume);
+  const voiceMuted = rawSettings?.voiceMuted ?? rawSettings?.voiceEnabled === false;
+
+  return {
+    voiceVolume,
+    voiceMuted,
+    voiceEnabled: !voiceMuted && voiceVolume > 0,
+  };
+}
+
 function createDefaultSettings(): ClientSettings {
-  const defaultSourcePaths = createDefaultSourcePaths();
+  const runtimePaths: SourcePaths = {
+    dakenTodayUpdateXml: runtimeConfig.settingsDefaults.sourcePaths.dakenTodayUpdateXml ?? "",
+    notebookExportRecentJson: runtimeConfig.settingsDefaults.sourcePaths.notebookExportRecentJson ?? "",
+    notebookRecordsRecentJson: runtimeConfig.settingsDefaults.sourcePaths.notebookRecordsRecentJson ?? "",
+  };
+  const sourceDirectories = {
+    ...createDefaultSourceDirectories(),
+    ...deriveSourceDirectories(runtimePaths),
+  };
+  const sourcePaths = {
+    ...createDefaultSourcePaths(),
+    ...runtimePaths,
+    ...deriveSourcePaths(sourceDirectories),
+  };
+
   return {
     apiBaseUrl: normalizeBaseUrl(runtimeConfig.settingsDefaults.apiBaseUrl),
     playerId: runtimeConfig.settingsDefaults.playerId?.trim() || crypto.randomUUID(),
     displayName: runtimeConfig.settingsDefaults.displayName?.trim() ?? "",
     source: normalizeSource(runtimeConfig.settingsDefaults.source),
-    sourcePaths: {
-      dakenTodayUpdateXml:
-        runtimeConfig.settingsDefaults.sourcePaths.dakenTodayUpdateXml ??
-        defaultSourcePaths.dakenTodayUpdateXml,
-      notebookExportRecentJson:
-        runtimeConfig.settingsDefaults.sourcePaths.notebookExportRecentJson ??
-        defaultSourcePaths.notebookExportRecentJson,
-      notebookRecordsRecentJson:
-        runtimeConfig.settingsDefaults.sourcePaths.notebookRecordsRecentJson ??
-        defaultSourcePaths.notebookRecordsRecentJson,
-    },
+    sourcePaths,
+    sourceDirectories,
     voiceEnabled: true,
+    voiceVolume: DEFAULT_VOICE_VOLUME,
+    voiceMuted: false,
   };
 }
 
 function normalizeSettings(rawSettings: PartialClientSettings | null): ClientSettings {
   const defaults = createDefaultSettings();
+  const normalizedRawDirectories: Partial<SourceDirectories> = {};
+  if (rawSettings?.sourceDirectories?.dakenDirectory !== undefined) {
+    normalizedRawDirectories.dakenDirectory = normalizeDirectory(rawSettings.sourceDirectories.dakenDirectory);
+  }
+  if (rawSettings?.sourceDirectories?.notebookDirectory !== undefined) {
+    normalizedRawDirectories.notebookDirectory = normalizeDirectory(rawSettings.sourceDirectories.notebookDirectory);
+  }
+  const pathHints: SourcePaths = {
+    ...defaults.sourcePaths,
+    ...rawSettings?.sourcePaths,
+  };
+  const sourceDirectories = {
+    ...defaults.sourceDirectories,
+    ...deriveSourceDirectories(pathHints),
+    ...normalizedRawDirectories,
+  };
+  const sourcePaths = {
+    ...defaults.sourcePaths,
+    ...pathHints,
+    ...deriveSourcePaths(sourceDirectories),
+  };
+  const voiceSettings = normalizeVoiceSettings(rawSettings);
+
   return {
     apiBaseUrl: normalizeBaseUrl(rawSettings?.apiBaseUrl ?? defaults.apiBaseUrl),
     playerId: rawSettings?.playerId?.trim() || defaults.playerId,
     displayName: rawSettings?.displayName?.trim() ?? defaults.displayName,
     source: normalizeSource(rawSettings?.source ?? defaults.source),
-    sourcePaths: {
-      ...defaults.sourcePaths,
-      ...rawSettings?.sourcePaths,
-    },
-    voiceEnabled: rawSettings?.voiceEnabled ?? true,
+    sourcePaths,
+    sourceDirectories,
+    ...voiceSettings,
   };
+}
+
+function syncVoiceDraft(draft: ClientSettings): ClientSettings {
+  const voiceEnabled = !draft.voiceMuted && draft.voiceVolume > 0;
+  return {
+    ...draft,
+    voiceEnabled,
+  };
+}
+
+export function getActiveSourceDirectory(settings: Pick<ClientSettings, "source" | "sourceDirectories">): string {
+  return settings.source === "inf_daken_counter"
+    ? settings.sourceDirectories.dakenDirectory
+    : settings.sourceDirectories.notebookDirectory;
+}
+
+export function isVoicePlaybackEnabled(
+  settings: Pick<ClientSettings, "voiceEnabled" | "voiceMuted" | "voiceVolume">,
+): boolean {
+  return settings.voiceEnabled && !settings.voiceMuted && settings.voiceVolume > 0;
+}
+
+export function getVoicePlaybackVolume(settings: Pick<ClientSettings, "voiceMuted" | "voiceVolume">): number {
+  if (settings.voiceMuted) {
+    return 0;
+  }
+
+  return normalizeVoiceVolume(settings.voiceVolume) / 100;
 }
 
 const initialSettings = normalizeSettings(readJson<PartialClientSettings | null>(SETTINGS_STORAGE_KEY, null));
@@ -105,23 +290,54 @@ export const settingsStore = {
   update<K extends keyof ClientSettings>(key: K, value: ClientSettings[K]): void {
     internalStore.setState((state) => ({
       ...state,
-      draft: {
+      draft: syncVoiceDraft({
         ...state.draft,
         [key]: value,
-      },
+      }),
       statusMessage: null,
     }));
   },
-  updateSourcePath<K extends keyof SourcePaths>(key: K, value: SourcePaths[K]): void {
+  updateSourceDirectory(source: SourceType, directory: string): void {
+    internalStore.setState((state) => {
+      const sourceDirectories =
+        source === "inf_daken_counter"
+          ? {
+              ...state.draft.sourceDirectories,
+              dakenDirectory: normalizeDirectory(directory),
+            }
+          : {
+              ...state.draft.sourceDirectories,
+              notebookDirectory: normalizeDirectory(directory),
+            };
+
+      return {
+        ...state,
+        draft: {
+          ...state.draft,
+          sourceDirectories,
+          sourcePaths: deriveSourcePaths(sourceDirectories),
+        },
+        statusMessage: null,
+      };
+    });
+  },
+  updateVoiceVolume(value: number): void {
     internalStore.setState((state) => ({
       ...state,
-      draft: {
+      draft: syncVoiceDraft({
         ...state.draft,
-        sourcePaths: {
-          ...state.draft.sourcePaths,
-          [key]: value,
-        },
-      },
+        voiceVolume: normalizeVoiceVolume(value),
+      }),
+      statusMessage: null,
+    }));
+  },
+  updateVoiceMuted(value: boolean): void {
+    internalStore.setState((state) => ({
+      ...state,
+      draft: syncVoiceDraft({
+        ...state.draft,
+        voiceMuted: value,
+      }),
       statusMessage: null,
     }));
   },
@@ -134,6 +350,13 @@ export const settingsStore = {
       saved: normalized,
       lastSavedAt: new Date().toISOString(),
       statusMessage: "Saved local settings.",
+    }));
+  },
+  restoreDraftFromSaved(): void {
+    internalStore.setState((state) => ({
+      ...state,
+      draft: state.saved,
+      statusMessage: null,
     }));
   },
   resetDraft(): void {

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -1,13 +1,14 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 :root {
-  color-scheme: light;
+  color-scheme: dark;
   font-family: "Segoe UI", "Yu Gothic UI", sans-serif;
   line-height: 1.5;
   font-weight: 400;
   color: #162032;
-  background:
-    radial-gradient(circle at top left, rgba(255, 214, 153, 0.6), transparent 30%),
-    radial-gradient(circle at top right, rgba(100, 171, 255, 0.35), transparent 25%),
-    linear-gradient(180deg, #f3efe4 0%, #d8e2f0 100%);
+  background: #1e1e1e;
 }
 
 * {
@@ -17,6 +18,11 @@
 body {
   margin: 0;
   min-width: 320px;
+  min-height: 100vh;
+  background: #1e1e1e;
+}
+
+#root {
   min-height: 100vh;
 }
 
@@ -99,6 +105,28 @@ textarea {
 
 .content-stage {
   min-width: 0;
+  flex: 1;
+  overflow-y: auto;
+  padding: 2.5rem;
+  background: #1e1e1e;
+}
+
+.custom-scrollbar {
+  scrollbar-color: rgba(255, 255, 255, 0.18) transparent;
+  scrollbar-width: thin;
+}
+
+.custom-scrollbar::-webkit-scrollbar {
+  width: 10px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
 }
 
 .page-grid {
@@ -146,7 +174,7 @@ textarea {
 
 .panel h2,
 .panel h3,
-h1 {
+.app-header h1 {
   margin: 0 0 0.75rem;
   line-height: 1.05;
 }
@@ -264,10 +292,11 @@ dd {
   align-items: flex-start;
 }
 
-input,
-select,
-textarea,
-button {
+.panel input,
+.panel select,
+.panel textarea,
+.panel button,
+.dialog-card button {
   border-radius: 16px;
   border: 1px solid rgba(22, 32, 50, 0.14);
   padding: 0.85rem 0.95rem;
@@ -538,5 +567,9 @@ pre {
   .dialog-actions {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .content-stage {
+    padding: 1.5rem;
   }
 }

--- a/apps/client/tailwind.config.js
+++ b/apps/client/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tauri-apps/api": "^2.5.1",
+        "lucide-react": "^0.446.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -29,12 +30,28 @@
         "@types/react": "^19.1.5",
         "@types/react-dom": "^19.1.5",
         "@vitejs/plugin-react": "^5.0.4",
+        "autoprefixer": "^10.4.19",
+        "postcss": "^8.4.39",
+        "tailwindcss": "^3.4.4",
         "vite": "^7.1.7"
       }
     },
     "apps/worker": {
       "name": "@infinitas/worker",
       "version": "0.1.0"
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -1500,6 +1517,44 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@poppinss/colors": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
@@ -2226,6 +2281,84 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.27",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
+      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1",
+        "caniuse-lite": "^1.0.30001774",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -2239,12 +2372,38 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
       "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/browserslist": {
       "version": "4.28.1",
@@ -2280,6 +2439,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001776",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001776.tgz",
@@ -2301,6 +2470,54 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2320,6 +2537,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/csstype": {
@@ -2356,6 +2586,20 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.307",
@@ -2426,6 +2670,46 @@
         "node": ">=6"
       }
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2444,6 +2728,33 @@
         }
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2459,6 +2770,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2467,6 +2788,104 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
       }
     },
     "node_modules/js-tokens": {
@@ -2512,6 +2931,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2520,6 +2959,52 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.446.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.446.0.tgz",
+      "integrity": "sha512-BU7gy8MfBMqvEdDPH79VhOXSEgyG8TSPOKWaExWGCQVqnGH7wGgDngPbofu+KdtVjPQBWbEmnfMTq90CTiiDRg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/miniflare": {
@@ -2550,6 +3035,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -2573,6 +3070,43 @@
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2610,6 +3144,26 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -2639,6 +3193,161 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -2667,6 +3376,74 @@
       "dev": true,
       "license": "MIT",
       "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
     },
@@ -2713,6 +3490,30 @@
         "@rollup/rollup-win32-x64-gnu": "4.59.0",
         "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/scheduler": {
@@ -2789,6 +3590,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/supports-color": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
@@ -2800,6 +3624,80 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/tinyglobby": {
@@ -2818,6 +3716,26 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -2891,6 +3809,13 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.1",

--- a/tasks/codex-settings-mock-shell.md
+++ b/tasks/codex-settings-mock-shell.md
@@ -1,0 +1,61 @@
+## 目的
+
+- `Settings` 画面を `C:\work\infinitas_arena\wireframe` の Mock に合わせて再構成する。
+- 左サイドナビを含む `App` 骨格を Mock ベースの見た目へ更新する。
+- 設定モデルを拡張し、音量・ミュートと監視元ディレクトリ指定を扱えるようにする。
+
+BASE_SHA: `bd741bc9a4f14e0aec16c27a628e769ed4f669f9`
+
+## 非目的
+
+- Room / Lobby / Stats 全面の完全リデザイン
+- Worker / Durable Objects / WebSocket schema の変更
+- 監視ソースのパース仕様変更
+
+## 変更点
+
+- `apps/client` に Mock 用 UI 依存を追加する。
+- `App.tsx` のヘッダー/サイドナビ構造を Mock ベースへ差し替える。
+- `SettingsPage.tsx` を Mock レイアウトへ差し替え、既存設定項目を必要最小限で再配置する。
+- `settings-store.ts` に音量・ミュート・監視元ディレクトリを追加し、既存保存データとの互換を維持する。
+- 必要に応じて Tauri 側にディレクトリ選択コマンドを追加する。
+- watcher 起動時はディレクトリ指定から実ファイルパスを導出する。
+
+## 影響範囲
+
+- ユーザー: Settings 画面とアプリ全体のナビ見た目が変わる
+- データ: localStorage の settings 保存形式が拡張される
+- 互換性: 既存 settings を壊さない移行が必要
+- Cloudflare: 影響なし
+
+## 対象ファイル / 対象レイヤ
+
+- client: `apps/client/src/app/App.tsx`
+- client: `apps/client/src/pages/SettingsPage.tsx`
+- client: `apps/client/src/stores/settings-store.ts`
+- client: `apps/client/src/stores/source-store.ts`
+- client: `apps/client/src/services/tauri-bridge.ts`
+- client: `apps/client/src/styles.css`
+- client tauri: `apps/client/src-tauri/src/*`
+- client deps: `apps/client/package.json`, ルート `package-lock.json`
+
+## テスト観点
+
+- [ ] client typecheck が通る
+- [ ] client build が通る
+- [ ] Tauri Rust 側がコンパイル可能
+- [ ] 既存 settings が読み込める
+- [ ] source ごとにディレクトリ指定から watcher 対象パスが正しく導出される
+- [ ] ルーム参加中の source 変更ロックが維持される
+
+## ロールバック方針
+
+- UI 変更と settings 拡張を単一ブランチ内で戻す
+- 互換問題があれば新規追加フィールドを無視し、従来 `sourcePaths` 読み込みへ戻す
+
+## コミット分割計画
+
+- [ ] UI 依存と Tauri ブリッジ準備
+- [ ] settings モデル拡張と watcher 入力変換
+- [ ] App / Settings UI の Mock 反映
+- [ ] ビルド・型検証


### PR DESCRIPTION
## 目的
- Settings 画面と app shell を wireframe の Mock に寄せる
- source ディレクトリ指定と音声設定をローカル settings に反映する
- 保存前バリデーションと Tauri 権限を追加して未保存変更が残らないようにする

## 変更点
- Tailwind と lucide-react を追加し、Settings 画面と sidebar を Mock ベースの UI に更新
- sourceDirectories / oiceVolume / oiceMuted を settings store に追加し、watcher 用の file path を自動導出
- Tauri に directory picker、source directory validation、core:default capability を追加
- Display Name 必須・10文字上限、source ディレクトリ配下の必須ファイル存在チェックを保存前に追加
- Settings を再度開いたときに未保存 draft ではなく saved settings を表示するよう修正

## 非変更点
- Worker / Durable Objects / WebSocket schema
- Lobby / Room / Stats の全面リデザイン
- 監視ソースの parser 仕様

## 影響範囲
- ユーザー: Settings 画面と app shell の見た目、ローカル設定 UX
- データ: client settings の localStorage 保存形式を拡張
- 互換性: 既存 settings を読み込みつつ新フィールドを補完
- Cloudflare: 影響なし

## テスト内容
- 
pm run typecheck:client
- 
pm run build:client
- 
pm run test:client-stats
- cargo check --manifest-path apps/client/src-tauri/Cargo.toml

## 回帰確認項目
- Settings を開き直したときに saved settings が表示される
- source ごとに directory 選択から watcher path が導出される
- Display Name と source directory の保存前バリデーションが効く
- Tauri 環境で event listen permission エラーが出ない