### PR TITLE
Strictly mark unrated matches in RESULT_READY

### DIFF
--- a/apps/client/src/features/stats/stats.test.ts
+++ b/apps/client/src/features/stats/stats.test.ts
@@ -11,7 +11,7 @@ function runCase(name: string, fn: () => void): void {
     throw error;
   }
 }
-import type { PlayStyle, RoomStateSnapshot } from "@infinitas/shared";
+import type { PlayStyle, ResultReadyPayload, RoomStateSnapshot } from "@infinitas/shared";
 import {
   createEmptyStatsArchive,
   type MatchGame,
@@ -160,7 +160,44 @@ function makeSnapshot(session: RoomStatsSession, closeReason: "ALL_ROUNDS_COMPLE
   };
 }
 
-function recordClosedMatch(archive: StatsArchive, session: RoomStatsSession): StatsArchive {
+function makeResultReady(input: {
+  session: RoomStatsSession;
+  isRated: boolean;
+  ratedBlockReason: ResultReadyPayload["summary"]["rated_block_reason"];
+  winnerPlayerIds?: string[];
+  completedRounds?: number;
+  totalRounds?: number;
+}): ResultReadyPayload {
+  const winnerPlayerIds = input.winnerPlayerIds ?? [MY_PLAYER_ID];
+
+  return {
+    summary: {
+      mode: input.session.settings.mode,
+      win_metric: input.session.settings.win_metric,
+      total_rounds: input.totalRounds ?? input.session.rounds.length,
+      completed_rounds: input.completedRounds ?? input.session.rounds.length,
+      winner_player_ids: winnerPlayerIds,
+      is_draw: winnerPlayerIds.length !== 1,
+      is_rated: input.isRated,
+      rated_block_reason: input.ratedBlockReason,
+      rating_before: null,
+      rating_after: null,
+      rating_delta: null,
+    },
+    per_round: {
+      rounds: [],
+    },
+    per_player: {
+      players: [],
+    },
+  };
+}
+
+function recordClosedMatch(
+  archive: StatsArchive,
+  session: RoomStatsSession,
+  resultReady: ResultReadyPayload | null = null,
+): StatsArchive {
   const processedAt = iso(58);
   const withSession = reduceArchiveWithSession(archive, {
     session,
@@ -171,6 +208,7 @@ function recordClosedMatch(archive: StatsArchive, session: RoomStatsSession): St
   return reduceArchiveWithClosedMatch(withSession, {
     session,
     snapshot: makeSnapshot(session),
+    resultReady,
     myPlayerId: MY_PLAYER_ID,
     processedAt: iso(59),
   });
@@ -450,6 +488,46 @@ runCase("ARENA final standing resolves ties by EX total, then confirmation time,
   assert.equal(sharedRankArchive.matches[0]?.final_rank, 1);
   assert.equal(sharedRankArchive.matches[0]?.match_result, "DRAW");
   assert.equal(sharedRankArchive.matches[0]?.rating_after, 1500);
+});
+
+runCase("DO-provided unrated decision blocks local rating updates", () => {
+  const session = makeSession({
+    roomId: "bpl-mismatch-unrated",
+    battleType: "BPL",
+    playMode: "SP",
+    playerIds: [MY_PLAYER_ID, "opponent"],
+    mode: "BPL",
+    rounds: [
+      makeRound(0, "SP", [
+        makeResult({ playerId: MY_PLAYER_ID, metricValue: 2200, submittedAt: iso(50), bp: 10 }),
+        makeResult({ playerId: "opponent", metricValue: 2100, submittedAt: iso(51), bp: 13 }),
+      ]),
+      makeRound(1, "SP", [
+        makeResult({ playerId: MY_PLAYER_ID, metricValue: 2000, submittedAt: iso(52), bp: 16 }),
+        makeResult({ playerId: "opponent", metricValue: 2150, submittedAt: iso(53), bp: 12 }),
+      ]),
+      makeRound(2, "SP", [
+        makeResult({ playerId: MY_PLAYER_ID, metricValue: 2300, submittedAt: iso(54), bp: 9 }),
+        makeResult({ playerId: "opponent", metricValue: 1900, submittedAt: iso(55), bp: 17 }),
+      ]),
+    ],
+  });
+
+  const archive = recordClosedMatch(
+    createEmptyStatsArchive(),
+    session,
+    makeResultReady({
+      session,
+      isRated: false,
+      ratedBlockReason: "mismatch_observed_key",
+      winnerPlayerIds: [MY_PLAYER_ID],
+    }),
+  );
+
+  assert.equal(archive.matches[0]?.is_rated, false);
+  assert.equal(archive.matches[0]?.invalid_reason, "mismatch_observed_key");
+  assert.equal(archive.matches[0]?.rating_after, null);
+  assert.equal(getCurrentRating(archive, "BPL", "SP"), null);
 });
 
 runCase("chart rankings require three matches and stay separated by chart id, rule, and mode", () => {

--- a/apps/client/src/features/stats/stats.ts
+++ b/apps/client/src/features/stats/stats.ts
@@ -55,6 +55,10 @@ function asNullableNumber(value: unknown): number | null {
   return value === null ? null : asNumber(value);
 }
 
+function asBoolean(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
+}
+
 function asSubmissionStatus(value: unknown): SubmissionStatus | null {
   return value === "PLAYED" || value === "SKIPPED" || value === "TIMEOUT" ? value : null;
 }
@@ -282,6 +286,49 @@ function buildSessionRoundFromResultReady(resultReady: ResultReadyPayload): Sess
   }
 
   return rounds.sort((left, right) => left.round_index - right.round_index);
+}
+
+function readResultReadyDecision(resultReady: ResultReadyPayload | null): {
+  isRated: boolean | null;
+  ratedBlockReason: string | null;
+} {
+  if (resultReady === null) {
+    return {
+      isRated: null,
+      ratedBlockReason: null,
+    };
+  }
+
+  const summaryRecord = asRecord(resultReady.summary);
+  return {
+    isRated: asBoolean(summaryRecord?.is_rated),
+    ratedBlockReason: asNullableString(summaryRecord?.rated_block_reason),
+  };
+}
+
+function resolveMatchRatingDecision(input: {
+  resultReady: ResultReadyPayload | null;
+  canRate: boolean;
+  fallbackInvalidReason: string | null;
+}): {
+  isRated: boolean;
+  invalidReason: string | null;
+} {
+  const summaryDecision = readResultReadyDecision(input.resultReady);
+  if (summaryDecision.isRated !== null) {
+    return {
+      isRated: summaryDecision.isRated && input.canRate,
+      invalidReason:
+        summaryDecision.isRated && input.canRate
+          ? null
+          : summaryDecision.ratedBlockReason ?? input.fallbackInvalidReason,
+    };
+  }
+
+  return {
+    isRated: input.canRate && input.fallbackInvalidReason === null,
+    invalidReason: input.fallbackInvalidReason,
+  };
 }
 
 export function captureRoomStatsSession(
@@ -686,6 +733,7 @@ function buildArenaStandings(
 function deriveArenaMatchRecord(
   session: RoomStatsSession,
   snapshot: RoomStateSnapshot,
+  resultReady: ResultReadyPayload | null,
   myPlayerId: string,
 ): MatchRecord {
   const completeRounds = session.rounds.filter((round) => getRoundComplete(round, session.players.length));
@@ -727,6 +775,11 @@ function deriveArenaMatchRecord(
         : tieBreakMissingEx
           ? "MISSING_EX_TIEBREAK"
           : null;
+  const ratingDecision = resolveMatchRatingDecision({
+    resultReady,
+    canRate: ratingScore !== null,
+    fallbackInvalidReason: invalidReason,
+  });
 
   return {
     match_id: session.room_id,
@@ -744,15 +797,15 @@ function deriveArenaMatchRecord(
     opponent_count: opponentCount,
     opponent_id: null,
     opponent_name: null,
-    is_rated: getBattleType(session.settings) !== "PRIVATE" && invalidReason === null && ratingScore !== null,
+    is_rated: ratingDecision.isRated,
     is_complete: isComplete,
     match_result: ratingScore === null ? "DRAW" : getGameResultFromScore(ratingScore),
     match_point_total: myStanding?.total_points ?? 0,
-    rating_score: ratingScore,
+    rating_score: ratingDecision.isRated ? ratingScore : null,
     rating_before: null,
     rating_after: null,
     rating_delta: null,
-    invalid_reason: invalidReason,
+    invalid_reason: ratingDecision.invalidReason,
     final_rank: myStanding?.final_rank ?? null,
     participant_count: session.players.length,
   };
@@ -762,6 +815,7 @@ function deriveBplMatchRecord(
   session: RoomStatsSession,
   matchGames: MatchGame[],
   snapshot: RoomStateSnapshot,
+  resultReady: ResultReadyPayload | null,
   myPlayerId: string,
 ): MatchRecord {
   const startedAt = sortByTimeAscending(matchGames)[0]?.played_at ?? snapshot.created_at ?? new Date().toISOString();
@@ -780,6 +834,11 @@ function deriveBplMatchRecord(
       : !isComplete
         ? "INCOMPLETE_MATCH"
         : null;
+  const ratingDecision = resolveMatchRatingDecision({
+    resultReady,
+    canRate: true,
+    fallbackInvalidReason: invalidReason,
+  });
 
   return {
     match_id: session.room_id,
@@ -790,15 +849,15 @@ function deriveBplMatchRecord(
     opponent_count: opponent ? 1 : 0,
     opponent_id: opponent?.player_id ?? null,
     opponent_name: opponent?.display_name ?? null,
-    is_rated: getBattleType(session.settings) !== "PRIVATE" && invalidReason === null,
+    is_rated: ratingDecision.isRated,
     is_complete: isComplete,
     match_result: matchResult,
     match_point_total: selfTotal,
-    rating_score: getResultScore(matchResult),
+    rating_score: ratingDecision.isRated ? getResultScore(matchResult) : null,
     rating_before: null,
     rating_after: null,
     rating_delta: null,
-    invalid_reason: invalidReason,
+    invalid_reason: ratingDecision.invalidReason,
     final_rank: matchResult === "WIN" ? 1 : matchResult === "LOSE" ? 2 : 1,
     participant_count: snapshot.players.length,
   };
@@ -843,6 +902,7 @@ export function reduceArchiveWithClosedMatch(
   input: {
     session: RoomStatsSession | null;
     snapshot: RoomStateSnapshot;
+    resultReady: ResultReadyPayload | null;
     myPlayerId: string;
     processedAt: string;
   },
@@ -857,8 +917,8 @@ export function reduceArchiveWithClosedMatch(
     .sort((left, right) => left.game_index - right.game_index);
   const nextMatch =
     session.settings.mode === "ARENA"
-      ? deriveArenaMatchRecord(session, input.snapshot, input.myPlayerId)
-      : deriveBplMatchRecord(session, matchGames, input.snapshot, input.myPlayerId);
+      ? deriveArenaMatchRecord(session, input.snapshot, input.resultReady, input.myPlayerId)
+      : deriveBplMatchRecord(session, matchGames, input.snapshot, input.resultReady, input.myPlayerId);
   const matches = upsertMatchRecord(archive.matches, nextMatch);
   const ratingResult = recalculateRatings(matches);
 

--- a/apps/client/src/services/stats-archive.ts
+++ b/apps/client/src/services/stats-archive.ts
@@ -86,6 +86,7 @@ function syncFromRoomStore(): void {
   const afterMatchClose = reduceArchiveWithClosedMatch(afterSessionFlush, {
     session: currentSession,
     snapshot,
+    resultReady: roomStore.getState().resultReady,
     myPlayerId,
     processedAt,
   });

--- a/apps/worker/src/durable/result-rating.ts
+++ b/apps/worker/src/durable/result-rating.ts
@@ -1,0 +1,105 @@
+import type { RatedBlockReason, RoomSettings, SubmissionStatus } from "@infinitas/shared";
+
+interface ResultRatingRoundResult {
+  status: SubmissionStatus | null;
+}
+
+interface ResultRatingRound {
+  played: boolean;
+  results: ResultRatingRoundResult[];
+}
+
+export interface EvaluateResultRatingInput {
+  visibility: RoomSettings["visibility"];
+  total_rounds: number;
+  completed_rounds: number;
+  winner_player_ids: string[];
+  rounds: ResultRatingRound[];
+  mismatch_observed_key: boolean;
+  force_advanced: boolean;
+}
+
+export interface ResultRatingDecision {
+  is_rated: boolean;
+  rated_block_reason: RatedBlockReason | null;
+  rating_before: number | null;
+  rating_after: number | null;
+  rating_delta: number | null;
+}
+
+function buildUnratedDecision(reason: RatedBlockReason): ResultRatingDecision {
+  return {
+    is_rated: false,
+    rated_block_reason: reason,
+    rating_before: null,
+    rating_after: null,
+    rating_delta: null,
+  };
+}
+
+export function evaluateResultRating(input: EvaluateResultRatingInput): ResultRatingDecision {
+  if (input.visibility === "PRIVATE") {
+    return buildUnratedDecision("private_room");
+  }
+
+  if (input.mismatch_observed_key) {
+    return buildUnratedDecision("mismatch_observed_key");
+  }
+
+  if (input.force_advanced) {
+    return buildUnratedDecision("force_advanced");
+  }
+
+  let missingSubmission = false;
+  let skipped = false;
+  let timedOut = false;
+
+  for (const round of input.rounds) {
+    if (!round.played) {
+      continue;
+    }
+
+    for (const result of round.results) {
+      if (result.status === null) {
+        missingSubmission = true;
+        continue;
+      }
+
+      if (result.status === "SKIPPED") {
+        skipped = true;
+      }
+
+      if (result.status === "TIMEOUT") {
+        timedOut = true;
+      }
+    }
+  }
+
+  if (skipped) {
+    return buildUnratedDecision("skip_occurred");
+  }
+
+  if (timedOut) {
+    return buildUnratedDecision("timeout_occurred");
+  }
+
+  if (missingSubmission) {
+    return buildUnratedDecision("missing_submission");
+  }
+
+  if (input.total_rounds === 0 || input.completed_rounds !== input.total_rounds) {
+    return buildUnratedDecision("incomplete_match");
+  }
+
+  if (input.winner_player_ids.length !== 1) {
+    return buildUnratedDecision("result_conflict");
+  }
+
+  return {
+    is_rated: true,
+    rated_block_reason: null,
+    rating_before: null,
+    rating_after: null,
+    rating_delta: null,
+  };
+}

--- a/apps/worker/src/durable/room-state.test.mjs
+++ b/apps/worker/src/durable/room-state.test.mjs
@@ -49,7 +49,7 @@ function createChartMaster() {
   };
 }
 
-function createState() {
+function createState(settingsOverride = {}) {
   const state = new RoomLobbyState(createChartMaster());
   state.initialize({
     room_id: "room-1",
@@ -63,6 +63,7 @@ function createState() {
       level_filter: "ANY",
       room_comment: "Rematch room",
       max_players: 4,
+      ...settingsOverride,
     },
   });
 
@@ -87,6 +88,39 @@ function createState() {
   );
 
   return state;
+}
+
+function prepareMatch(state, input = {}) {
+  const startAt = input.startAt ?? "2026-03-08T00:01:00.000Z";
+  const hostPick = input.hostPick ?? "chart-1";
+  const guestPick = input.guestPick ?? "chart-2";
+
+  assert.equal(state.setPlayerReady("host", true).ok, true);
+  assert.equal(state.setPlayerReady("guest", true).ok, true);
+  assert.deepEqual(state.startMatch("host", new Date(startAt)), { ok: true });
+  assert.equal(state.submitPick("host", hostPick, new Date("2026-03-08T00:01:10.000Z")).ok, true);
+  assert.equal(state.submitPick("guest", guestPick, new Date("2026-03-08T00:01:11.000Z")).ok, true);
+  assert.equal(state.getRoomState(), "PLAYING");
+}
+
+function submitCurrentRoundResult(state, playerId, roundIndex, metricValue, nowAt) {
+  const snapshot = state.toSnapshot();
+  assert.ok(snapshot.current_round, "current round should exist");
+  assert.equal(snapshot.current_round.round_index, roundIndex);
+  return state.submitResult(
+    playerId,
+    roundIndex,
+    snapshot.current_round.expected_key,
+    metricValue,
+    null,
+    new Date(nowAt),
+  );
+}
+
+function getResultSummary(state) {
+  const payload = state.getResultReadyPayload();
+  assert.ok(payload, "result ready payload should exist");
+  return payload.summary;
 }
 
 function playCurrentRound(state, roundIndex, hostMetric, guestMetric, nowBase) {
@@ -175,4 +209,149 @@ test("RESULT -> LOBBY clears ready and match transient state without auto-start"
   assert.equal(state.setPlayerReady("host", true).ok, true);
   assert.equal(state.setPlayerReady("guest", true).ok, true);
   assert.deepEqual(state.startMatch("host", new Date("2026-03-08T00:04:20.000Z")), { ok: true });
+});
+
+test("strict rated match is true only on fully completed clean match", () => {
+  const state = createState();
+  prepareMatch(state);
+
+  playCurrentRound(state, 0, 2200, 2100, "2026-03-08T00:02");
+  playCurrentRound(state, 1, 2300, 2000, "2026-03-08T00:03");
+
+  const summary = getResultSummary(state);
+  assert.equal(summary.is_rated, true);
+  assert.equal(summary.rated_block_reason, null);
+  assert.equal(summary.rating_before, null);
+  assert.equal(summary.rating_after, null);
+  assert.equal(summary.rating_delta, null);
+  assert.deepEqual(summary.winner_player_ids, ["host"]);
+});
+
+test("missing submission still generates RESULT_READY and marks the match unrated", () => {
+  const state = createState();
+  prepareMatch(state);
+
+  assert.equal(
+    submitCurrentRoundResult(state, "host", 0, 2200, "2026-03-08T00:02:00.000Z").ok,
+    true,
+  );
+
+  state["enterResult"](new Date("2026-03-08T00:02:30.000Z"));
+
+  const summary = getResultSummary(state);
+  assert.equal(summary.is_rated, false);
+  assert.equal(summary.rated_block_reason, "missing_submission");
+  assert.equal(summary.rating_before, null);
+  assert.equal(summary.rating_after, null);
+  assert.equal(summary.rating_delta, null);
+});
+
+test("SKIPPED blocks rating", () => {
+  const state = createState();
+  prepareMatch(state);
+
+  const firstRound = state.skipSelf("host", 0, "TECH", new Date("2026-03-08T00:02:00.000Z"));
+  assert.equal(firstRound.ok, true);
+  assert.equal(
+    submitCurrentRoundResult(state, "guest", 0, 2100, "2026-03-08T00:02:01.000Z").ok,
+    true,
+  );
+
+  playCurrentRound(state, 1, 2300, 2000, "2026-03-08T00:03");
+
+  const summary = getResultSummary(state);
+  assert.equal(summary.is_rated, false);
+  assert.equal(summary.rated_block_reason, "skip_occurred");
+});
+
+test("TIMEOUT blocks rating", () => {
+  const state = createState();
+  prepareMatch(state);
+
+  assert.equal(
+    submitCurrentRoundResult(state, "host", 0, 2200, "2026-03-08T00:02:00.000Z").ok,
+    true,
+  );
+  const transition = state.expireCurrentRoundIfNeeded(new Date("2026-03-08T00:08:00.000Z"));
+  assert.ok(transition);
+  assert.equal(transition.confirmations.some((entry) => entry.status === "TIMEOUT"), true);
+
+  playCurrentRound(state, 1, 2300, 2000, "2026-03-08T00:09");
+
+  const summary = getResultSummary(state);
+  assert.equal(summary.is_rated, false);
+  assert.equal(summary.rated_block_reason, "timeout_occurred");
+});
+
+test("FORCE_ADVANCE blocks rating", () => {
+  const state = createState();
+  prepareMatch(state);
+
+  assert.equal(
+    submitCurrentRoundResult(state, "host", 0, 2200, "2026-03-08T00:02:00.000Z").ok,
+    true,
+  );
+  const result = state.forceAdvance("host", new Date("2026-03-08T00:02:10.000Z"));
+  assert.equal(result.ok, true);
+  assert.ok(result.force_advance_applied);
+
+  playCurrentRound(state, 1, 2300, 2000, "2026-03-08T00:03");
+
+  const summary = getResultSummary(state);
+  assert.equal(summary.is_rated, false);
+  assert.equal(summary.rated_block_reason, "force_advanced");
+});
+
+test("mismatched observed_key poisons the match even if the player later submits a correct result", () => {
+  const state = createState();
+  prepareMatch(state);
+
+  const snapshot = state.toSnapshot();
+  assert.ok(snapshot.current_round);
+  const mismatch = state.submitResult(
+    "host",
+    0,
+    {
+      ...snapshot.current_round.expected_key,
+      title_search_key: `${snapshot.current_round.expected_key.title_search_key}-wrong`,
+    },
+    2200,
+    null,
+    new Date("2026-03-08T00:02:00.000Z"),
+  );
+  assert.deepEqual(mismatch, { ok: false, reason: "RESULT_KEY_MISMATCH", confirmations: [] });
+
+  playCurrentRound(state, 0, 2200, 2100, "2026-03-08T00:02");
+  playCurrentRound(state, 1, 2300, 2000, "2026-03-08T00:03");
+
+  const summary = getResultSummary(state);
+  assert.equal(summary.is_rated, false);
+  assert.equal(summary.rated_block_reason, "mismatch_observed_key");
+});
+
+test("BPL early finish is unrated because not all rounds completed", () => {
+  const state = createState({ mode: "BPL", max_players: 2 });
+  prepareMatch(state);
+
+  playCurrentRound(state, 0, 2200, 2100, "2026-03-08T00:02");
+  playCurrentRound(state, 1, 2300, 2000, "2026-03-08T00:03");
+
+  const summary = getResultSummary(state);
+  assert.equal(state.getRoomState(), "RESULT");
+  assert.equal(summary.is_rated, false);
+  assert.equal(summary.rated_block_reason, "incomplete_match");
+});
+
+test("conflicting final result blocks rating", () => {
+  const state = createState({ mode: "BPL", max_players: 2 });
+  prepareMatch(state);
+
+  playCurrentRound(state, 0, 2200, 2100, "2026-03-08T00:02");
+  playCurrentRound(state, 1, 2000, 2300, "2026-03-08T00:03");
+  playCurrentRound(state, 2, 2100, 2100, "2026-03-08T00:04");
+
+  const summary = getResultSummary(state);
+  assert.equal(summary.is_rated, false);
+  assert.equal(summary.rated_block_reason, "result_conflict");
+  assert.deepEqual(summary.winner_player_ids.sort(), ["guest", "host"]);
 });

--- a/apps/worker/src/durable/room-state.ts
+++ b/apps/worker/src/durable/room-state.ts
@@ -26,6 +26,7 @@ import {
   type WinMetric,
 } from "@infinitas/shared";
 import type { ResolvedMasterChart, RoomChartMaster } from "../master/chart-master";
+import { evaluateResultRating } from "./result-rating";
 
 interface InternalPlayer {
   player_id: string;
@@ -220,6 +221,8 @@ export interface RoomStatePersistenceRecord {
   current_round: CurrentRoundSnapshot | null;
   match_player_ids: string[];
   result_ready_payload: ResultReadyPayload | null;
+  result_key_mismatch_detected?: boolean;
+  force_advanced_round_indices?: number[];
 }
 
 const DEFAULT_SETTINGS: RoomSettings = {
@@ -317,6 +320,66 @@ function cloneRoundConfirmation(entry: RoundConfirmationEvent): RoundConfirmatio
   };
 }
 
+function getSourceMetric(sourceMeta: JsonObject | null, key: "score"): number | null {
+  if (sourceMeta === null) {
+    return null;
+  }
+
+  const value = (sourceMeta as Record<string, unknown>)[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function getConfirmationExScore(
+  confirmation: RoundConfirmationEvent | undefined,
+  winMetric: WinMetric,
+): number | null {
+  if (confirmation === undefined) {
+    return null;
+  }
+
+  return getSourceMetric(confirmation.source_meta, "score") ??
+    (winMetric === "SCORE" ? confirmation.metric_value : null);
+}
+
+function resolveArenaWinnerPlayerIds(
+  players: Array<{
+    player_id: string;
+    total_points: number;
+    total_ex_score: number | null;
+    last_confirmed_at: string | null;
+  }>,
+): string[] {
+  if (players.length === 0) {
+    return [];
+  }
+
+  const highestPoints = players.reduce((maxValue, player) => Math.max(maxValue, player.total_points), 0);
+  let leaders = players.filter((player) => player.total_points === highestPoints);
+  if (leaders.length <= 1) {
+    return leaders.map((player) => player.player_id);
+  }
+
+  if (leaders.every((player) => player.total_ex_score !== null)) {
+    const highestExScore = leaders.reduce(
+      (maxValue, player) => Math.max(maxValue, player.total_ex_score ?? Number.NEGATIVE_INFINITY),
+      Number.NEGATIVE_INFINITY,
+    );
+    leaders = leaders.filter((player) => player.total_ex_score === highestExScore);
+    if (leaders.length <= 1) {
+      return leaders.map((player) => player.player_id);
+    }
+  }
+
+  if (leaders.every((player) => player.last_confirmed_at !== null)) {
+    const earliestConfirmation =
+      [...leaders].map((player) => player.last_confirmed_at ?? "").sort((left, right) => left.localeCompare(right))[0] ??
+      null;
+    leaders = leaders.filter((player) => player.last_confirmed_at === earliestConfirmation);
+  }
+
+  return leaders.map((player) => player.player_id);
+}
+
 export class RoomLobbyState {
   private initialized = false;
   private roomId = "";
@@ -337,6 +400,8 @@ export class RoomLobbyState {
   private currentRound: CurrentRoundSnapshot | null = null;
   private matchPlayerIds: string[] = [];
   private resultReadyPayload: ResultReadyPayload | null = null;
+  private resultKeyMismatchDetected = false;
+  private readonly forceAdvancedRoundIndices = new Set<number>();
 
   constructor(private readonly chartMaster: RoomChartMaster) {}
 
@@ -527,6 +592,8 @@ export class RoomLobbyState {
     this.frozenRounds = [];
     this.currentRound = null;
     this.resultReadyPayload = null;
+    this.resultKeyMismatchDetected = false;
+    this.forceAdvancedRoundIndices.clear();
 
     for (const player of this.players.values()) {
       player.ready = false;
@@ -673,6 +740,7 @@ export class RoomLobbyState {
     }
 
     if (!this.isSameExpectedKey(this.currentRound.expected_key, observedKey)) {
+      this.resultKeyMismatchDetected = true;
       return { ok: false, reason: "RESULT_KEY_MISMATCH", confirmations: [] };
     }
 
@@ -1071,6 +1139,8 @@ export class RoomLobbyState {
             },
       match_player_ids: [...this.matchPlayerIds],
       result_ready_payload: this.resultReadyPayload,
+      result_key_mismatch_detected: this.resultKeyMismatchDetected,
+      force_advanced_round_indices: Array.from(this.forceAdvancedRoundIndices).sort((left, right) => left - right),
     };
   }
 
@@ -1139,6 +1209,11 @@ export class RoomLobbyState {
           };
     this.matchPlayerIds = [...record.match_player_ids];
     this.resultReadyPayload = record.result_ready_payload;
+    this.resultKeyMismatchDetected = record.result_key_mismatch_detected === true;
+    this.forceAdvancedRoundIndices.clear();
+    for (const roundIndex of record.force_advanced_round_indices ?? []) {
+      this.forceAdvancedRoundIndices.add(roundIndex);
+    }
   }
 
   private getCurrentRoundDeadline(): Date | null {
@@ -1254,6 +1329,7 @@ export class RoomLobbyState {
       confirmations: clonedConfirmations,
     };
     if (options.force_advance_applied !== undefined) {
+      this.forceAdvancedRoundIndices.add(options.force_advance_applied.round_index);
       result.force_advance_applied = {
         round_index: options.force_advance_applied.round_index,
         timed_out_players: [...options.force_advance_applied.timed_out_players],
@@ -1343,6 +1419,8 @@ export class RoomLobbyState {
     this.currentRound = null;
     this.matchPlayerIds = [];
     this.resultReadyPayload = null;
+    this.resultKeyMismatchDetected = false;
+    this.forceAdvancedRoundIndices.clear();
 
     for (const player of this.players.values()) {
       player.ready = false;
@@ -1616,8 +1694,12 @@ export class RoomLobbyState {
 
     if (this.settings.mode === "ARENA") {
       const totalPoints = new Map<string, number>();
+      const totalExScore = new Map<string, number | null>();
+      const lastConfirmedAt = new Map<string, string | null>();
       for (const playerId of this.matchPlayerIds) {
         totalPoints.set(playerId, 0);
+        totalExScore.set(playerId, 0);
+        lastConfirmedAt.set(playerId, null);
       }
 
       const rounds = this.frozenRounds.map((round) => {
@@ -1667,6 +1749,17 @@ export class RoomLobbyState {
           const rank = confirmation === undefined ? null : (rankByPlayerId.get(playerId) ?? null);
           const arenaPoints = rank === null ? 0 : this.getArenaPointsForRank(rank);
           totalPoints.set(playerId, (totalPoints.get(playerId) ?? 0) + arenaPoints);
+          const exScore = getConfirmationExScore(confirmation, this.settings.win_metric);
+          totalExScore.set(
+            playerId,
+            exScore === null || totalExScore.get(playerId) === null ? null : (totalExScore.get(playerId) ?? 0) + exScore,
+          );
+          if (
+            confirmation?.submitted_at !== undefined &&
+            ((lastConfirmedAt.get(playerId) ?? null) === null || (lastConfirmedAt.get(playerId) ?? "") < confirmation.submitted_at)
+          ) {
+            lastConfirmedAt.set(playerId, confirmation.submitted_at);
+          }
 
           const roundResult = {
             round_index: round.round_index,
@@ -1707,12 +1800,25 @@ export class RoomLobbyState {
         player_id: playerId,
         display_name: this.getPlayerDisplayName(playerId),
         total_points: totalPoints.get(playerId) ?? 0,
+        total_ex_score: totalExScore.get(playerId) ?? null,
+        last_confirmed_at: lastConfirmedAt.get(playerId) ?? null,
         rounds: perPlayerRounds.get(playerId) ?? [],
       }));
-      const highestPoints = players.reduce((maxValue, player) => Math.max(maxValue, player.total_points), 0);
-      const winnerPlayerIds = players
-        .filter((player) => player.total_points === highestPoints)
-        .map((player) => player.player_id);
+      const winnerPlayerIds = resolveArenaWinnerPlayerIds(players);
+      const ratingDecision = evaluateResultRating({
+        visibility: this.settings.visibility,
+        total_rounds: this.frozenRounds.length,
+        completed_rounds: completedRounds,
+        winner_player_ids: winnerPlayerIds,
+        rounds: rounds.map((round) => ({
+          played: round.played,
+          results: round.results.map((result) => ({
+            status: result.status,
+          })),
+        })),
+        mismatch_observed_key: this.resultKeyMismatchDetected,
+        force_advanced: this.forceAdvancedRoundIndices.size > 0,
+      });
 
       return {
         summary: {
@@ -1722,6 +1828,7 @@ export class RoomLobbyState {
           completed_rounds: completedRounds,
           winner_player_ids: winnerPlayerIds,
           is_draw: winnerPlayerIds.length !== 1,
+          ...ratingDecision,
         },
         per_round: {
           rounds,
@@ -1779,6 +1886,20 @@ export class RoomLobbyState {
     const winnerPlayerIds = players
       .filter((player) => player.round_wins === highestWins)
       .map((player) => player.player_id);
+    const ratingDecision = evaluateResultRating({
+      visibility: this.settings.visibility,
+      total_rounds: this.frozenRounds.length,
+      completed_rounds: completedRounds,
+      winner_player_ids: winnerPlayerIds,
+      rounds: rounds.map((round) => ({
+        played: round.played,
+        results: round.results.map((result) => ({
+          status: result.status,
+        })),
+      })),
+      mismatch_observed_key: this.resultKeyMismatchDetected,
+      force_advanced: this.forceAdvancedRoundIndices.size > 0,
+    });
 
     return {
       summary: {
@@ -1788,6 +1909,7 @@ export class RoomLobbyState {
         completed_rounds: completedRounds,
         winner_player_ids: winnerPlayerIds,
         is_draw: winnerPlayerIds.length !== 1,
+        ...ratingDecision,
       },
       per_round: {
         rounds,

--- a/docs/design/01_fsm.md
+++ b/docs/design/01_fsm.md
@@ -189,6 +189,17 @@
 - 復帰時は前マッチの ready / round / pick / aggregation / `match_ttl` をすべてクリアする
 - room_id / member 構成 / host / battle context は維持する
 
+### 10.5 rated / unrated 判定（v1）
+- rated 判定は DO が一元管理し、`RESULT_READY.summary.is_rated` を権威情報とする
+- 以下をすべて満たす場合のみ rated:
+  - 全参加者の確定結果が揃っている
+  - 全 round が確定している
+  - `observed_key == expected_key` の不一致が発生していない
+  - `SKIPPED` / `TIMEOUT` / `FORCE_ADVANCE` が1件もない
+  - マッチが途中終了していない
+  - 最終勝者が一意に確定している
+- 上記のいずれかを満たさない場合は `RESULT_READY` 自体は生成するが `is_rated = false` とし、`rated_block_reason` を設定する
+
 ## 11. CLOSED（解散）
 - ホスト操作で即 `CLOSED` も可
 - 対戦正常終了時は `RESULT` に入り、必要に応じて `RESULT -> LOBBY` で再戦準備に戻す

--- a/docs/design/02_ws_protocol.md
+++ b/docs/design/02_ws_protocol.md
@@ -113,8 +113,10 @@
 
 ### 4.5 RESULT
 - `RESULT_READY`
-  - payload: `{ summary: object, per_round: object, per_player: object }`
+  - payload: `{ summary: { mode, win_metric, total_rounds, completed_rounds, winner_player_ids, is_draw, is_rated, rated_block_reason, rating_before, rating_after, rating_delta }, per_round: object, per_player: object }`
   - 備考: `per_round.rounds[].results[]` には `status / metric_value / reason / submitted_at / submitted_by / source_meta?` を含めてもよい
+  - 備考: `rated_block_reason` は最低限 `missing_submission | mismatch_observed_key | incomplete_match | skip_occurred | timeout_occurred | force_advanced | result_conflict` を扱う
+  - 備考: v1 では `RESULT_READY.summary.is_rated` がレート適用可否の権威情報
   - 備考: 通常フローでは `PLAYING -> RESULT` 遷移時に配信し、`RESULT -> LOBBY` 復帰まで保持して表示する
 
 ### 4.6 同期/エラー

--- a/docs/design/03_data_model.md
+++ b/docs/design/03_data_model.md
@@ -27,7 +27,7 @@
 - `result_deadline: datetime|null`（互換用。通常フローでは `null`）
 - `closed_at: datetime|null`
 - `close_reason: ALL_ROUNDS_COMPLETED|MATCH_TTL_EXPIRED|READY_CHECK_TTL_EXPIRED|HOST_DISCONNECTED|HOST_ABORTED|PICKING_ABORTED|FORCE_CLOSED|null`
-- `result_ready_payload: object|null`（`RESULT` 中は保持し、`RESULT -> LOBBY` 復帰時にクリア）
+- `result_ready_payload: object|null`（`RESULT` 中は保持し、`RESULT -> LOBBY` 復帰時にクリア。`summary.is_rated / rated_block_reason / rating_*` を含む）
 - `event_seq: int`
 
 ### 2.2 RoomSettings（Ph1）
@@ -288,6 +288,8 @@
   - レート系列は `ARENA_SP` / `ARENA_DP` / `BPL_SP` / `BPL_DP` を分離する
   - レート更新は `matches` を基準にマッチ単位で行う
   - ARENA は `match_games` を集約して最終順位を決め、pairwise 擬似対戦で `matches.rating_delta` を算出する
-  - `PRIVATE` はレート対象外だが `play_results` と安定度集計には含める
+  - `RESULT_READY.summary.is_rated` をレート適用可否の権威情報とする
+  - `PRIVATE`、`SKIPPED`、`TIMEOUT`、`FORCE_ADVANCE`、未提出、不一致、途中終了、最終結果衝突を含むマッチはレート対象外
+  - unrated でも `matches / match_games / play_results` は保存し、`matches.invalid_reason` に block 理由を保持する
   - 曲別勝率ランキングは `match_games` を基準に集計する
   - 曲識別は表示名ではなく `chart_id` を正とする

--- a/packages/shared/src/ws/server.ts
+++ b/packages/shared/src/ws/server.ts
@@ -81,8 +81,32 @@ export interface ForceAdvanceAppliedPayload {
   timed_out_players: string[];
 }
 
+export type RatedBlockReason =
+  | "private_room"
+  | "missing_submission"
+  | "mismatch_observed_key"
+  | "incomplete_match"
+  | "skip_occurred"
+  | "timeout_occurred"
+  | "force_advanced"
+  | "result_conflict";
+
+export interface ResultReadySummary {
+  mode: "ARENA" | "BPL";
+  win_metric: "SCORE" | "MISSCOUNT";
+  total_rounds: number;
+  completed_rounds: number;
+  winner_player_ids: string[];
+  is_draw: boolean;
+  is_rated: boolean;
+  rated_block_reason: RatedBlockReason | null;
+  rating_before: number | null;
+  rating_after: number | null;
+  rating_delta: number | null;
+}
+
 export interface ResultReadyPayload {
-  summary: JsonObject;
+  summary: ResultReadySummary;
   per_round: JsonObject;
   per_player: JsonObject;
 }

--- a/tasks/codex-strict-rated-result-ready.md
+++ b/tasks/codex-strict-rated-result-ready.md
@@ -1,0 +1,53 @@
+- 目的
+  - v1 の rated/unrated 判定を Durable Object 側で厳格化し、`RESULT_READY.payload.summary` に rated 判定結果とレート適用有無を明示する。
+- 非目的
+  - レーティング計算式自体の変更
+  - 監視ソース I/O 仕様の変更
+  - ロビー/KV 仕様の変更
+
+- BASE_SHA
+  - `d01e0d747b5782842cd45cbd05a22800c44761a4`
+
+- 変更点
+  - `RESULT_READY` の shared schema と design docs に rated 判定結果を追加する。
+  - worker の result 集計時に strict rated 判定を一元化し、`skip/timeout/force advance/missing/mismatch/incomplete/conflict` を unrated とする。
+  - client 側の結果表示/統計取り込みで DO 提供の rated 結果を優先し、unrated でも結果保存と表示が成立するようにする。
+  - 関連テストを追加し、最低限の回帰確認を行う。
+
+- 影響範囲
+  - ユーザー
+    - 結果画面で rated/unrated と理由が明示される。
+    - 一部これまで rated 扱いだったケースが unrated になる。
+  - データ
+    - `RESULT_READY.payload.summary` に追加フィールドが入る。
+    - ローカル stats archive は DO 判定を反映してレート更新可否を決める。
+  - 互換性
+    - 既存クライアントが summary 追加フィールドを無視できる前提。
+    - 既存保存データはフィールド欠損を許容する必要がある。
+  - Cloudflare
+    - DO の集計ロジックと WS payload が変わる。KV 変更はなし。
+
+- 対象ファイル / 対象レイヤ
+  - worker: `apps/worker/src/durable/room-state.ts`, 関連テスト
+  - shared: `packages/shared/src/ws/server.ts` など `RESULT_READY` 型定義
+  - client: 結果表示/統計取り込みの関連箇所
+  - docs: `docs/design/02_ws_protocol.md`, `docs/design/03_data_model.md` など必要最小限
+
+- テスト観点
+  - [ ] 全員提出・全 round 正常完了時のみ rated
+  - [ ] missing submission で unrated
+  - [ ] `SKIPPED` 1件で unrated
+  - [ ] `TIMEOUT` 1件で unrated
+  - [ ] `FORCE_ADVANCE` で unrated
+  - [ ] mismatch/conflict/incomplete で unrated
+  - [ ] unrated でも `RESULT_READY` が生成され、rating fields は null
+  - [ ] client 側で DO 判定が stats に反映される
+
+- ロールバック方針
+  - `RESULT_READY` summary 追加と strict rated 判定をまとめて revert し、既存の local stats 推定ロジックに戻す。
+
+- コミット分割計画
+  - [ ] docs/shared schema 更新
+  - [ ] worker strict rated 判定実装
+  - [ ] client/stats 反映
+  - [ ] テスト追加と検証


### PR DESCRIPTION
## 目的
- v1 の rated/unrated 判定を Durable Object 側で厳格化し、`RESULT_READY` に判定結果を明示する。

## 変更点
- `RESULT_READY.summary` に `is_rated` / `rated_block_reason` / `rating_before` / `rating_after` / `rating_delta` を追加
- worker で strict rated 判定を一元化し、`missing_submission` / `mismatch_observed_key` / `incomplete_match` / `skip_occurred` / `timeout_occurred` / `force_advanced` / `result_conflict` を unrated 理由として返すように変更
- `mismatch_observed_key` と `force_advance` の発生を match 単位で保持し、`RESULT_READY` 生成時に反映
- client stats は DO 提供の rated 判定を優先し、unrated 時はレート更新だけを停止
- design docs を新しい contract に更新

## 非変更点
- Elo 計算式自体は変更しない
- 監視ソース I/O 仕様は変更しない
- ロビー/KV スキーマは変更しない

## 影響範囲
- ユーザー: これまでレート対象になっていた一部の不完全マッチが unrated になる
- データ: `RESULT_READY.summary` に rated 判定フィールドが追加される
- 互換性: 既存クライアントが追加 summary フィールドを無視できる前提。rating 値は v1 では引き続き client ローカル計算
- Cloudflare: DO 集計ロジックと WS payload が更新される。KV 変更はなし

## テスト内容
- `node C:\work\infinitas_arena\infinitas_bpl\node_modules\typescript\bin\tsc --noEmit -p tsconfig.json`
- `cmd /c "rmdir /s /q .tmp\worker-tests 2>nul & mkdir .tmp\worker-tests & node_modules\.bin\esbuild.cmd apps\worker\src\durable\room-state.test.mjs --bundle --platform=node --format=esm --outfile=.tmp\worker-tests\room-state.test.mjs && node --test .tmp\worker-tests\room-state.test.mjs"`
- `npm run test:client-stats`

## 回帰確認項目
- clean match のみ rated になること
- `SKIPPED` / `TIMEOUT` / `FORCE_ADVANCE` / 未提出 / mismatch / 途中終了 / 引き分け競合で unrated になること
- unrated でも `RESULT_READY` と結果保存は成立し、client 側のレート更新だけが止まること

## ロールバック方針
- この PR の 4 コミットを順に revert して、旧来の local stats 推定に戻す

## 互換性影響の有無
- あり。`RESULT_READY.summary` に追加フィールドが入る

## Cloudflare resources 影響
- Durable Objects のみ。KV / Wrangler 設定変更なし

## docs/design 更新有無
- あり。`docs/design/01_fsm.md` / `docs/design/02_ws_protocol.md` / `docs/design/03_data_model.md`