### PR TITLE
Add desktop updater release workflow

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -55,13 +55,13 @@ jobs:
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN_RELEASE: ${{ secrets.CLOUDFLARE_API_TOKEN_RELEASE }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           $required = @{
             TAURI_SIGNING_PRIVATE_KEY = $env:TAURI_SIGNING_PRIVATE_KEY
             TAURI_SIGNING_PRIVATE_KEY_PASSWORD = $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD
-            CLOUDFLARE_API_TOKEN = $env:CLOUDFLARE_API_TOKEN
+            CLOUDFLARE_API_TOKEN_RELEASE = $env:CLOUDFLARE_API_TOKEN_RELEASE
             CLOUDFLARE_ACCOUNT_ID = $env:CLOUDFLARE_ACCOUNT_ID
           }
 
@@ -149,7 +149,7 @@ jobs:
 
       - name: Upload updater artifacts to R2
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN_RELEASE: ${{ secrets.CLOUDFLARE_API_TOKEN_RELEASE }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           .\scripts\release\publish-updater-artifacts.ps1 `
@@ -159,7 +159,7 @@ jobs:
 
       - name: Update KV latest after upload
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN_RELEASE: ${{ secrets.CLOUDFLARE_API_TOKEN_RELEASE }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           & npx wrangler kv key put `
@@ -175,7 +175,7 @@ jobs:
 
       - name: Post-check published artifacts and latest
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN_RELEASE: ${{ secrets.CLOUDFLARE_API_TOKEN_RELEASE }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           $verifyDir = Join-Path $env:RUNNER_TEMP "release-post-check"

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,0 +1,226 @@
+name: Release Desktop
+
+on:
+  workflow_dispatch:
+    inputs:
+      download_base_path:
+        description: R2 prefix for updater artifacts
+        required: true
+        default: bpl-app/stable
+        type: string
+      app_target:
+        description: Tauri updater target
+        required: true
+        default: windows-x86_64
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-desktop-stable
+  cancel-in-progress: false
+
+env:
+  WRANGLER_CONFIG_PATH: apps/update-worker/wrangler.toml
+  KV_LATEST_KEY: app:stable:latest
+
+jobs:
+  release:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable-x86_64-pc-windows-msvc
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/client/src-tauri -> target
+
+      - name: Validate release secrets
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          $required = @{
+            TAURI_SIGNING_PRIVATE_KEY = $env:TAURI_SIGNING_PRIVATE_KEY
+            TAURI_SIGNING_PRIVATE_KEY_PASSWORD = $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+            CLOUDFLARE_API_TOKEN = $env:CLOUDFLARE_API_TOKEN
+            CLOUDFLARE_ACCOUNT_ID = $env:CLOUDFLARE_ACCOUNT_ID
+          }
+
+          foreach ($entry in $required.GetEnumerator()) {
+            if ([string]::IsNullOrWhiteSpace($entry.Value)) {
+              throw "Missing required secret: $($entry.Key)"
+            }
+          }
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Resolve release metadata
+        id: release_meta
+        env:
+          INPUT_DOWNLOAD_BASE_PATH: ${{ inputs.download_base_path }}
+          INPUT_APP_TARGET: ${{ inputs.app_target }}
+          VAR_CLOUDFLARE_R2_BUCKET: ${{ vars.CLOUDFLARE_R2_BUCKET }}
+          VAR_CLOUDFLARE_KV_BINDING_NAME: ${{ vars.CLOUDFLARE_KV_BINDING_NAME }}
+        run: |
+          $version = (node scripts/release/get-tauri-version.mjs | Out-String).Trim()
+          if ([string]::IsNullOrWhiteSpace($version)) {
+            throw "Version extraction returned empty output."
+          }
+
+          $downloadBasePath = $env:INPUT_DOWNLOAD_BASE_PATH
+          if ([string]::IsNullOrWhiteSpace($downloadBasePath)) {
+            $downloadBasePath = "bpl-app/stable"
+          }
+          $downloadBasePath = $downloadBasePath.Trim().Trim("/")
+          if ([string]::IsNullOrWhiteSpace($downloadBasePath)) {
+            throw "download_base_path resolved to an empty string."
+          }
+
+          $appTarget = $env:INPUT_APP_TARGET
+          if ([string]::IsNullOrWhiteSpace($appTarget)) {
+            $appTarget = "windows-x86_64"
+          }
+          $appTarget = $appTarget.Trim()
+          if ([string]::IsNullOrWhiteSpace($appTarget)) {
+            throw "app_target resolved to an empty string."
+          }
+
+          $bucket = $env:VAR_CLOUDFLARE_R2_BUCKET
+          if ([string]::IsNullOrWhiteSpace($bucket)) {
+            $bucket = "infinitas-arena-updates"
+          }
+
+          $kvBindingName = $env:VAR_CLOUDFLARE_KV_BINDING_NAME
+          if ([string]::IsNullOrWhiteSpace($kvBindingName)) {
+            $kvBindingName = "APP_KV"
+          }
+
+          $bundleDir = "apps/client/src-tauri/target/release/bundle/msi"
+          $artifactDir = Join-Path $env:RUNNER_TEMP "desktop-release\$version"
+          $r2ObjectPrefix = "$downloadBasePath/$version/$appTarget"
+
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "app_version=$version"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "app_target=$appTarget"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "bundle_dir=$bundleDir"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "artifact_dir=$artifactDir"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "r2_bucket=$bucket"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "r2_object_prefix=$r2ObjectPrefix"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "kv_binding_name=$kvBindingName"
+
+      - name: Build signed Windows updater artifacts
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: npm --workspace @infinitas/client run tauri:build
+
+      - name: Collect and normalize updater artifacts
+        run: |
+          .\scripts\release\collect-updater-artifacts.ps1 `
+            -BundleDirectory "${{ steps.release_meta.outputs.bundle_dir }}" `
+            -Version "${{ steps.release_meta.outputs.app_version }}" `
+            -OutputDirectory "${{ steps.release_meta.outputs.artifact_dir }}"
+
+      - name: Upload normalized updater artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-updater-${{ steps.release_meta.outputs.app_version }}
+          path: ${{ steps.release_meta.outputs.artifact_dir }}
+          if-no-files-found: error
+
+      - name: Upload updater artifacts to R2
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          .\scripts\release\publish-updater-artifacts.ps1 `
+            -BucketName "${{ steps.release_meta.outputs.r2_bucket }}" `
+            -ObjectPrefix "${{ steps.release_meta.outputs.r2_object_prefix }}" `
+            -ArtifactDirectory "${{ steps.release_meta.outputs.artifact_dir }}"
+
+      - name: Update KV latest after upload
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          & npx wrangler kv key put `
+            "${{ env.KV_LATEST_KEY }}" `
+            "${{ steps.release_meta.outputs.app_version }}" `
+            --config "${{ env.WRANGLER_CONFIG_PATH }}" `
+            --binding "${{ steps.release_meta.outputs.kv_binding_name }}" `
+            --remote
+
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to update KV latest key."
+          }
+
+      - name: Post-check published artifacts and latest
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          $verifyDir = Join-Path $env:RUNNER_TEMP "release-post-check"
+          New-Item -ItemType Directory -Force -Path $verifyDir | Out-Null
+
+          $bucket = "${{ steps.release_meta.outputs.r2_bucket }}"
+          $prefix = "${{ steps.release_meta.outputs.r2_object_prefix }}"
+
+          $msiObject = "$bucket/$prefix/app.msi"
+          $sigObject = "$bucket/$prefix/app.msi.sig"
+          $msiPath = Join-Path $verifyDir "app.msi"
+          $sigPath = Join-Path $verifyDir "app.msi.sig"
+
+          & npx wrangler r2 object get $msiObject --file $msiPath --remote
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to verify R2 object: $msiObject"
+          }
+
+          & npx wrangler r2 object get $sigObject --file $sigPath --remote
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to verify R2 object: $sigObject"
+          }
+
+          $msiSize = (Get-Item -LiteralPath $msiPath).Length
+          $sigContent = (Get-Content -Raw -LiteralPath $sigPath).Trim()
+          if ($msiSize -le 0) {
+            throw "Verified MSI object is empty."
+          }
+          if ([string]::IsNullOrWhiteSpace($sigContent)) {
+            throw "Verified MSI signature object is empty."
+          }
+
+          $latest = & npx wrangler kv key get `
+            "${{ env.KV_LATEST_KEY }}" `
+            --config "${{ env.WRANGLER_CONFIG_PATH }}" `
+            --binding "${{ steps.release_meta.outputs.kv_binding_name }}" `
+            --text `
+            --remote
+
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to verify KV latest key."
+          }
+
+          $latest = ($latest | Out-String).Trim()
+
+          if ($latest -ne "${{ steps.release_meta.outputs.app_version }}") {
+            throw "KV latest value '$latest' does not match released version '${{ steps.release_meta.outputs.app_version }}'."
+          }

--- a/apps/update-worker/README.md
+++ b/apps/update-worker/README.md
@@ -67,3 +67,76 @@ Worker は `app.msi` の URL を `DOWNLOAD_BASE_URL + objectKey` で組み立て
 - `npm --workspace @infinitas/update-worker run deploy`
 
 `build` は `wrangler deploy --dry-run` を使った bundle 確認です。`deploy` 前に namespace ID と `DOWNLOAD_BASE_URL` を本番値で確認してください。
+
+## GitHub Actions release workflow
+
+Windows 向け updater 配布は [release-desktop.yml](../../.github/workflows/release-desktop.yml) で行います。v1 では `workflow_dispatch` の手動実行のみを前提にし、以下の順序を固定しています。
+
+1. `apps/client/src-tauri/tauri.conf.json` から version を一度だけ抽出する
+2. GitHub Secrets 経由で updater 署名鍵を注入して Tauri build を行う
+3. `.msi` と `.msi.sig` を 1 件ずつ特定し、`app.msi` / `app.msi.sig` に正規化する
+4. R2 へ upload する
+5. upload 成功後のみ KV `app:stable:latest` を更新する
+6. R2 object と KV 値を `wrangler ... --remote` で post-check する
+
+### 必要な GitHub Secrets
+
+- `TAURI_SIGNING_PRIVATE_KEY`
+- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`
+- `CLOUDFLARE_API_TOKEN`
+- `CLOUDFLARE_ACCOUNT_ID`
+
+### 任意の GitHub Variables
+
+- `CLOUDFLARE_R2_BUCKET`
+  - 未設定時の既定値: `infinitas-arena-updates`
+- `CLOUDFLARE_KV_BINDING_NAME`
+  - 未設定時の既定値: `APP_KV`
+
+### workflow_dispatch inputs
+
+- `download_base_path`
+  - 既定値: `bpl-app/stable`
+- `app_target`
+  - 既定値: `windows-x86_64`
+
+### Cloudflare 側の準備
+
+- R2 bucket `infinitas-arena-updates` が存在していること
+- KV namespace `infinitas-arena-config` が存在していること
+- Worker `infinitas-arena-update-api` の Wrangler 設定が repo 内の [wrangler.toml](./wrangler.toml) と一致していること
+- 配布 URL のベースが `DOWNLOAD_BASE_URL` と整合していること
+
+### 起動方法
+
+1. GitHub Actions の `Release Desktop` workflow を開く
+2. 必要なら `download_base_path` / `app_target` を上書きする
+3. 実行後、artifact `desktop-updater-<version>` と R2 / KV の post-check 成功を確認する
+
+### R2 path 規約
+
+workflow は R2 に次の path で配置します。
+
+```text
+bpl-app/
+  stable/
+    <version>/
+      windows-x86_64/
+        app.msi
+        app.msi.sig
+```
+
+### latest 更新順序
+
+`app:stable:latest` は R2 upload の後にしか更新しません。build、artifact 収集、upload のいずれかが失敗した場合は workflow を fail させ、latest は進めません。
+
+### 失敗時の扱いとロールバック
+
+- version 抽出、artifact 収集、R2 upload、KV update のどこかで失敗したら workflow は fail します
+- 2 個目の R2 upload に失敗した場合は、先に upload した object を削除して partial upload を残さないようにします
+- `app:stable:latest` は upload 成功後にしか更新しないため、既存版は維持されます
+- もし KV を戻す必要がある場合は、`wrangler kv key put --binding APP_KV "app:stable:latest" "<previous-version>" --remote` を使って手動で直前 version に戻します
+
+### Wrangler v4 の注意
+
+Wrangler v4 では remote の R2 / KV 操作に `--remote` が必要です。release workflow でも `wrangler r2 object put/get/delete` と `wrangler kv key put/get` のすべてで `--remote` を明示しています。

--- a/apps/update-worker/README.md
+++ b/apps/update-worker/README.md
@@ -83,7 +83,7 @@ Windows 向け updater 配布は [release-desktop.yml](../../.github/workflows/r
 
 - `TAURI_SIGNING_PRIVATE_KEY`
 - `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`
-- `CLOUDFLARE_API_TOKEN`
+- `CLOUDFLARE_API_TOKEN_RELEASE`
 - `CLOUDFLARE_ACCOUNT_ID`
 
 ### 任意の GitHub Variables

--- a/scripts/release/collect-updater-artifacts.ps1
+++ b/scripts/release/collect-updater-artifacts.ps1
@@ -1,0 +1,61 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$BundleDirectory,
+
+  [Parameter(Mandatory = $true)]
+  [string]$Version,
+
+  [Parameter(Mandatory = $true)]
+  [string]$OutputDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Get-SingleArtifact {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$SearchRoot,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Pattern,
+
+    [Parameter(Mandatory = $true)]
+    [string]$VersionSubstring,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Label
+  )
+
+  $matches = @(Get-ChildItem -LiteralPath $SearchRoot -Recurse -File -Filter $Pattern |
+    Where-Object { $_.Name.Contains($VersionSubstring) } |
+    Sort-Object FullName)
+
+  if ($matches.Count -eq 0) {
+    throw "Missing $Label artifact in $SearchRoot for version $VersionSubstring."
+  }
+
+  if ($matches.Count -gt 1) {
+    $details = ($matches | ForEach-Object { $_.FullName }) -join [Environment]::NewLine
+    throw "Expected exactly one $Label artifact in $SearchRoot for version $VersionSubstring, found $($matches.Count):$([Environment]::NewLine)$details"
+  }
+
+  return $matches[0]
+}
+
+$resolvedBundleDirectory = (Resolve-Path -LiteralPath $BundleDirectory).Path
+New-Item -ItemType Directory -Force -Path $OutputDirectory | Out-Null
+
+$msiFile = Get-SingleArtifact -SearchRoot $resolvedBundleDirectory -Pattern "*.msi" -VersionSubstring $Version -Label ".msi"
+$sigFile = Get-SingleArtifact -SearchRoot $resolvedBundleDirectory -Pattern "*.msi.sig" -VersionSubstring $Version -Label ".msi.sig"
+
+$normalizedMsiPath = Join-Path $OutputDirectory "app.msi"
+$normalizedSigPath = Join-Path $OutputDirectory "app.msi.sig"
+
+Copy-Item -LiteralPath $msiFile.FullName -Destination $normalizedMsiPath -Force
+Copy-Item -LiteralPath $sigFile.FullName -Destination $normalizedSigPath -Force
+
+Write-Host "Collected MSI: $($msiFile.FullName)"
+Write-Host "Collected signature: $($sigFile.FullName)"
+Write-Host "Normalized MSI path: $normalizedMsiPath"
+Write-Host "Normalized signature path: $normalizedSigPath"

--- a/scripts/release/get-tauri-version.mjs
+++ b/scripts/release/get-tauri-version.mjs
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const configPath = resolve("apps/client/src-tauri/tauri.conf.json");
+const semverPattern =
+  /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+
+let config;
+
+try {
+  config = JSON.parse(readFileSync(configPath, "utf8"));
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Failed to read ${configPath}: ${message}`);
+  process.exit(1);
+}
+
+const rawVersion = typeof config.version === "string" ? config.version.trim() : "";
+const normalizedVersion = rawVersion.startsWith("v") ? rawVersion.slice(1) : rawVersion;
+
+if (normalizedVersion.length === 0) {
+  console.error(`Missing "version" in ${configPath}.`);
+  process.exit(1);
+}
+
+if (!semverPattern.test(normalizedVersion)) {
+  console.error(
+    `Version "${normalizedVersion}" from ${configPath} is not valid semver.`,
+  );
+  process.exit(1);
+}
+
+process.stdout.write(`${normalizedVersion}\n`);

