### PR TITLE
Add Cloudflare Worker update API

### DIFF
--- a/apps/update-worker/README.md
+++ b/apps/update-worker/README.md
@@ -1,0 +1,69 @@
+# update-worker
+
+Cloudflare Workers で Tauri 2 updater の dynamic update server を提供する package です。
+
+## 必要な Cloudflare リソース
+
+- Worker: `infinitas-arena-update-api`
+- KV namespace: `infinitas-arena-config`
+- R2 bucket: `infinitas-arena-updates`
+
+## Binding 名
+
+- `APP_KV`: 更新設定を読む KV binding
+- `APP_BUCKET`: `.sig` を読む R2 binding
+- `DOWNLOAD_BASE_URL`: 配布 MSI を返すためのベース URL
+
+`DOWNLOAD_BASE_URL` には配布 URL のベースを設定します。v1 では `https://pub-f873923a35b944bbb316013ecc7e3805.r2.dev` を入れていますが、配布先を切り替える場合はここだけ差し替えます。
+
+## API
+
+- Endpoint: `GET /api/app/update`
+- Query:
+  - `version`: クライアントの現在バージョン
+  - `target`: `windows-x86_64`
+
+判定ルール:
+
+- `app:update:disabled == "true"` のときは `204 No Content`
+- `app:stable:latest` が未設定または invalid のときは `500`
+- `version >= latest` のときは `204 No Content`
+- `version < latest` のときは `200 OK` と updater JSON
+
+返却 JSON は dynamic update server 形式で、少なくとも `version`, `url`, `signature` を返します。`signature` には `app.msi.sig` のファイル内容そのものを入れます。
+
+## KV キー
+
+- `app:stable:latest`
+  - 例: `1.0.1`
+- `app:update:disabled`
+  - 例: `false`
+
+## R2 パス規約
+
+```text
+bpl-app/
+  stable/
+    1.0.1/
+      windows-x86_64/
+        app.msi
+        app.msi.sig
+```
+
+Worker は `app.msi` の URL を `DOWNLOAD_BASE_URL + objectKey` で組み立て、`.sig` は `APP_BUCKET` から読み出して JSON に含めます。
+
+## ローカル開発
+
+1. [wrangler.toml](./wrangler.toml) の `APP_KV` namespace ID を実際の `infinitas-arena-config` ID に置き換える
+2. 必要なら `DOWNLOAD_BASE_URL` を配布 URL に合わせて更新する
+3. `npm --workspace @infinitas/update-worker run dev`
+4. 別ターミナルから `curl "http://127.0.0.1:8787/api/app/update?version=1.0.0&target=windows-x86_64"`
+
+ローカルの `wrangler dev` では binding がシミュレートされるため、KV / R2 を使った update 判定をそのまま確認できます。
+
+## デプロイ
+
+- `npm --workspace @infinitas/update-worker run build`
+- `npm --workspace @infinitas/update-worker run deploy`
+
+`build` は `wrangler deploy --dry-run` を使った bundle 確認です。`deploy` 前に namespace ID と `DOWNLOAD_BASE_URL` を本番値で確認してください。

--- a/apps/update-worker/package.json
+++ b/apps/update-worker/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@infinitas/update-worker",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "build": "wrangler deploy --dry-run",
+    "deploy": "wrangler deploy",
+    "test": "tsx --test src/index.test.mjs src/lib/version.test.mjs",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  }
+}

