### PR TITLE
ci: add github actions validation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable-x86_64-pc-windows-msvc
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/client/src-tauri -> target
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck TypeScript
+        run: npm run typecheck
+
+      - name: Build client
+        run: npm run build:client
+
+      - name: Run client stats tests
+        run: npm run test:client-stats
+
+      - name: Cargo check Tauri app
+        working-directory: apps/client/src-tauri
+        run: cargo check
+
+      - name: Bundle Worker with Wrangler dry-run
+        working-directory: apps/worker
+        run: npx wrangler deploy --dry-run

--- a/tasks/codex-ci-workflow.md
+++ b/tasks/codex-ci-workflow.md
@@ -49,8 +49,8 @@
 3. ローカルで対象コマンドを再実行し、結果を反映。
 
 ## 検証結果
-- [ ] `npm run typecheck`
-- [ ] `npm run build:client`
-- [ ] `cargo check`
-- [ ] `npm run test:client-stats`
-- [ ] `npx wrangler deploy --dry-run`
+- [x] `npm run typecheck`
+- [x] `npm run build:client`
+- [x] `cargo check`
+- [x] `npm run test:client-stats`
+- [x] `npx wrangler deploy --dry-run`

--- a/tasks/codex-ci-workflow.md
+++ b/tasks/codex-ci-workflow.md
@@ -1,0 +1,56 @@
+# Plan: codex/ci-workflow
+
+## 作業宣言
+- worktree: `C:\work\infinitas_arena\infinitas_bpl_ci`
+- branch: `codex/ci-workflow`
+- base branch: `v1`
+- BASE_SHA: `cafc52e8cca8b5a21abee80cc095ba60f552ef90`
+
+## 目的
+- GitHub Actions の CI workflow を追加し、既存の主要検証コマンドを pull request / push で自動実行できるようにする。
+- 本番リリース前チェックリストにある最低限の自動検証のうち、現時点でローカル再現できるものを CI へ載せる。
+
+## 非目的
+- lint 基盤の新規導入。
+- Worker/DO テスト実行基盤の整備。
+- Tauri 本番ビルドや Cloudflare 本番 deploy の自動化。
+- アプリ本体ロジックや設計仕様の変更。
+
+## 変更点
+- `.github/workflows/ci.yml` を追加する。
+- Windows runner 上で Node / Rust をセットアップし、既存 script ベースで typecheck / build / cargo check / stats test を実行する。
+- workflow は全 `push` / `pull_request` と `workflow_dispatch` を対象にする。
+
+## 影響範囲
+- ユーザー:
+  - 直接影響なし。
+- データ:
+  - 変更なし。
+- 互換性:
+  - アプリ実行時の互換性影響なし。
+- Cloudflare:
+  - deploy は行わず、ローカル bundle 相当のチェックまでに留める可能性がある。
+
+## 対象ファイル / 対象レイヤ
+- `.github/workflows/ci.yml`
+- `tasks/codex-ci-workflow.md`
+
+## テスト観点
+- workflow で使用する各コマンドがローカルで成功する。
+- Windows runner を前提とした Rust toolchain 設定と整合する。
+- 既存未整備項目（lint、Worker テスト）が CI 対象外であることが明確に分かる。
+
+## ロールバック方針
+- `.github/workflows/ci.yml` を revert して CI 導入前の状態へ戻す。
+
+## Commit Plan（コミット分割計画）
+1. CI workflow plan 追加（本ファイル）。
+2. GitHub Actions workflow 追加。
+3. ローカルで対象コマンドを再実行し、結果を反映。
+
+## 検証結果
+- [ ] `npm run typecheck`
+- [ ] `npm run build:client`
+- [ ] `cargo check`
+- [ ] `npm run test:client-stats`
+- [ ] `npx wrangler deploy --dry-run`


### PR DESCRIPTION
目的
- GitHub Actions の CI workflow を追加し、既存の主要検証を push / pull request ごとに自動実行できるようにする。

変更点
- `.github/workflows/ci.yml` を追加
- Windows runner で Node.js / Rust をセットアップ
- `npm run typecheck`
- `npm run build:client`
- `npm run test:client-stats`
- `cargo check`
- `npx wrangler deploy --dry-run`
  を CI で実行
- Plan Mode の記録を `tasks/codex-ci-workflow.md` に追加

非変更点
- lint 基盤の導入
- Worker/DO テスト実行基盤の整備
- Tauri 本番 build / Cloudflare 本番 deploy の自動化
- アプリ本体ロジックの変更

影響範囲（ユーザー / データ / 互換性 / Cloudflare）
- ユーザー: 直接影響なし
- データ: 変更なし
- 互換性: 実行時互換性への影響なし
- Cloudflare: dry-run の bundle 検証のみ。本番 deploy は行わない

テスト内容
- `npm run typecheck`
- `npm run build:client`
- `npm run test:client-stats`
- `cargo check` (`apps/client/src-tauri`)
- `npx wrangler deploy --dry-run` (`apps/worker`)

回帰確認項目
- Windows 環境で Rust toolchain と Node セットアップが通ること
- client build と stats test が継続して成功すること
- Worker bundle dry-run が CI 上でも成立すること

ロールバック方針
- `.github/workflows/ci.yml` と `tasks/codex-ci-workflow.md` を revert する

互換性影響の有無
- なし

Cloudflare resources 影響
- なし（dry-run のみ）

docs/design 更新有無
- なし
