### PR TITLE
Add deploy workflow for infinitas-arena worker

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,87 @@
+name: Deploy infinitas-arena Worker
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - v1
+    paths:
+      - "apps/worker/**"
+      - ".github/workflows/deploy-worker.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-worker-production
+  cancel-in-progress: false
+
+env:
+  WORKER_DIR: apps/worker
+  WORKER_NAME: infinitas-arena
+  WORKER_SMOKE_PATH: /api/charts?play_style=SP&level_filter=ANY
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Validate deploy configuration
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_DEPLOY_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_WORKERS_SUBDOMAIN: ${{ vars.CLOUDFLARE_WORKERS_SUBDOMAIN }}
+        run: |
+          required_vars=(
+            CLOUDFLARE_API_TOKEN
+            CLOUDFLARE_ACCOUNT_ID
+            CLOUDFLARE_WORKERS_SUBDOMAIN
+          )
+
+          for name in "${required_vars[@]}"; do
+            if [[ -z "${!name}" ]]; then
+              echo "Missing required configuration: ${name}" >&2
+              exit 1
+            fi
+          done
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Deploy Worker with Wrangler
+        working-directory: ${{ env.WORKER_DIR }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_DEPLOY_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx wrangler deploy
+
+      - name: Smoke check workers.dev deployment
+        env:
+          WORKER_SMOKE_URL: https://${{ env.WORKER_NAME }}.${{ vars.CLOUDFLARE_WORKERS_SUBDOMAIN }}.workers.dev${{ env.WORKER_SMOKE_PATH }}
+        run: |
+          body_file="$(mktemp)"
+
+          for attempt in 1 2 3 4 5; do
+            status_code="$(curl --silent --show-error --output "${body_file}" --write-out "%{http_code}" "${WORKER_SMOKE_URL}")"
+
+            if [[ "${status_code}" == 2* ]]; then
+              echo "Smoke check passed on attempt ${attempt}: ${WORKER_SMOKE_URL}"
+              exit 0
+            fi
+
+            if [[ "${attempt}" -eq 5 ]]; then
+              echo "Smoke check failed with HTTP ${status_code}: ${WORKER_SMOKE_URL}" >&2
+              cat "${body_file}" >&2
+              exit 1
+            fi
+
+            sleep 5
+          done

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -1,0 +1,80 @@
+# worker
+
+LOBBY 系本体 Cloudflare Worker を提供する package です。
+
+## Cloudflare リソース
+
+- Worker: `infinitas-arena`
+- Durable Object binding: `ROOM_DO`
+- KV binding: `ROOM_LOBBY_KV`
+- migration tag: `v1-room-do-lobby`
+
+この package は updater 用 Worker ではありません。desktop release は [release-desktop.yml](../../.github/workflows/release-desktop.yml)、updater API は [apps/update-worker](../update-worker/README.md) を使います。
+
+## Wrangler 設定
+
+- config: [wrangler.toml](./wrangler.toml)
+- working directory: `apps/worker`
+
+deploy は常にこの `wrangler.toml` を前提にします。repo ルートから曖昧に deploy せず、`apps/worker` を基準に `wrangler deploy` を実行します。
+
+## ローカル実行
+
+- install: `npm ci`
+- typecheck: `npm --workspace @infinitas/worker run typecheck`
+- dry-run deploy: `cd apps/worker && npx wrangler deploy --dry-run`
+- deploy: `cd apps/worker && npx wrangler deploy`
+
+## GitHub Actions deploy workflow
+
+LOBBY Worker の production deploy は [deploy-worker.yml](../../.github/workflows/deploy-worker.yml) で行います。
+
+### 役割
+
+- `apps/worker` の Worker を GitHub Actions から deploy する
+- `workflow_dispatch` で手動実行する
+- `push` 時は `v1` ブランチ上の次の変更で自動実行する
+  - `apps/worker/**`
+  - `.github/workflows/deploy-worker.yml`
+- deploy 後に `workers.dev` へ簡易疎通確認を行う
+
+### 必要な GitHub Secrets
+
+- `CLOUDFLARE_DEPLOY_TOKEN`
+- `CLOUDFLARE_ACCOUNT_ID`
+
+`CLOUDFLARE_DEPLOY_TOKEN` は workflow 内で `CLOUDFLARE_API_TOKEN` として渡します。用途は LOBBY Worker deploy 専用で、desktop release や updater 用 KV 更新には使いません。
+
+想定する最小権限:
+
+- `Account Settings: Read`
+- `Workers Scripts: Edit`
+- `Workers KV Storage: Edit`
+
+### 必要な GitHub Variables
+
+- `CLOUDFLARE_WORKERS_SUBDOMAIN`
+
+smoke check では次の URL を使います。
+
+```text
+https://infinitas-arena.<CLOUDFLARE_WORKERS_SUBDOMAIN>.workers.dev/api/charts?play_style=SP&level_filter=ANY
+```
+
+### 手動実行方法
+
+1. GitHub Actions の `Deploy infinitas-arena Worker` workflow を開く
+2. `Run workflow` から対象 ref を選んで実行する
+3. `Deploy Worker with Wrangler` と `Smoke check workers.dev deployment` の成功を確認する
+
+### 自動実行条件
+
+`push` では次の path に変更がある場合だけ実行します。
+
+```yaml
+paths:
+  - "apps/worker/**"
+  - ".github/workflows/deploy-worker.yml"
+```
+
+shared package 依存を後から追加したい場合は `paths` に明示的に足します。v1 では `apps/worker/**` を中心にした最小構成に留めます。

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -1,4 +1,4 @@
-name = "infinitas-bpl-worker"
+name = "infinitas-arena"
 main = "src/index.ts"
 compatibility_date = "2025-01-01"
 

--- a/tasks/codex-deploy-worker-workflow.md
+++ b/tasks/codex-deploy-worker-workflow.md
@@ -1,0 +1,58 @@
+# Plan: codex/deploy-worker-workflow
+
+## 作業宣言
+- worktree: `C:\work\infinitas_arena\infinitas_bpl`
+- branch: `codex/deploy-worker-workflow`
+- base branch: `v1`
+- BASE_SHA: `b3c83eaf9b077150b289f8ae9c74f44175f636db`
+
+## 目的
+- LOBBY 系 Cloudflare Worker を GitHub Actions から production deploy できる workflow を追加する。
+- `apps/worker/` 配下の変更時または手動実行時に `wrangler deploy` を実行できるようにする。
+- deploy 後に `workers.dev` への簡易疎通確認を自動で行えるようにする。
+
+## 非目的
+- desktop release workflow との統合。
+- updater 用 Worker / R2 / KV latest 更新の自動化。
+- staging 環境や複数 Worker 同時 deploy の導入。
+- Worker 本体 API の大規模変更。
+
+## 変更点
+- `.github/workflows/deploy-worker.yml` を追加する。
+- `apps/worker/wrangler.toml` の Worker 名を `infinitas-arena` に揃える。
+- `apps/worker/README.md` を追加し、deploy workflow の役割、手動実行、必要 secrets / variables、smoke check の前提を明記する。
+
+## 影響範囲
+- ユーザー:
+  - 直接影響なし。
+- データ:
+  - 本番 deploy 実行時に Worker script / DO migration が Cloudflare 側へ反映される。
+- 互換性:
+  - Worker 名は `apps/worker/wrangler.toml` を正として扱う。
+- Cloudflare:
+  - Workers Scripts / KV / DO migration を伴う production deploy workflow を追加する。
+
+## 対象ファイル / 対象レイヤ
+- `.github/workflows/deploy-worker.yml`
+- `apps/worker/wrangler.toml`
+- `apps/worker/README.md`
+- `tasks/codex-deploy-worker-workflow.md`
+
+## テスト観点
+- workflow が `workflow_dispatch` と `push(paths)` を持つ。
+- install は root workspace の `npm ci` で再現できる。
+- deploy は `apps/worker` を working directory にして `npx wrangler deploy` を実行する。
+- smoke check は `workers.dev` の `GET /api/charts?play_style=SP&level_filter=ANY` で 2xx を確認する。
+
+## ロールバック方針
+- workflow と Worker README を revert し、必要なら `apps/worker/wrangler.toml` の Worker 名を元に戻す。
+
+## Commit Plan（コミット分割計画）
+1. deploy workflow plan 追加。
+2. Worker deploy workflow と最小限の設定更新。
+3. Worker 用 README 追加と検証結果反映。
+
+## 検証予定
+- `npm --workspace @infinitas/worker run typecheck`
+- `cd apps/worker && npx wrangler deploy --dry-run`
+- `git diff --check`

--- a/tasks/codex-deploy-worker-workflow.md
+++ b/tasks/codex-deploy-worker-workflow.md
@@ -52,7 +52,7 @@
 2. Worker deploy workflow と最小限の設定更新。
 3. Worker 用 README 追加と検証結果反映。
 
-## 検証予定
-- `npm --workspace @infinitas/worker run typecheck`
-- `cd apps/worker && npx wrangler deploy --dry-run`
-- `git diff --check`
+## 検証結果
+- [x] `npm --workspace @infinitas/worker run typecheck`
+- [x] `cd apps/worker && npx wrangler deploy --dry-run`
+- [x] `git diff --check`


### PR DESCRIPTION
## 目的
- LOBBY 系本体 Cloudflare Worker `infinitas-arena` を GitHub Actions から production deploy できるようにする
- `apps/worker/` 配下の変更時または手動実行時に `wrangler deploy` を実行できるようにする

## 変更点
- `.github/workflows/deploy-worker.yml` を追加し、`workflow_dispatch` と `push(paths)` で Worker deploy を実行するようにした
- deploy を `apps/worker` working-directory の `npx wrangler deploy` に固定し、deploy 後に `workers.dev` への smoke check を追加した
- `apps/worker/wrangler.toml` の Worker 名を `infinitas-arena` に揃えた
- `apps/worker/README.md` を追加し、workflow の役割、手動実行方法、必要 secrets / variable を追記した

## 非変更点
- desktop release workflow
- updater 用 Worker / R2 upload / updater 用 KV 更新
- staging 環境
- custom domain 設定

## 影響範囲
- ユーザー: 直接影響なし
- データ: deploy 実行時に Worker script と DO migration が Cloudflare 側へ反映される
- 互換性: `apps/worker/wrangler.toml` の Worker 名を `infinitas-arena` として扱う
- Cloudflare: GitHub Actions から Worker production deploy を行う経路を追加。`CLOUDFLARE_DEPLOY_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` と `CLOUDFLARE_WORKERS_SUBDOMAIN` を利用

## テスト内容
- `npm --workspace @infinitas/worker run typecheck`
- `cd apps/worker && npx wrangler deploy --dry-run`

## 回帰確認項目
- `workflow_dispatch` で手動実行できること
- `v1` ブランチで `apps/worker/**` または `.github/workflows/deploy-worker.yml` 変更時のみ自動実行されること
- `apps/worker/wrangler.toml` を使って deploy し、`/api/charts?play_style=SP&level_filter=ANY` で smoke check できること

## ロールバック方針
- `deploy-worker.yml`、`apps/worker/README.md`、`apps/worker/wrangler.toml` の変更を revert して deploy workflow 導入前へ戻す

## 追加メモ
- docs/design の更新は不要と判断
- BASE_SHA: `b3c83eaf9b077150b289f8ae9c74f44175f636db`