--- a/apps/update-worker/src/index.test.mjs
+++ b/apps/update-worker/src/index.test.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import worker from "./index.ts";
+
+const DOWNLOAD_BASE_URL = "https://pub-f873923a35b944bbb316013ecc7e3805.r2.dev";
+
+function createEnv({
+  latest = "1.0.1",
+  disabled = "false",
+  signature = "BASE64_SIGNATURE",
+} = {}) {
+  return {
+    APP_KV: {
+      async get(key, type) {
+        assert.equal(type, "text");
+        if (key === "app:stable:latest") {
+          return latest;
+        }
+        if (key === "app:update:disabled") {
+          return disabled;
+        }
+        return null;
+      },
+    },
+    APP_BUCKET: {
+      async get(key) {
+        if (key !== "bpl-app/stable/1.0.1/windows-x86_64/app.msi.sig") {
+          return null;
+        }
+        if (signature === null) {
+          return null;
+        }
+        return {
+          async text() {
+            return signature;
+          },
+        };
+      },
+    },
+    DOWNLOAD_BASE_URL,
+  };
+}
+
+async function readJson(response) {
+  return JSON.parse(await response.text());
+}
+
+test("returns 200 updater JSON when a newer version exists", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/api/app/update?version=1.0.0&target=windows-x86_64"),
+    createEnv(),
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("content-type"), "application/json; charset=utf-8");
+
+  const payload = await readJson(response);
+  assert.equal(payload.version, "1.0.1");
+  assert.equal(
+    payload.url,
+    `${DOWNLOAD_BASE_URL}/bpl-app/stable/1.0.1/windows-x86_64/app.msi`,
+  );
+  assert.equal(payload.signature, "BASE64_SIGNATURE");
+  assert.equal(payload.notes, "不具合修正");
+  assert.equal(payload.pub_date, "2026-03-09T00:00:00.000Z");
+});
+
+test("returns 204 when current version is already latest", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/api/app/update?version=1.0.1&target=windows-x86_64"),
+    createEnv(),
+  );
+
+  assert.equal(response.status, 204);
+  assert.equal(await response.text(), "");
+});
+
+test("returns 204 when updates are disabled", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/api/app/update?version=1.0.0&target=windows-x86_64"),
+    createEnv({ disabled: "true" }),
+  );
+
+  assert.equal(response.status, 204);
+});
+
+test("returns 400 when target is missing", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/api/app/update?version=1.0.0"),
+    createEnv(),
+  );
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await readJson(response), { error: "target is required" });
+});
+
+test("returns 400 when version is missing", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/api/app/update?target=windows-x86_64"),
+    createEnv(),
+  );
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await readJson(response), { error: "version is required" });
+});
+
+test("returns 400 when target is unsupported", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/api/app/update?version=1.0.0&target=darwin-x86_64"),
+    createEnv(),
+  );
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await readJson(response), { error: "invalid target" });
+});
+
+test("returns 500 when latest version is not configured", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/api/app/update?version=1.0.0&target=windows-x86_64"),
+    createEnv({ latest: null }),
+  );
+
+  assert.equal(response.status, 500);
+  assert.deepEqual(await readJson(response), { error: "internal error" });
+});
+
+test("returns 500 when signature object is missing", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/api/app/update?version=1.0.0&target=windows-x86_64"),
+    createEnv({ signature: null }),
+  );
+
+  assert.equal(response.status, 500);
+  assert.deepEqual(await readJson(response), { error: "internal error" });
+});

--- a/apps/update-worker/src/index.ts
+++ b/apps/update-worker/src/index.ts
@@ -1,0 +1,15 @@
+import { notFound } from "./lib/response";
+import { handleUpdateRequest } from "./routes/update";
+import type { Env } from "./types/env";
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/api/app/update") {
+      return handleUpdateRequest(request, env);
+    }
+
+    return notFound();
+  },
+};

--- a/apps/update-worker/src/lib/response.ts
+++ b/apps/update-worker/src/lib/response.ts
@@ -1,0 +1,41 @@
+const JSON_CONTENT_TYPE = "application/json; charset=utf-8";
+
+function json(status: number, payload: unknown, headers?: HeadersInit): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      "content-type": JSON_CONTENT_TYPE,
+      ...headers,
+    },
+  });
+}
+
+export function ok(payload: unknown): Response {
+  return json(200, payload);
+}
+
+export function badRequest(message: string): Response {
+  return json(400, { error: message });
+}
+
+export function internalError(): Response {
+  return json(500, { error: "internal error" });
+}
+
+export function methodNotAllowed(allowed: string[]): Response {
+  return json(
+    405,
+    { error: "method not allowed" },
+    {
+      Allow: allowed.join(", "),
+    },
+  );
+}
+
+export function noContent(): Response {
+  return new Response(null, { status: 204 });
+}
+
+export function notFound(): Response {
+  return json(404, { error: "not found" });
+}

