### PR TITLE
feat(client): add Tauri updater foundation

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2.5.1",
+    "@tauri-apps/plugin-updater": "^2.5.1",
     "lucide-react": "^0.446.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/apps/client/src-tauri/Cargo.lock
+++ b/apps/client/src-tauri/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "ashpd"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +518,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +779,17 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1368,8 +1394,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1379,9 +1407,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1663,6 +1693,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,7 +1744,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -1876,6 +1923,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-tts",
+ "tauri-plugin-updater",
  "unicode-normalization",
 ]
 
@@ -2152,6 +2200,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2223,6 +2277,12 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2466,6 +2526,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2479,6 +2540,18 @@ dependencies = [
  "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2548,6 +2621,20 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2961,6 +3048,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3177,6 +3319,47 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -3205,7 +3388,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -3231,6 +3414,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3262,10 +3459,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3460,6 +3698,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3698,6 +3948,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3813,6 +4069,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3848,7 +4115,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3963,6 +4230,37 @@ dependencies = [
  "ts-rs",
  "tts",
  "uuid",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b7db616844d73d55e4d00190be101b29de463d5cb70321c2840fa4e9c414c4"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.12.28",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.59.0",
+ "zip",
 ]
 
 [[package]]
@@ -4206,6 +4504,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4567,6 +4875,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4785,6 +5099,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -4879,6 +5206,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webkit2gtk"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4920,6 +5257,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4980,7 +5326,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5060,19 +5406,6 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -5171,15 +5504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5199,15 +5523,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5223,6 +5538,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5702,6 +6026,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5827,6 +6161,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5857,6 +6197,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "indexmap 2.13.0",
+ "memchr",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/apps/client/src-tauri/Cargo.toml
+++ b/apps/client/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", features = [] }
 tauri-plugin-tts = "0.1.2"
+tauri-plugin-updater = "2.5.1"
 unicode-normalization = "0.1"
 
 [build-dependencies]

--- a/apps/client/src-tauri/UPDATER.md
+++ b/apps/client/src-tauri/UPDATER.md
@@ -1,0 +1,23 @@
+# Tauri updater configuration
+
+The updater plugin configuration lives in [tauri.conf.json](./tauri.conf.json) under `plugins.updater`.
+
+- `endpoints` is intentionally empty by default so local development can fall back to the current app version when no update server exists yet.
+- `pubkey` is a placeholder value for PR-1. Replace it before shipping a signed updater feed.
+- The frontend passes the updater `target` from `VITE_UPDATER_TARGET` or `?updateTarget=...`, defaulting to `windows-x86_64`.
+
+For build-time injection, override the plugin config with the `TAURI_UPDATER_PLUGIN_CONFIG` environment variable.
+
+Example:
+
+```json
+{
+  "endpoints": [
+    "https://example.invalid/api/app/update?target={{target}}&current_version={{current_version}}"
+  ],
+  "pubkey": "REPLACE_WITH_MINISIGN_PUBLIC_KEY",
+  "windows": {
+    "installMode": "passive"
+  }
+}
+```

--- a/apps/client/src-tauri/capabilities/default.json
+++ b/apps/client/src-tauri/capabilities/default.json
@@ -3,5 +3,5 @@
   "identifier": "main-capability",
   "description": "Capability for the main window",
   "windows": ["main"],
-  "permissions": ["core:default", "tts:default"]
+  "permissions": ["core:default", "tts:default", "updater:default"]
 }

--- a/apps/client/src-tauri/src/lib.rs
+++ b/apps/client/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ use watchers::SourceWatcherManager;
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_tts::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(SourceWatcherManager::default())
         .invoke_handler(tauri::generate_handler![
             get_source_watcher_state,

--- a/apps/client/src-tauri/tauri.conf.json
+++ b/apps/client/src-tauri/tauri.conf.json
@@ -26,9 +26,19 @@
     }
   },
   "bundle": {
-    "active": false,
+    "active": true,
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/icon.ico"
     ]
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": [],
+      "pubkey": "untrusted comment: minisign public key: 4A4ADDE56402CA4F\nRWRPygJk5d1KSlGI01qVinTVXwhY3suiXcBLG1RysjR2HbIHqHcXJiah",
+      "windows": {
+        "installMode": "passive"
+      }
+    }
   }
 }