--- a/scripts/release/publish-updater-artifacts.ps1
+++ b/scripts/release/publish-updater-artifacts.ps1
@@ -1,0 +1,54 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$BucketName,
+
+  [Parameter(Mandatory = $true)]
+  [string]$ObjectPrefix,
+
+  [Parameter(Mandatory = $true)]
+  [string]$ArtifactDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$resolvedArtifactDirectory = (Resolve-Path -LiteralPath $ArtifactDirectory).Path
+$artifactNames = @("app.msi", "app.msi.sig")
+$uploadedObjects = New-Object System.Collections.Generic.List[string]
+$cleanupFailures = New-Object System.Collections.Generic.List[string]
+
+try {
+  foreach ($artifactName in $artifactNames) {
+    $artifactPath = Join-Path $resolvedArtifactDirectory $artifactName
+    if (-not (Test-Path -LiteralPath $artifactPath)) {
+      throw "Missing normalized artifact: $artifactPath"
+    }
+
+    $objectPath = "$BucketName/$ObjectPrefix/$artifactName"
+    Write-Host "Uploading $artifactName to $objectPath"
+
+    & npx wrangler r2 object put $objectPath --file $artifactPath --remote
+    if ($LASTEXITCODE -ne 0) {
+      throw "wrangler r2 object put failed for $objectPath"
+    }
+
+    [void]$uploadedObjects.Add($objectPath)
+  }
+} catch {
+  for ($index = $uploadedObjects.Count - 1; $index -ge 0; $index -= 1) {
+    $uploadedObject = $uploadedObjects[$index]
+    Write-Warning "Upload failed. Deleting already uploaded object: $uploadedObject"
+
+    & npx wrangler r2 object delete $uploadedObject --remote
+    if ($LASTEXITCODE -ne 0) {
+      [void]$cleanupFailures.Add($uploadedObject)
+    }
+  }
+
+  if ($cleanupFailures.Count -gt 0) {
+    $failedCleanupList = $cleanupFailures -join ", "
+    throw "R2 upload failed and cleanup also failed for: $failedCleanupList"
+  }
+
+  throw
+}