--- a/apps/update-worker/src/lib/update.ts
+++ b/apps/update-worker/src/lib/update.ts
@@ -1,0 +1,121 @@
+import type { Env } from "../types/env";
+import type { UpdateCheckQuery, UpdateResponse } from "../types/update";
+import { normalizeVersion } from "./version";
+
+export const SUPPORTED_TARGET = "windows-x86_64";
+
+const UPDATE_DISABLED_KEY = "app:update:disabled";
+const LATEST_VERSION_KEY = "app:stable:latest";
+const ARTIFACT_PREFIX = "bpl-app/stable";
+const MSI_FILE_NAME = "app.msi";
+const DEFAULT_UPDATE_NOTES = "不具合修正";
+const DEFAULT_UPDATE_PUB_DATE = "2026-03-09T00:00:00.000Z";
+
+export class UpdateBadRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UpdateBadRequestError";
+  }
+}
+
+export class UpdateInternalError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UpdateInternalError";
+  }
+}
+
+export function parseAndValidateQuery(request: Request): UpdateCheckQuery {
+  const url = new URL(request.url);
+  const version = url.searchParams.get("version");
+  if (version === null || version.trim().length === 0) {
+    throw new UpdateBadRequestError("version is required");
+  }
+
+  const target = url.searchParams.get("target");
+  if (target === null || target.trim().length === 0) {
+    throw new UpdateBadRequestError("target is required");
+  }
+
+  if (target !== SUPPORTED_TARGET) {
+    throw new UpdateBadRequestError("invalid target");
+  }
+
+  try {
+    return {
+      currentVersion: normalizeVersion(version),
+      target,
+    };
+  } catch {
+    throw new UpdateBadRequestError("invalid version");
+  }
+}
+
+export async function isUpdateDisabled(env: Env): Promise<boolean> {
+  const rawValue = await env.APP_KV.get(UPDATE_DISABLED_KEY, "text");
+  return rawValue?.trim().toLowerCase() === "true";
+}
+
+export async function readLatestVersion(env: Env): Promise<string> {
+  const rawValue = await env.APP_KV.get(LATEST_VERSION_KEY, "text");
+  if (rawValue === null || rawValue.trim().length === 0) {
+    throw new UpdateInternalError("latest version is not configured");
+  }
+
+  try {
+    return normalizeVersion(rawValue);
+  } catch {
+    throw new UpdateInternalError("latest version is invalid");
+  }
+}
+
+export function buildArtifactPath(version: string, target: string): string {
+  return `${ARTIFACT_PREFIX}/${version}/${target}/${MSI_FILE_NAME}`;
+}
+
+export async function readSignature(env: Env, objectKey: string): Promise<string> {
+  const object = await env.APP_BUCKET.get(`${objectKey}.sig`);
+  if (object === null) {
+    throw new UpdateInternalError("signature object is missing");
+  }
+
+  const signature = (await object.text()).trim();
+  if (signature.length === 0) {
+    throw new UpdateInternalError("signature object is empty");
+  }
+
+  return signature;
+}
+
+export function buildUpdateUrl(env: Env, objectKey: string): string {
+  const baseUrl = env.DOWNLOAD_BASE_URL.trim().replace(/\/+$/, "");
+  if (baseUrl.length === 0) {
+    throw new UpdateInternalError("download base url is not configured");
+  }
+
+  return `${baseUrl}/${objectKey}`;
+}
+
+interface BuildUpdateResponseInput {
+  version: string;
+  url: string;
+  signature: string;
+  notes?: string;
+  pubDate?: string;
+}
+
+export function buildUpdateResponse({
+  version,
+  url,
+  signature,
+  notes = DEFAULT_UPDATE_NOTES,
+  pubDate = DEFAULT_UPDATE_PUB_DATE,
+}: BuildUpdateResponseInput): UpdateResponse {
+  return {
+    version,
+    url,
+    signature,
+    notes,
+    pub_date: pubDate,
+  };
+}

--- a/apps/update-worker/src/lib/version.test.mjs
+++ b/apps/update-worker/src/lib/version.test.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { compareVersions, normalizeVersion } from "./version.ts";
+
+test("compareVersions handles numeric patch ordering", () => {
+  assert.equal(compareVersions("1.0.9", "1.0.10") < 0, true);
+});
+
+test("normalizeVersion accepts a leading v", () => {
+  assert.equal(normalizeVersion("v1.0.0"), "1.0.0");
+});
+
+test("normalizeVersion rejects invalid semver", () => {
+  assert.throws(() => normalizeVersion("1.0"), /invalid version/);
+});