--- a/apps/client/src/app/AppBootstrap.tsx
+++ b/apps/client/src/app/AppBootstrap.tsx
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+import { App } from "./App";
+import { UpdaterGateDialog } from "../components/UpdaterGateDialog";
+import { useAppUpdater } from "../hooks/useAppUpdater";
+import { appUpdaterService } from "../services/updater/updater-service";
+
+export function AppBootstrap() {
+  const snapshot = useAppUpdater((state) => state);
+
+  useEffect(() => {
+    void appUpdaterService.bootstrap();
+  }, []);
+
+  if (snapshot.phase === "continue-app" || snapshot.phase === "done") {
+    return <App />;
+  }
+
+  return (
+    <UpdaterGateDialog
+      snapshot={snapshot}
+      onStartUpdate={() => {
+        void appUpdaterService.installAvailableUpdate();
+      }}
+    />
+  );
+}

--- a/apps/client/src/components/UpdaterGateDialog.tsx
+++ b/apps/client/src/components/UpdaterGateDialog.tsx
@@ -1,0 +1,222 @@
+import { AlertTriangle, Download, LoaderCircle, ShieldAlert } from "lucide-react";
+import type { AppUpdaterState } from "../stores/updater-store";
+
+interface UpdaterGateDialogProps {
+  snapshot: AppUpdaterState;
+  onStartUpdate: () => void;
+}
+
+function formatByteCount(bytes: number | null): string {
+  if (bytes === null || !Number.isFinite(bytes) || bytes < 0) {
+    return "--";
+  }
+
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+
+  const units = ["KB", "MB", "GB"];
+  let value = bytes / 1024;
+  let unitIndex = 0;
+
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+
+  return `${value.toFixed(value >= 100 ? 0 : 1)} ${units[unitIndex]}`;
+}
+
+function createPhaseCopy(snapshot: AppUpdaterState): {
+  title: string;
+  statusText: string;
+  bodyLines: string[];
+  Icon: typeof LoaderCircle;
+  accentClass: string;
+  iconClass: string;
+  buttonLabel: string | null;
+} {
+  switch (snapshot.phase) {
+    case "update-available":
+      return {
+        title: "更新が必要です",
+        statusText: "最新の更新が見つかりました。",
+        bodyLines: [
+          "最新のバージョンがあります。",
+          "更新中はアプリを操作できません。",
+          "更新後に再起動します。",
+        ],
+        Icon: Download,
+        accentClass: "text-cyan-300",
+        iconClass: "border-cyan-500/20 bg-cyan-500/10 text-cyan-300",
+        buttonLabel: "更新する",
+      };
+    case "downloading":
+      return {
+        title: "更新しています",
+        statusText: "更新をダウンロードしています...",
+        bodyLines: ["更新中はアプリを操作できません。"],
+        Icon: LoaderCircle,
+        accentClass: "text-cyan-300",
+        iconClass: "border-cyan-500/20 bg-cyan-500/10 text-cyan-300",
+        buttonLabel: null,
+      };
+    case "installing":
+      return {
+        title: "更新しています",
+        statusText: "更新を適用しています...",
+        bodyLines: ["更新中はアプリを操作できません。", "更新後に再起動します。"],
+        Icon: LoaderCircle,
+        accentClass: "text-cyan-300",
+        iconClass: "border-cyan-500/20 bg-cyan-500/10 text-cyan-300",
+        buttonLabel: null,
+      };
+    case "failed":
+      return {
+        title: "更新に失敗しました",
+        statusText: snapshot.failure?.message ?? "更新の確認に失敗しました",
+        bodyLines: ["現在のバージョンで起動します。"],
+        Icon: AlertTriangle,
+        accentClass: "text-amber-300",
+        iconClass: "border-amber-500/20 bg-amber-500/10 text-amber-300",
+        buttonLabel: null,
+      };
+    case "idle":
+    case "checking":
+    default:
+      return {
+        title: "起動しています",
+        statusText: "更新を確認しています...",
+        bodyLines: ["起動前の準備を進めています。"],
+        Icon: LoaderCircle,
+        accentClass: "text-cyan-300",
+        iconClass: "border-cyan-500/20 bg-cyan-500/10 text-cyan-300",
+        buttonLabel: null,
+      };
+  }
+}
+
+export function UpdaterGateDialog({ snapshot, onStartUpdate }: UpdaterGateDialogProps) {
+  const copy = createPhaseCopy(snapshot);
+  const progressPercent = snapshot.progress.percent;
+  const showProgress = snapshot.phase === "downloading" || snapshot.phase === "installing";
+  const showVersionMeta = snapshot.currentVersion !== null || snapshot.nextVersion !== null;
+  const progressWidth =
+    progressPercent !== null && Number.isFinite(progressPercent)
+      ? `${Math.max(8, Math.min(100, progressPercent))}%`
+      : snapshot.phase === "installing"
+        ? "100%"
+        : "30%";
+
+  return (
+    <main className="flex min-h-screen w-full items-center justify-center overflow-hidden bg-[#101114] px-4 py-8 text-white">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(34,211,238,0.16),transparent_38%),linear-gradient(180deg,#111214_0%,#09090b_100%)]" />
+
+      <div
+        className="relative z-10 w-full max-w-[460px] overflow-hidden rounded-[32px] border border-white/10 bg-[#16171a]/95 shadow-[0_40px_120px_rgba(0,0,0,0.45)] backdrop-blur-xl"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="updater-gate-title"
+      >
+        <div className="p-8 text-center">
+          <div className={`mb-6 inline-flex rounded-full border p-4 ${copy.iconClass}`}>
+            <copy.Icon
+              size={42}
+              strokeWidth={2.5}
+              className={snapshot.phase === "checking" || snapshot.phase === "downloading" || snapshot.phase === "installing" ? "animate-spin" : undefined}
+            />
+          </div>
+
+          <p className={`mb-3 text-[10px] font-black uppercase tracking-[0.35em] ${copy.accentClass}`}>
+            Startup Update Gate
+          </p>
+          <h1 id="updater-gate-title" className="text-3xl font-black tracking-tight text-white">
+            {copy.title}
+          </h1>
+          <p className="mt-3 text-sm font-semibold text-gray-200">{copy.statusText}</p>
+
+          <div className="mt-5 space-y-2 text-sm leading-relaxed text-gray-400">
+            {copy.bodyLines.map((line) => (
+              <p key={line}>{line}</p>
+            ))}
+          </div>
+        </div>
+
+        {showVersionMeta ? (
+          <div className="mx-8 rounded-2xl border border-white/5 bg-black/25 p-5 text-left">
+            <span className="block text-[10px] font-black uppercase tracking-[0.28em] text-gray-500">
+              Version
+            </span>
+            <div className="mt-3 grid grid-cols-2 gap-4">
+              <div>
+                <span className="block text-[10px] font-black uppercase tracking-[0.28em] text-gray-500">
+                  Current
+                </span>
+                <strong className="mt-1 block text-sm font-black text-white">
+                  {snapshot.currentVersion ?? "--"}
+                </strong>
+              </div>
+              <div>
+                <span className="block text-[10px] font-black uppercase tracking-[0.28em] text-gray-500">
+                  Update
+                </span>
+                <strong className="mt-1 block text-sm font-black text-white">
+                  {snapshot.nextVersion ?? "--"}
+                </strong>
+              </div>
+            </div>
+          </div>
+        ) : null}
+
+        {showProgress ? (
+          <div className="mx-8 mt-6 rounded-2xl border border-white/5 bg-black/25 p-5 text-left">
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-[10px] font-black uppercase tracking-[0.28em] text-gray-500">
+                Download Event
+              </span>
+              <span className="text-xs font-black text-cyan-300">
+                {snapshot.progress.event ?? "Started"}
+              </span>
+            </div>
+
+            <div className="mt-4 h-2 overflow-hidden rounded-full bg-white/10">
+              <div
+                className={`h-full rounded-full bg-gradient-to-r from-cyan-400 via-cyan-300 to-white ${progressPercent === null ? "animate-pulse" : ""}`}
+                style={{ width: progressWidth }}
+              />
+            </div>
+
+            <div className="mt-4 flex items-center justify-between gap-4 text-xs text-gray-400">
+              <span>
+                {formatByteCount(snapshot.progress.downloadedBytes)}
+                {snapshot.progress.totalBytes !== null
+                  ? ` / ${formatByteCount(snapshot.progress.totalBytes)}`
+                  : ""}
+              </span>
+              <span>
+                {progressPercent !== null ? `${progressPercent}%` : snapshot.phase === "installing" ? "Installing" : "Streaming"}
+              </span>
+            </div>
+          </div>
+        ) : null}
+
+        <div className="px-8 py-8">
+          {copy.buttonLabel ? (
+            <button
+              type="button"
+              onClick={onStartUpdate}
+              className="w-full rounded-2xl bg-cyan-400 py-4 text-sm font-black uppercase tracking-[0.2em] text-black transition-all hover:bg-cyan-300"
+            >
+              {copy.buttonLabel}
+            </button>
+          ) : (
+            <div className="flex items-center justify-center gap-2 rounded-2xl border border-white/5 bg-white/[0.02] px-4 py-4 text-[11px] font-black uppercase tracking-[0.24em] text-gray-500">
+              <ShieldAlert size={14} />
+              アプリ本体はまだ起動していません
+            </div>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/client/src/hooks/useAppUpdater.ts
+++ b/apps/client/src/hooks/useAppUpdater.ts
@@ -1,0 +1,7 @@
+import { type AppUpdaterState, useUpdaterStore } from "../stores/updater-store";
+
+export function useAppUpdater<TSelected>(
+  selector: (state: AppUpdaterState) => TSelected,
+): TSelected {
+  return useUpdaterStore(selector);
+}

--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { App } from "./app/App";
+import { AppBootstrap } from "./app/AppBootstrap";
 import "./styles.css";
 
 const container = document.getElementById("root");
@@ -11,6 +11,6 @@ if (!container) {
 
 createRoot(container).render(
   <StrictMode>
-    <App />
+    <AppBootstrap />
   </StrictMode>,
 );

--- a/apps/client/src/runtime/runtime-config.ts
+++ b/apps/client/src/runtime/runtime-config.ts
@@ -14,6 +14,11 @@ export interface RuntimeSettingsDefaults {
   sourcePaths: RuntimeSourcePathDefaults;
 }
 
+export interface RuntimeUpdaterConfig {
+  target: string | undefined;
+  checkTimeoutMs: number;
+}
+
 export interface RuntimeConfig {
   debugUiEnabled: boolean;
   instanceId: string | null;
@@ -21,6 +26,7 @@ export interface RuntimeConfig {
   mockScenarioId: string | null;
   autoCapture: boolean;
   captureDelayMs: number;
+  updater: RuntimeUpdaterConfig;
   settingsDefaults: RuntimeSettingsDefaults;
 }
 
@@ -65,6 +71,13 @@ const displayName = readSearchParam("name");
 const playerId = readSearchParam("playerId");
 const apiBaseUrl = readSearchParam("api");
 const source = parseSourceType(readSearchParam("source"));
+const updaterTarget =
+  readSearchParam("updateTarget") ?? import.meta.env.VITE_UPDATER_TARGET?.trim() ?? "windows-x86_64";
+const updaterTimeoutEnvRaw = import.meta.env.VITE_UPDATER_CHECK_TIMEOUT_MS?.trim();
+const updaterTimeoutEnv =
+  updaterTimeoutEnvRaw && updaterTimeoutEnvRaw.length > 0
+    ? Number(updaterTimeoutEnvRaw)
+    : Number.NaN;
 
 export const runtimeConfig: RuntimeConfig = {
   debugUiEnabled: import.meta.env.DEV,
@@ -73,6 +86,12 @@ export const runtimeConfig: RuntimeConfig = {
   mockScenarioId: readSearchParam("scenario") ?? null,
   autoCapture: readFlagParam("capture"),
   captureDelayMs: readNumberParam("captureDelayMs", 500),
+  updater: {
+    target: updaterTarget.trim().length > 0 ? updaterTarget.trim() : undefined,
+    checkTimeoutMs: Number.isFinite(updaterTimeoutEnv)
+      ? updaterTimeoutEnv
+      : readNumberParam("updateTimeoutMs", 10000),
+  },
   settingsDefaults: {
     apiBaseUrl,
     playerId,

--- a/apps/client/src/services/updater/updater-config.ts
+++ b/apps/client/src/services/updater/updater-config.ts
@@ -1,0 +1,16 @@
+import type { CheckOptions } from "@tauri-apps/plugin-updater";
+import { runtimeConfig } from "../../runtime/runtime-config";
+
+export const STARTUP_UPDATER_FALLBACK_DELAY_MS = 2400;
+
+export function getStartupUpdaterCheckOptions(): CheckOptions {
+  const options: CheckOptions = {
+    timeout: runtimeConfig.updater.checkTimeoutMs,
+  };
+
+  if (runtimeConfig.updater.target) {
+    options.target = runtimeConfig.updater.target;
+  }
+
+  return options;
+}

--- a/apps/client/src/services/updater/updater-service.ts
+++ b/apps/client/src/services/updater/updater-service.ts
@@ -1,0 +1,274 @@
+import type { DownloadEvent, Update } from "@tauri-apps/plugin-updater";
+import { isTauriRuntime } from "../tauri-bridge";
+import {
+  STARTUP_UPDATER_FALLBACK_DELAY_MS,
+  getStartupUpdaterCheckOptions,
+} from "./updater-config";
+import { updaterStore } from "../../stores/updater-store";
+
+type UpdaterApiModule = typeof import("@tauri-apps/plugin-updater");
+type FailureStage = "check" | "download" | "install";
+
+const UPDATER_LOG_PREFIX = "[app-updater]";
+
+function logInfo(message: string, context?: Record<string, unknown>): void {
+  if (context) {
+    console.info(UPDATER_LOG_PREFIX, message, context);
+    return;
+  }
+
+  console.info(UPDATER_LOG_PREFIX, message);
+}
+
+function logError(message: string, error: unknown, context?: Record<string, unknown>): void {
+  if (context) {
+    console.error(UPDATER_LOG_PREFIX, message, context, error);
+    return;
+  }
+
+  console.error(UPDATER_LOG_PREFIX, message, error);
+}
+
+function formatErrorDetail(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+function failureMessage(stage: FailureStage): string {
+  switch (stage) {
+    case "download":
+      return "更新のダウンロードに失敗しました";
+    case "install":
+      return "更新の適用に失敗しました";
+    case "check":
+    default:
+      return "更新の確認に失敗しました";
+  }
+}
+
+let updaterApiPromise: Promise<UpdaterApiModule> | null = null;
+
+async function getUpdaterApi(): Promise<UpdaterApiModule> {
+  updaterApiPromise ??= import("@tauri-apps/plugin-updater");
+  return updaterApiPromise;
+}
+
+class AppUpdaterService {
+  private startupPromise: Promise<void> | null = null;
+  private installPromise: Promise<void> | null = null;
+  private fallbackTimerId: number | null = null;
+  private pendingUpdate: Update | null = null;
+
+  async bootstrap(): Promise<void> {
+    if (this.startupPromise !== null) {
+      return this.startupPromise;
+    }
+
+    this.startupPromise = this.runBootstrap();
+    return this.startupPromise;
+  }
+
+  async installAvailableUpdate(): Promise<void> {
+    if (this.installPromise !== null) {
+      return this.installPromise;
+    }
+
+    this.installPromise = this.runInstallFlow();
+    try {
+      await this.installPromise;
+    } finally {
+      this.installPromise = null;
+    }
+  }
+
+  private async runBootstrap(): Promise<void> {
+    if (!isTauriRuntime()) {
+      logInfo("Skipping startup updater check outside the Tauri runtime.");
+      updaterStore.allowAppStart();
+      return;
+    }
+
+    const options = getStartupUpdaterCheckOptions();
+    updaterStore.beginChecking();
+    logInfo("Starting updater check.", options.target ? { target: options.target } : undefined);
+
+    try {
+      const { check } = await getUpdaterApi();
+      const update = await check(options);
+
+      if (update === null) {
+        logInfo("Updater check completed with no update.");
+        updaterStore.allowAppStart();
+        return;
+      }
+
+      this.pendingUpdate = update;
+      logInfo("Updater check found an available update.", {
+        currentVersion: update.currentVersion,
+        nextVersion: update.version,
+      });
+      updaterStore.setUpdateAvailable({
+        currentVersion: update.currentVersion,
+        nextVersion: update.version,
+      });
+    } catch (error) {
+      this.handleFailure("check", error);
+    }
+  }
+
+  private async runInstallFlow(): Promise<void> {
+    const update = this.pendingUpdate;
+    if (update === null) {
+      return;
+    }
+
+    const currentVersion = update.currentVersion;
+    const nextVersion = update.version;
+    let downloadedBytes = 0;
+    let totalBytes: number | null = null;
+
+    updaterStore.beginDownload({
+      currentVersion,
+      nextVersion,
+    });
+    logInfo("Starting update download.", {
+      currentVersion,
+      nextVersion,
+    });
+
+    try {
+      await update.download((event) => {
+        if (event.event === "Started") {
+          totalBytes = event.data.contentLength ?? null;
+        } else if (event.event === "Progress") {
+          downloadedBytes += event.data.chunkLength;
+        } else if (event.event === "Finished" && totalBytes !== null) {
+          downloadedBytes = totalBytes;
+        }
+
+        updaterStore.updateDownloadProgress(
+          this.createProgressSnapshot(event, downloadedBytes, totalBytes),
+        );
+        logInfo("Updater progress event.", {
+          event: event.event,
+          downloadedBytes,
+          totalBytes,
+        });
+      });
+    } catch (error) {
+      await this.closePendingUpdate();
+      this.handleFailure("download", error, {
+        currentVersion,
+        nextVersion,
+      });
+      return;
+    }
+
+    updaterStore.beginInstall({
+      currentVersion,
+      nextVersion,
+    });
+    logInfo("Starting update install.", {
+      currentVersion,
+      nextVersion,
+    });
+
+    try {
+      await update.install();
+      updaterStore.markDone({
+        currentVersion,
+        nextVersion,
+      });
+      logInfo("Updater install completed.");
+    } catch (error) {
+      await this.closePendingUpdate();
+      this.handleFailure("install", error, {
+        currentVersion,
+        nextVersion,
+      });
+    }
+  }
+
+  private createProgressSnapshot(
+    event: DownloadEvent,
+    downloadedBytes: number,
+    totalBytes: number | null,
+  ) {
+    const percent =
+      totalBytes !== null && totalBytes > 0
+        ? Math.min(100, Math.round((downloadedBytes / totalBytes) * 100))
+        : event.event === "Finished"
+          ? 100
+          : null;
+
+    return {
+      event: event.event,
+      downloadedBytes,
+      totalBytes,
+      percent,
+    };
+  }
+
+  private handleFailure(
+    stage: FailureStage,
+    error: unknown,
+    context: { currentVersion?: string; nextVersion?: string } = {},
+  ): void {
+    const message = failureMessage(stage);
+    const detail = formatErrorDetail(error);
+
+    logError(message, error, context);
+    updaterStore.setFailed({
+      stage,
+      message,
+      detail,
+      currentVersion: context.currentVersion ?? null,
+      nextVersion: context.nextVersion ?? null,
+    });
+    this.scheduleFallbackStart();
+  }
+
+  private scheduleFallbackStart(): void {
+    if (typeof window === "undefined") {
+      updaterStore.allowAppStart();
+      return;
+    }
+
+    if (this.fallbackTimerId !== null) {
+      window.clearTimeout(this.fallbackTimerId);
+    }
+
+    this.fallbackTimerId = window.setTimeout(() => {
+      this.fallbackTimerId = null;
+      logInfo("Continuing to the current app version after updater fallback.");
+      updaterStore.allowAppStart();
+    }, STARTUP_UPDATER_FALLBACK_DELAY_MS);
+  }
+
+  private async closePendingUpdate(): Promise<void> {
+    if (this.pendingUpdate === null) {
+      return;
+    }
+
+    try {
+      await this.pendingUpdate.close();
+    } catch (error) {
+      logError("Failed to close updater resource.", error);
+    } finally {
+      this.pendingUpdate = null;
+    }
+  }
+}
+
+export const appUpdaterService = new AppUpdaterService();

--- a/apps/client/src/stores/updater-store.ts
+++ b/apps/client/src/stores/updater-store.ts
@@ -1,0 +1,153 @@
+import { createExternalStore, useExternalStore } from "./create-store";
+
+export type AppUpdaterPhase =
+  | "idle"
+  | "checking"
+  | "update-available"
+  | "downloading"
+  | "installing"
+  | "failed"
+  | "done"
+  | "continue-app";
+
+export type UpdaterFailureStage = "check" | "download" | "install";
+export type UpdaterProgressEvent = "Started" | "Progress" | "Finished" | null;
+
+export interface UpdaterProgressState {
+  event: UpdaterProgressEvent;
+  downloadedBytes: number;
+  totalBytes: number | null;
+  percent: number | null;
+}
+
+export interface UpdaterFailureState {
+  stage: UpdaterFailureStage;
+  message: string;
+  detail: string;
+}
+
+export interface AppUpdaterState {
+  phase: AppUpdaterPhase;
+  currentVersion: string | null;
+  nextVersion: string | null;
+  progress: UpdaterProgressState;
+  failure: UpdaterFailureState | null;
+}
+
+interface VersionState {
+  currentVersion: string | null;
+  nextVersion: string | null;
+}
+
+interface FailureInput extends VersionState {
+  stage: UpdaterFailureStage;
+  message: string;
+  detail: string;
+}
+
+const emptyProgress: UpdaterProgressState = {
+  event: null,
+  downloadedBytes: 0,
+  totalBytes: null,
+  percent: null,
+};
+
+const initialState: AppUpdaterState = {
+  phase: "idle",
+  currentVersion: null,
+  nextVersion: null,
+  progress: emptyProgress,
+  failure: null,
+};
+
+const internalStore = createExternalStore<AppUpdaterState>(initialState);
+
+export const updaterStore = {
+  ...internalStore,
+  beginChecking(): void {
+    internalStore.setState((state) => ({
+      ...state,
+      phase: "checking",
+      failure: null,
+      progress: emptyProgress,
+    }));
+  },
+  setUpdateAvailable({ currentVersion, nextVersion }: VersionState): void {
+    internalStore.setState((state) => ({
+      ...state,
+      phase: "update-available",
+      currentVersion,
+      nextVersion,
+      failure: null,
+      progress: emptyProgress,
+    }));
+  },
+  beginDownload({ currentVersion, nextVersion }: VersionState): void {
+    internalStore.setState((state) => ({
+      ...state,
+      phase: "downloading",
+      currentVersion,
+      nextVersion,
+      failure: null,
+      progress: {
+        event: "Started",
+        downloadedBytes: 0,
+        totalBytes: null,
+        percent: 0,
+      },
+    }));
+  },
+  updateDownloadProgress(progress: UpdaterProgressState): void {
+    internalStore.setState((state) => ({
+      ...state,
+      progress,
+    }));
+  },
+  beginInstall({ currentVersion, nextVersion }: VersionState): void {
+    internalStore.setState((state) => ({
+      ...state,
+      phase: "installing",
+      currentVersion,
+      nextVersion,
+      failure: null,
+      progress: {
+        ...state.progress,
+        event: "Finished",
+        percent: 100,
+      },
+    }));
+  },
+  setFailed({ stage, message, detail, currentVersion, nextVersion }: FailureInput): void {
+    internalStore.setState((state) => ({
+      ...state,
+      phase: "failed",
+      currentVersion,
+      nextVersion,
+      failure: {
+        stage,
+        message,
+        detail,
+      },
+    }));
+  },
+  markDone({ currentVersion, nextVersion }: VersionState): void {
+    internalStore.setState((state) => ({
+      ...state,
+      phase: "done",
+      currentVersion,
+      nextVersion,
+    }));
+  },
+  allowAppStart(): void {
+    internalStore.setState((state) => ({
+      ...state,
+      phase: "continue-app",
+    }));
+  },
+};
+
+export function useUpdaterStore<TSelected>(
+  selector: (state: AppUpdaterState) => TSelected,
+): TSelected {
+  return useExternalStore(internalStore, selector);
+}

--- a/apps/client/src/vite-env.d.ts
+++ b/apps/client/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_UPDATER_TARGET?: string;
+  readonly VITE_UPDATER_CHECK_TIMEOUT_MS?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tauri-apps/api": "^2.5.1",
+        "@tauri-apps/plugin-updater": "^2.5.1",
         "lucide-react": "^0.446.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
@@ -2402,6 +2403,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-updater": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.5.1.tgz",
+      "integrity": "sha512-7fNJraKRbKkxguMY5lG2W20pBvAUkLu+cqnbu0UcK7DqeZgrAnNECcGBIDG6fJ6C+0fAp2V2dMIgznhffOBCcg==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.0.0"
       }
     },
     "node_modules/@types/babel__core": {


### PR DESCRIPTION
## 目的
- INFINITAS Arena クライアントに Tauri 2 updater plugin を導入し、起動時のみ更新確認する基盤を追加する
- 更新ありのときは通常画面へ進ませず、キャンセル不可モーダルと進捗表示を経て install まで進める
- check / download / install の失敗時は現行バージョンで通常起動へフォールバックする

## 変更点
- Tauri updater plugin の依存追加、Rust 登録、capability 追加、`createUpdaterArtifacts: true` 設定
- 公開鍵と updater endpoint を `plugins.updater` に集約し、`TAURI_UPDATER_PLUGIN_CONFIG` で差し替えられる構成へ整理
- `AppBootstrap` / updater store / service / gate dialog を追加し、起動時の更新確認、強制モーダル、進捗表示、失敗時フォールバックを実装
- updater 設定差し替え手順を `apps/client/src-tauri/UPDATER.md` に追記

## 非変更点
- Cloudflare Worker / KV / R2 の更新配信実装
- GitHub Actions や配布自動化
- beta/stable 分離、強制アップデート、min_supported_version
- 設定画面からの手動更新確認
- Windows コード署名証明書の導入

## 影響範囲
- ユーザー: 起動時に updater 判定が入り、更新ありの場合のみブロッキング UI が表示される
- データ: 永続データ形式の変更なし
- 互換性: 既存アプリの通常起動フローに updater ゲートが追加されるが、失敗時は現行版で継続する
- Cloudflare: なし。後続 PR で endpoint 実装を差し込む前提の受け口のみ追加

## テスト内容
- `npm run typecheck:client`
- `npm run build:client`
- `cargo check` (`apps/client/src-tauri`)
- `npm run lint`
- `npm run test:client-stats`

## 回帰確認項目
- updater endpoint 未接続時でもエラー表示後に通常起動できること
- 更新なしで通常起動できること
- 更新ありで強制モーダルと進捗表示が出ること
- `更新する` 押下で download -> install へ進むこと
- check / download / install 失敗時に起動不能にならないこと

## ロールバック方針
- updater 導入コミットを戻し、既存の直接起動フローへ復帰する
- Tauri plugin / capability / config 追加を取り消して updater ゲートを削除する

## 互換性影響
- 永続データ互換性への影響なし
- docs/design の更新なし

## Cloudflare resources 影響
- なし