--- a/tasks/release-desktop-updater.md
+++ b/tasks/release-desktop-updater.md
@@ -58,7 +58,17 @@
 
 ## コミット分割計画
 
-- [ ] 設計確認（既存 build / version / Wrangler / README の確認）
-- [ ] release workflow と補助スクリプト実装
-- [ ] README / 運用メモ更新
-- [ ] ローカル検証と差分確認
+- [x] 設計確認（既存 build / version / Wrangler / README の確認）
+- [x] release workflow と補助スクリプト実装
+- [x] README / 運用メモ更新
+- [x] ローカル検証と差分確認
+
+## 検証結果
+
+- `node scripts/release/get-tauri-version.mjs`
+- `npm ci`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run build:client`
+- `npm run test:worker`
+- `npm --workspace @infinitas/update-worker run build`

--- a/tasks/release-desktop-updater.md
+++ b/tasks/release-desktop-updater.md
@@ -1,0 +1,64 @@
+# release-desktop-updater
+
+## BASE_SHA
+
+- `4c3428a62e0130f1ebbb2a765d5ecb354fb698ad`
+
+## 目的
+
+- GitHub Actions 上で Windows 向け Tauri アプリをビルドし、updater 署名済み `.msi` / `.sig` を生成する
+- 生成物を Cloudflare R2 にアップロードし、成功後のみ KV の `app:stable:latest` を更新する
+- 手動実行可能な release workflow と、その運用に必要な README を整備する
+
+## 非目的
+
+- update API Worker 本体の実装や仕様追加
+- beta / rollout / min_supported_version / force-update の先回り実装
+- R2 bucket / KV namespace の新規作成自動化
+- Windows コード署名証明書の導入
+- GitHub Releases を配布の正本に戻すこと
+
+## 変更点
+
+- GitHub Actions workflow を追加し、Windows runner で Tauri build を実行する
+- CI で updater 署名鍵を環境変数注入し、`.msi` と `.sig` を収集して正規化する
+- Wrangler を使って R2 upload と KV 更新を順序保証付きで行う
+- 必要に応じて補助スクリプトまたは Wrangler 設定を追加し、責務を分離する
+- README または運用メモに secrets / vars / 実行手順 / ロールバックを追記する
+
+## 影響範囲
+
+- ユーザー: 配布フローのみ。アプリ実行時の UI / 機能仕様は変更しない
+- データ: `app:stable:latest` の更新手順にのみ影響し、値はアプリ version を単一ソースから反映する
+- 互換性: updater が参照する配布物 path 規約を固定化する
+- Cloudflare: R2 bucket への object upload、KV key put/get、Wrangler 認証に影響する
+
+## 対象ファイル / 対象レイヤ
+
+- `.github/workflows/*`
+- `README.md` および必要なら補助ドキュメント
+- `wrangler.jsonc` または既存 Wrangler 設定
+- 必要なら CI 用補助スクリプト
+- 参照のみ: `package.json`, `apps/client` / `src-tauri` の version source と build 設定
+
+## テスト観点
+
+- version を単一ソースから抽出できる
+- Windows build が updater 署名付き成果物を生成できる
+- `.msi` / `.sig` が 1 件ずつ特定でき、見つからなければ fail する
+- R2 upload 成功後のみ KV `app:stable:latest` が更新される
+- upload / KV / version 抽出の失敗で workflow が fail し、latest が進まない
+- Wrangler v4 の remote 操作として `--remote` が明示されている
+
+## ロールバック方針
+
+- workflow 失敗時は `app:stable:latest` を更新しない
+- 既存配布物と既存 latest を維持する
+- 必要時は KV を手動で直前 version に戻し、R2 上の誤配置物を確認して対処する
+
+## コミット分割計画
+
+- [ ] 設計確認（既存 build / version / Wrangler / README の確認）
+- [ ] release workflow と補助スクリプト実装
+- [ ] README / 運用メモ更新
+- [ ] ローカル検証と差分確認


### PR DESCRIPTION
- [x] WORKFLOW.md を確認した
- [x] QUALITY.md を満たしている

## 目的

GitHub Actions 上で Windows 向け Tauri updater 配布フローを整備し、署名付き build、R2 upload、KV `app:stable:latest` 更新までを手動実行できるようにする。

## 変更点

- `Release Desktop` workflow を追加し、`workflow_dispatch` で Windows runner 上の release フローを実行可能にした
- Tauri version 抽出、`.msi` / `.sig` 収集と正規化、R2 upload を補助スクリプトに分離した
- R2 upload 成功後のみ KV `app:stable:latest` を更新し、R2 / KV の post-check を追加した
- update-worker README に secrets、実行手順、R2 path 規約、rollback、Wrangler v4 `--remote` の注意を追記した
- Plan Mode 用の task ファイルに BASE_SHA と検証結果を記録した

## 非変更点

- update API Worker 本体の挙動
- beta / rollout / min_supported_version / force-update
- R2 bucket / KV namespace / custom domain の新規作成自動化
- Windows コード署名証明書
- GitHub Releases を配布正本に戻す変更

## 影響範囲

- ユーザー: 配布運用のみ。アプリ UI / ゲーム進行には影響しない
- データ: KV `app:stable:latest` の更新手順にのみ影響する
- 互換性: updater 配布物の R2 path を `bpl-app/stable/<version>/windows-x86_64/` に固定する
- Cloudflare: R2 object put/get/delete と KV key put/get を Wrangler v4 `--remote` で実行する

## テスト内容

- `node scripts/release/get-tauri-version.mjs`
- `npm ci`
- `npm run lint`
- `npm run typecheck`
- `npm run build:client`
- `npm run test:worker`
- `npm --workspace @infinitas/update-worker run build`

## 回帰確認項目

- 手動 workflow 実行で `.msi` / `.sig` が生成されること
- R2 に `bpl-app/stable/<version>/windows-x86_64/app.msi` と `app.msi.sig` が配置されること
- upload 成功後のみ KV `app:stable:latest` が更新されること
- upload 失敗時に latest が進まないこと

## ロールバック方針

- workflow 失敗時は KV を更新しない
- 2 個目の R2 upload 失敗時は先に upload した object を削除する
- 必要時は KV `app:stable:latest` を直前 version に手動で戻す

## 互換性影響の有無

配布運用の追加のみで、既存の client / worker contract 変更はない。

## Cloudflare resources 影響

既存の Worker / R2 / KV を利用する。新規 resource 作成は含まない。

## docs/design 更新有無

なし