--- a/apps/update-worker/src/lib/version.ts
+++ b/apps/update-worker/src/lib/version.ts
@@ -1,0 +1,123 @@
+interface ParsedVersion {
+  normalized: string;
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string[];
+}
+
+const SEMVER_PATTERN =
+  /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+const NUMERIC_IDENTIFIER_PATTERN = /^\d+$/;
+
+function parseVersion(version: string): ParsedVersion | null {
+  const match = SEMVER_PATTERN.exec(version.trim());
+  if (match === null) {
+    return null;
+  }
+
+  const majorRaw = match[1];
+  const minorRaw = match[2];
+  const patchRaw = match[3];
+  const prereleaseRaw = match[4];
+  const buildRaw = match[5];
+  if (majorRaw === undefined || minorRaw === undefined || patchRaw === undefined) {
+    return null;
+  }
+
+  const normalized = `${majorRaw}.${minorRaw}.${patchRaw}${prereleaseRaw ? `-${prereleaseRaw}` : ""}${buildRaw ? `+${buildRaw}` : ""}`;
+
+  return {
+    normalized,
+    major: Number.parseInt(majorRaw, 10),
+    minor: Number.parseInt(minorRaw, 10),
+    patch: Number.parseInt(patchRaw, 10),
+    prerelease: prereleaseRaw ? prereleaseRaw.split(".") : [],
+  };
+}
+
+function compareIdentifier(left: string, right: string): number {
+  const leftIsNumeric = NUMERIC_IDENTIFIER_PATTERN.test(left);
+  const rightIsNumeric = NUMERIC_IDENTIFIER_PATTERN.test(right);
+
+  if (leftIsNumeric && rightIsNumeric) {
+    return Number.parseInt(left, 10) - Number.parseInt(right, 10);
+  }
+
+  if (leftIsNumeric) {
+    return -1;
+  }
+
+  if (rightIsNumeric) {
+    return 1;
+  }
+
+  return left.localeCompare(right);
+}
+
+function comparePrerelease(left: string[], right: string[]): number {
+  if (left.length === 0 && right.length === 0) {
+    return 0;
+  }
+
+  if (left.length === 0) {
+    return 1;
+  }
+
+  if (right.length === 0) {
+    return -1;
+  }
+
+  const maxLength = Math.max(left.length, right.length);
+  for (let index = 0; index < maxLength; index += 1) {
+    const leftIdentifier = left[index];
+    const rightIdentifier = right[index];
+
+    if (leftIdentifier === undefined) {
+      return -1;
+    }
+
+    if (rightIdentifier === undefined) {
+      return 1;
+    }
+
+    const result = compareIdentifier(leftIdentifier, rightIdentifier);
+    if (result !== 0) {
+      return result;
+    }
+  }
+
+  return 0;
+}
+
+export function normalizeVersion(version: string): string {
+  const parsed = parseVersion(version);
+  if (parsed === null) {
+    throw new Error("invalid version");
+  }
+
+  return parsed.normalized;
+}
+
+export function compareVersions(current: string, latest: string): number {
+  const currentParsed = parseVersion(current);
+  const latestParsed = parseVersion(latest);
+
+  if (currentParsed === null || latestParsed === null) {
+    throw new Error("invalid version");
+  }
+
+  if (currentParsed.major !== latestParsed.major) {
+    return currentParsed.major - latestParsed.major;
+  }
+
+  if (currentParsed.minor !== latestParsed.minor) {
+    return currentParsed.minor - latestParsed.minor;
+  }
+
+  if (currentParsed.patch !== latestParsed.patch) {
+    return currentParsed.patch - latestParsed.patch;
+  }
+
+  return comparePrerelease(currentParsed.prerelease, latestParsed.prerelease);
+}

--- a/apps/update-worker/src/routes/update.ts
+++ b/apps/update-worker/src/routes/update.ts
@@ -1,0 +1,84 @@
+import { badRequest, internalError, methodNotAllowed, noContent, ok } from "../lib/response";
+import {
+  buildArtifactPath,
+  buildUpdateResponse,
+  buildUpdateUrl,
+  isUpdateDisabled,
+  parseAndValidateQuery,
+  readLatestVersion,
+  readSignature,
+  UpdateBadRequestError,
+} from "../lib/update";
+import { compareVersions } from "../lib/version";
+import type { Env } from "../types/env";
+
+export async function handleUpdateRequest(request: Request, env: Env): Promise<Response> {
+  if (request.method !== "GET") {
+    return methodNotAllowed(["GET"]);
+  }
+
+  console.info("[update-api] request start", { method: request.method, url: request.url });
+
+  try {
+    const query = parseAndValidateQuery(request);
+    console.info("[update-api] query received", query);
+
+    const disabled = await isUpdateDisabled(env);
+    console.info("[update-api] disabled flag", { disabled });
+    if (disabled) {
+      console.info("[update-api] no update", { reason: "disabled" });
+      return noContent();
+    }
+
+    const latestVersion = await readLatestVersion(env);
+    console.info("[update-api] latest version", { latestVersion });
+
+    if (compareVersions(query.currentVersion, latestVersion) >= 0) {
+      console.info("[update-api] no update", {
+        reason: "already-latest",
+        currentVersion: query.currentVersion,
+        latestVersion,
+      });
+      return noContent();
+    }
+
+    const objectKey = buildArtifactPath(latestVersion, query.target);
+    let signature: string;
+    try {
+      signature = await readSignature(env, objectKey);
+    } catch (error) {
+      console.error("[update-api] signature read failed", {
+        objectKey,
+        message: error instanceof Error ? error.message : "unknown error",
+      });
+      throw error;
+    }
+
+    const payload = buildUpdateResponse({
+      version: latestVersion,
+      url: buildUpdateUrl(env, objectKey),
+      signature,
+    });
+
+    console.info("[update-api] update available", {
+      currentVersion: query.currentVersion,
+      latestVersion,
+      objectKey,
+    });
+    return ok(payload);
+  } catch (error) {
+    if (error instanceof UpdateBadRequestError) {
+      console.warn("[update-api] invalid request", {
+        message: error.message,
+        url: request.url,
+      });
+      return badRequest(error.message);
+    }
+
+    console.error("[update-api] internal error", {
+      message: error instanceof Error ? error.message : "unknown error",
+      url: request.url,
+    });
+    return internalError();
+  }
+}

--- a/apps/update-worker/src/types/env.ts
+++ b/apps/update-worker/src/types/env.ts
@@ -1,0 +1,17 @@
+export interface KVNamespace {
+  get(key: string, type: "text"): Promise<string | null>;
+}
+
+export interface R2ObjectBody {
+  text(): Promise<string>;
+}
+
+export interface R2Bucket {
+  get(key: string): Promise<R2ObjectBody | null>;
+}
+
+export interface Env {
+  APP_KV: KVNamespace;
+  APP_BUCKET: R2Bucket;
+  DOWNLOAD_BASE_URL: string;
+}

--- a/apps/update-worker/src/types/update.ts
+++ b/apps/update-worker/src/types/update.ts
@@ -1,0 +1,12 @@
+export interface UpdateCheckQuery {
+  currentVersion: string;
+  target: string;
+}
+
+export interface UpdateResponse {
+  version: string;
+  url: string;
+  signature: string;
+  notes?: string;
+  pub_date?: string;
+}

--- a/apps/update-worker/tsconfig.json
+++ b/apps/update-worker/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/apps/update-worker/wrangler.toml
+++ b/apps/update-worker/wrangler.toml
@@ -1,0 +1,16 @@
+name = "infinitas-arena-update-api"
+main = "src/index.ts"
+compatibility_date = "2026-03-09"
+
+[vars]
+DOWNLOAD_BASE_URL = "https://pub-f873923a35b944bbb316013ecc7e3805.r2.dev"
+
+[[kv_namespaces]]
+binding = "APP_KV"
+id = "3eafa68e99cd442783c5af7ace3f69e1"
+preview_id = "470e5cad2ab84220bd8d2440706ce723"
+
+[[r2_buckets]]
+binding = "APP_BUCKET"
+bucket_name = "infinitas-arena-updates"
+preview_bucket_name = "infinitas-arena-updates"

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,10 @@
         "vite": "^7.1.7"
       }
     },
+    "apps/update-worker": {
+      "name": "@infinitas/update-worker",
+      "version": "0.1.0"
+    },
     "apps/worker": {
       "name": "@infinitas/worker",
       "version": "0.1.0",
@@ -1656,6 +1660,10 @@
     },
     "node_modules/@infinitas/shared": {
       "resolved": "packages/shared",
+      "link": true
+    },
+    "node_modules/@infinitas/update-worker": {
+      "resolved": "apps/update-worker",
       "link": true
     },
     "node_modules/@infinitas/worker": {

--- a/tasks/codex-update-api-worker.md
+++ b/tasks/codex-update-api-worker.md
@@ -1,0 +1,58 @@
+# codex-update-api-worker
+
+- BASE_SHA: `8393e203977c420d3bab27e8170b2a8870ac11d8`
+
+## 目的
+
+- Cloudflare Workers ベースの Tauri updater dynamic update server を既存 `apps/worker` に追加する。
+- `/api/app/update` で stable / Windows 向けの更新有無判定と updater JSON 応答を返せるようにする。
+- KV と R2 binding、ローカル開発手順、運用前提をコードと README に明示する。
+
+## 非目的
+
+- GitHub Actions からの upload 自動化
+- beta channel、rollout、min_supported_version、force update
+- Access 保護や認証導入
+- Durable Objects の利用
+- クライアント側 updater 基盤の再設計
+
+## 変更点
+
+- [ ] `apps/worker` に update route と pure function 群を追加
+- [ ] version / target validation、SemVer 比較、204 / 200 / 400 / 500 応答を実装
+- [ ] KV `app:stable:latest` / `app:update:disabled` と R2 `.sig` 読み出しを追加
+- [ ] Wrangler の KV / R2 / vars binding と `WorkerEnv` を更新
+- [ ] 正常系 / 異常系をカバーする worker テストを追加
+- [ ] Worker 向け README にローカル開発・デプロイ・R2 パス規約を追記
+
+## 影響範囲
+
+- ユーザー: Windows クライアントが update server から更新確認できるようになる
+- データ: KV に update 用の 2 キーを追加で参照するが、既存 room/lobby データ形式は変更しない
+- 互換性: updater dynamic server 形式の JSON を返す。既存 room/charts API 契約は変更しない
+- Cloudflare: Worker route、Wrangler bindings、KV / R2 リソース参照、download base URL 変数が追加される
+
+## 対象ファイル / 対象レイヤ
+
+- worker routes / services / utils (`apps/worker/src/**`)
+- worker env / configuration (`apps/worker/wrangler.toml`, `apps/worker/src/types/env.ts`)
+- worker package docs / tests (`apps/worker/**`)
+
+## テスト観点
+
+- `version=1.0.0`, latest=`1.0.1` で 200 + updater JSON
+- `version=1.0.1`, latest=`1.0.1` で 204
+- `disabled=true` で 204
+- `version` / `target` 欠落や unsupported target で 400
+- latest 未設定、`.sig` 不在で 500
+- worker typecheck / lint / test / wrangler build が通る
+
+## ロールバック方針
+
+- update route と binding 追加差分を丸ごと戻し、既存 room/charts worker のみの状態へ戻す
+- README の update API 追記を削除し、Cloudflare リソース参照を元に戻す
+
+## コミット分割計画
+
+- [ ] worker update API と bindings / tests の追加
+- [ ] README と検証結果の整理


### PR DESCRIPTION
## 目的
- Cloudflare Workers ベースの Tauri updater dynamic update server を追加する
- `GET /api/app/update` で stable / Windows 向けの更新確認 API を成立させる

## 変更点
- `apps/update-worker` を追加し、`GET /api/app/update` を実装
- `APP_KV` / `APP_BUCKET` / `DOWNLOAD_BASE_URL` binding を `wrangler.toml` に追加
- SemVer 正規化 / 比較、R2 `.sig` 読み出し、dynamic update server JSON 生成を分離実装
- 正常系 / 異常系テストと Worker README、Plan 記録を追加

## 非変更点
- GitHub Actions からの upload 自動化
- beta channel / rollout / min supported version / force update
- Access 保護、Durable Objects 導入
- 既存 room / charts Worker API の仕様変更

## 影響範囲
- ユーザー: Windows クライアントが update server から更新確認できるようになる
- データ: KV `app:stable:latest` / `app:update:disabled` と R2 の `.sig` を参照する
- 互換性: updater dynamic server JSON を返す。既存 room / charts API への変更はなし
- Cloudflare: 新規 Worker `infinitas-arena-update-api`、KV namespace `infinitas-arena-config`、R2 bucket `infinitas-arena-updates`、`DOWNLOAD_BASE_URL` を利用する

## テスト内容
- `npm --workspace @infinitas/update-worker run typecheck`
- `npm --workspace @infinitas/update-worker run test`
- `npm run lint`
- `npm --workspace @infinitas/update-worker run build`

## 回帰確認項目
- `version=1.0.0`, latest=`1.0.1` で 200
- `version=1.0.1`, latest=`1.0.1` で 204
- `disabled=true` で 204
- target 不正で 400
- `.sig` 不在で 500

## ロールバック方針
- `apps/update-worker` と task / README 追加差分を revert して update API を取り下げる

## 互換性影響の有無
- 既存 API 契約や保存形式への互換性影響なし

## Cloudflare resources 影響
- Worker / KV / R2 / env var binding の追加あり
- KV IDs は `preview_id=470e5cad2ab84220bd8d2440706ce723`、`id=3eafa68e99cd442783c5af7ace3f69e1` を設定済み

## docs/design 更新有無
- なし
