### PR TITLE
inf-notebook監視をsummary.json起点へ切り替え

### DIFF
--- a/apps/client/src-tauri/src/commands/source_directory_validation.rs
+++ b/apps/client/src-tauri/src/commands/source_directory_validation.rs
@@ -31,7 +31,7 @@ pub fn validate_source_directory(
         SourceType::InfDakenCounter => vec![join_path(base_directory, &["today_update.xml"])],
         SourceType::InfNotebook => vec![
             join_path(base_directory, &["export", "recent.json"]),
-            join_path(base_directory, &["records", "recent.json"]),
+            join_path(base_directory, &["records", "summary.json"]),
         ],
     };
 

--- a/apps/client/src-tauri/src/parsers/notebook.rs
+++ b/apps/client/src-tauri/src/parsers/notebook.rs
@@ -1,18 +1,30 @@
 use std::{
+    collections::{HashMap, HashSet},
     env, fs,
     path::{Path, PathBuf},
+    thread,
+    time::Duration,
 };
 
 use serde::Deserialize;
-use unicode_normalization::UnicodeNormalization;
+use serde_json::Value;
 
 use crate::{
     models::{ParsedSourceChange, ParsedSourceObservation, SourcePathsConfig, SourceType},
     parsers::{ParserInput, SourceParser},
 };
 
+const SUMMARY_DEBOUNCE_MS: u64 = 120;
+const SUMMARY_PARSE_RETRY_COUNT: usize = 2;
+const SUMMARY_PARSE_RETRY_DELAY_MS: u64 = 80;
+const RECENT_PARSE_RETRY_COUNT: usize = 2;
+const RECENT_PARSE_RETRY_DELAY_MS: u64 = 80;
+const RECENT_MISSING_RETRY_COUNT: usize = 2;
+const RECENT_MISSING_RETRY_DELAY_MS: u64 = 120;
+
 #[derive(Clone, Debug, Deserialize)]
 struct NotebookExportRecentFile {
+    #[serde(default)]
     list: Vec<NotebookRecentEntry>,
 }
 
@@ -25,21 +37,127 @@ struct NotebookRecentEntry {
     misscount: i64,
 }
 
+#[derive(Clone, Debug, Deserialize)]
+struct WorkerChartMasterSnapshot {
+    #[serde(default)]
+    charts: Vec<WorkerChartMasterChart>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct WorkerChartMasterChart {
+    play_style: String,
+    difficulty: String,
+    title: String,
+    title_search_key: String,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct SummaryChartKey {
+    musicname: String,
+    play_style: String,
+    difficulty: String,
+}
+
+#[derive(Clone, Debug)]
+struct SummaryLatestRecord {
+    musicname: String,
+    play_style: String,
+    difficulty: String,
+    latest_timestamp: String,
+}
+
+#[derive(Clone, Debug, Default)]
+struct SummarySnapshot {
+    latest_by_chart: HashMap<SummaryChartKey, String>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct ChartIndexKey {
+    play_style: String,
+    difficulty: String,
+    title_search_key: String,
+}
+
+#[derive(Clone, Debug, Default)]
+struct AliasCatalog {
+    alias_to_title_search_key: HashMap<String, String>,
+    chart_index: HashSet<ChartIndexKey>,
+}
+
+impl AliasCatalog {
+    fn resolve_alias_exact(&self, musicname: &str) -> Option<&String> {
+        self.alias_to_title_search_key.get(musicname)
+    }
+
+    fn has_chart(&self, play_style: &str, difficulty: &str, title_search_key: &str) -> bool {
+        self.chart_index.contains(&ChartIndexKey {
+            play_style: play_style.to_string(),
+            difficulty: difficulty.to_string(),
+            title_search_key: title_search_key.to_string(),
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+struct RecentIndexedRecord {
+    music: String,
+    difficulty_raw: String,
+    difficulty_normalized: Option<String>,
+    score: u32,
+    misscount: u32,
+}
+
+#[derive(Clone, Debug, Default)]
+struct RecentTimestampIndex {
+    by_timestamp: HashMap<String, Vec<RecentIndexedRecord>>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum NotebookResolutionStatus {
+    ResolvedFull,
+    ResolvedPartial,
+    UnresolvedAlias,
+    AmbiguousRecent,
+}
+
+#[derive(Clone, Debug)]
+struct NotebookResolutionResult {
+    status: NotebookResolutionStatus,
+    summary: SummaryLatestRecord,
+    title_search_key: Option<String>,
+    recent: Option<RecentIndexedRecord>,
+    warnings: Vec<String>,
+}
+
 pub struct NotebookParser {
-    export_recent_path: PathBuf,
-    export_recent_path_key: String,
-    last_seen_timestamp: Option<String>,
+    summary_path: PathBuf,
+    summary_path_key: String,
+    recent_path: PathBuf,
+    last_summary_snapshot: SummarySnapshot,
+    alias_catalog: AliasCatalog,
 }
 
 impl NotebookParser {
     pub fn new(source_paths: &SourcePathsConfig) -> Self {
-        let export_recent_path = PathBuf::from(source_paths.notebook_export_recent_json.trim());
-        let last_seen_timestamp = read_latest_timestamp(&export_recent_path).ok().flatten();
+        Self::new_internal(source_paths, load_alias_catalog())
+    }
 
+    #[cfg(test)]
+    fn new_with_catalog(source_paths: &SourcePathsConfig, alias_catalog: AliasCatalog) -> Self {
+        Self::new_internal(source_paths, alias_catalog)
+    }
+
+    fn new_internal(source_paths: &SourcePathsConfig, alias_catalog: AliasCatalog) -> Self {
+        let summary_path = PathBuf::from(source_paths.notebook_records_recent_json.trim());
+        let recent_path = PathBuf::from(source_paths.notebook_export_recent_json.trim());
+        let last_summary_snapshot = read_summary_snapshot_once(&summary_path)
+            .unwrap_or_else(|_| SummarySnapshot::default());
         Self {
-            export_recent_path_key: path_key(&export_recent_path),
-            export_recent_path,
-            last_seen_timestamp,
+            summary_path_key: path_key(&summary_path),
+            summary_path,
+            recent_path,
+            last_summary_snapshot,
+            alias_catalog,
         }
     }
 }
@@ -49,8 +167,7 @@ impl SourceParser for NotebookParser {
         let metadata = fs::metadata(&input.changed_path)
             .map_err(|error| format!("Failed to read {:?}: {error}", input.changed_path))?;
         let changed_path_key = path_key(&input.changed_path);
-
-        if changed_path_key != self.export_recent_path_key {
+        if changed_path_key != self.summary_path_key {
             return Ok(Some(ParsedSourceChange {
                 source: SourceType::InfNotebook,
                 file_path: input.changed_path.to_string_lossy().into_owned(),
@@ -59,75 +176,496 @@ impl SourceParser for NotebookParser {
             }));
         }
 
-        let export_recent = read_export_recent(&self.export_recent_path)?;
-        let latest_timestamp = export_recent
-            .list
-            .iter()
-            .map(|entry| entry.timestamp.as_str())
-            .max()
-            .map(str::to_string);
-        let previous_last_seen = self.last_seen_timestamp.as_deref();
+        thread::sleep(Duration::from_millis(SUMMARY_DEBOUNCE_MS));
+        let Some(current_summary_snapshot) = read_summary_snapshot_with_retry(&self.summary_path)?
+        else {
+            return Ok(None);
+        };
 
-        let observations = export_recent
-            .list
-            .iter()
-            .rev()
-            .filter(|entry| is_newer_timestamp(entry.timestamp.as_str(), previous_last_seen))
-            .map(parse_observation)
-            .collect::<Result<Vec<_>, _>>()?;
+        let changed_latest_entries =
+            extract_changed_latest_entries(&self.last_summary_snapshot, &current_summary_snapshot);
+        self.last_summary_snapshot = current_summary_snapshot;
+        if changed_latest_entries.is_empty() {
+            return Ok(Some(ParsedSourceChange {
+                source: SourceType::InfNotebook,
+                file_path: self.summary_path.to_string_lossy().into_owned(),
+                file_size_bytes: metadata.len(),
+                observations: Vec::new(),
+            }));
+        }
 
-        self.last_seen_timestamp = latest_timestamp;
+        let mut recent_index = read_recent_index_with_retry(&self.recent_path)?;
+        let resolution_results = resolve_latest_entries_with_recent_retry(
+            &changed_latest_entries,
+            &self.alias_catalog,
+            &self.recent_path,
+            &mut recent_index,
+        )?;
+        log_resolution_results(&resolution_results);
+
+        let observations = resolution_results
+            .iter()
+            .filter_map(resolution_result_to_observation)
+            .collect::<Vec<_>>();
 
         Ok(Some(ParsedSourceChange {
             source: SourceType::InfNotebook,
-            file_path: self.export_recent_path.to_string_lossy().into_owned(),
+            file_path: self.summary_path.to_string_lossy().into_owned(),
             file_size_bytes: metadata.len(),
             observations,
         }))
     }
 }
 
-fn read_latest_timestamp(path: &Path) -> Result<Option<String>, String> {
+fn read_summary_snapshot_once(path: &Path) -> Result<SummarySnapshot, String> {
     if !path.exists() {
-        return Ok(None);
+        return Ok(SummarySnapshot::default());
     }
-
-    let export_recent = read_export_recent(path)?;
-    Ok(export_recent
-        .list
-        .iter()
-        .map(|entry| entry.timestamp.as_str())
-        .max()
-        .map(str::to_string))
-}
-
-fn read_export_recent(path: &Path) -> Result<NotebookExportRecentFile, String> {
     let raw_json = fs::read_to_string(path)
         .map_err(|error| format!("Failed to read {}: {error}", path.to_string_lossy()))?;
-    serde_json::from_str::<NotebookExportRecentFile>(&raw_json).map_err(|error| {
-        format!(
-            "Failed to parse {} as inf-notebook recent.json: {error}",
+    parse_summary_snapshot(&raw_json)
+}
+
+fn read_summary_snapshot_with_retry(path: &Path) -> Result<Option<SummarySnapshot>, String> {
+    if !path.exists() {
+        return Err(format!(
+            "Failed to read {}: file does not exist.",
             path.to_string_lossy()
-        )
+        ));
+    }
+    for attempt in 0..=SUMMARY_PARSE_RETRY_COUNT {
+        let raw_json = fs::read_to_string(path)
+            .map_err(|error| format!("Failed to read {}: {error}", path.to_string_lossy()))?;
+        match parse_summary_snapshot(&raw_json) {
+            Ok(snapshot) => return Ok(Some(snapshot)),
+            Err(error) => {
+                if attempt < SUMMARY_PARSE_RETRY_COUNT {
+                    thread::sleep(Duration::from_millis(SUMMARY_PARSE_RETRY_DELAY_MS));
+                    continue;
+                }
+                eprintln!(
+                    "inf-notebook: ignored summary update because records/summary.json is not readable yet ({}): {error}",
+                    path.to_string_lossy()
+                );
+                return Ok(None);
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn parse_summary_snapshot(raw_json: &str) -> Result<SummarySnapshot, String> {
+    let root: Value = serde_json::from_str(raw_json)
+        .map_err(|error| format!("Failed to parse summary.json payload: {error}"))?;
+    let Some(musics) = root.get("musics").and_then(Value::as_object) else {
+        return Err("summary.json is missing object field 'musics'.".to_string());
+    };
+
+    let mut latest_by_chart = HashMap::new();
+    for (musicname_raw, playtype_value) in musics {
+        let musicname = musicname_raw.trim();
+        if musicname.is_empty() {
+            continue;
+        }
+        let Some(playtypes) = playtype_value.as_object() else {
+            continue;
+        };
+        for (playtype_raw, difficulty_value) in playtypes {
+            let Some(play_style) = normalize_play_style(playtype_raw) else {
+                continue;
+            };
+            let Some(difficulties) = difficulty_value.as_object() else {
+                continue;
+            };
+            for (difficulty_raw, chart_record_value) in difficulties {
+                let Some(difficulty) = normalize_chart_difficulty(difficulty_raw) else {
+                    continue;
+                };
+                let Some(latest_timestamp_raw) = extract_latest_timestamp(chart_record_value)
+                else {
+                    continue;
+                };
+                let Ok(latest_timestamp) = parse_timestamp(latest_timestamp_raw) else {
+                    continue;
+                };
+                latest_by_chart.insert(
+                    SummaryChartKey {
+                        musicname: musicname.to_string(),
+                        play_style: play_style.clone(),
+                        difficulty,
+                    },
+                    latest_timestamp,
+                );
+            }
+        }
+    }
+    Ok(SummarySnapshot { latest_by_chart })
+}
+
+fn extract_latest_timestamp(chart_record: &Value) -> Option<&str> {
+    let latest_node = chart_record.get("latest")?;
+    latest_node
+        .as_str()
+        .or_else(|| latest_node.get("timestamp").and_then(Value::as_str))
+        .or_else(|| chart_record.get("latest_timestamp").and_then(Value::as_str))
+}
+
+fn extract_changed_latest_entries(
+    previous_snapshot: &SummarySnapshot,
+    current_snapshot: &SummarySnapshot,
+) -> Vec<SummaryLatestRecord> {
+    let mut changed_entries = current_snapshot
+        .latest_by_chart
+        .iter()
+        .filter_map(|(key, latest_timestamp)| {
+            let previous = previous_snapshot.latest_by_chart.get(key);
+            if previous == Some(latest_timestamp) {
+                return None;
+            }
+            Some(SummaryLatestRecord {
+                musicname: key.musicname.clone(),
+                play_style: key.play_style.clone(),
+                difficulty: key.difficulty.clone(),
+                latest_timestamp: latest_timestamp.clone(),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    changed_entries.sort_by(|left, right| {
+        right
+            .latest_timestamp
+            .cmp(&left.latest_timestamp)
+            .then_with(|| left.musicname.cmp(&right.musicname))
+            .then_with(|| left.play_style.cmp(&right.play_style))
+            .then_with(|| left.difficulty.cmp(&right.difficulty))
+    });
+    changed_entries
+}
+
+fn read_recent_index_with_retry(path: &Path) -> Result<Option<RecentTimestampIndex>, String> {
+    if !path.exists() {
+        return Err(format!(
+            "Failed to read {}: file does not exist.",
+            path.to_string_lossy()
+        ));
+    }
+    for attempt in 0..=RECENT_PARSE_RETRY_COUNT {
+        let raw_json = fs::read_to_string(path)
+            .map_err(|error| format!("Failed to read {}: {error}", path.to_string_lossy()))?;
+        match parse_recent_timestamp_index(&raw_json) {
+            Ok(index) => return Ok(Some(index)),
+            Err(error) => {
+                if attempt < RECENT_PARSE_RETRY_COUNT {
+                    thread::sleep(Duration::from_millis(RECENT_PARSE_RETRY_DELAY_MS));
+                    continue;
+                }
+                eprintln!(
+                    "inf-notebook: could not parse export/recent.json yet ({}): {error}",
+                    path.to_string_lossy()
+                );
+                return Ok(None);
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn parse_recent_timestamp_index(raw_json: &str) -> Result<RecentTimestampIndex, String> {
+    let export_recent = serde_json::from_str::<NotebookExportRecentFile>(raw_json)
+        .map_err(|error| format!("Failed to parse export/recent.json payload: {error}"))?;
+    Ok(build_recent_timestamp_index(&export_recent.list))
+}
+
+fn build_recent_timestamp_index(entries: &[NotebookRecentEntry]) -> RecentTimestampIndex {
+    let mut by_timestamp: HashMap<String, Vec<RecentIndexedRecord>> = HashMap::new();
+    for entry in entries {
+        let timestamp = match parse_timestamp(entry.timestamp.as_str()) {
+            Ok(timestamp) => timestamp,
+            Err(error) => {
+                eprintln!(
+                    "inf-notebook: skipped recent entry due to timestamp parse error: {error}"
+                );
+                continue;
+            }
+        };
+        let score = match parse_metric_value(entry.score, "score", &timestamp) {
+            Ok(score) => score,
+            Err(error) => {
+                eprintln!("inf-notebook: skipped recent entry due to score parse error: {error}");
+                continue;
+            }
+        };
+        let misscount = match parse_metric_value(entry.misscount, "misscount", &timestamp) {
+            Ok(misscount) => misscount,
+            Err(error) => {
+                eprintln!(
+                    "inf-notebook: skipped recent entry due to misscount parse error: {error}"
+                );
+                continue;
+            }
+        };
+        by_timestamp
+            .entry(timestamp)
+            .or_default()
+            .push(RecentIndexedRecord {
+                music: entry.music.trim().to_string(),
+                difficulty_raw: entry.difficulty.trim().to_string(),
+                difficulty_normalized: normalize_chart_difficulty(entry.difficulty.as_str()),
+                score,
+                misscount,
+            });
+    }
+    RecentTimestampIndex { by_timestamp }
+}
+
+fn resolve_latest_entries_with_recent_retry(
+    changed_entries: &[SummaryLatestRecord],
+    alias_catalog: &AliasCatalog,
+    recent_path: &Path,
+    recent_index: &mut Option<RecentTimestampIndex>,
+) -> Result<Vec<NotebookResolutionResult>, String> {
+    let mut results = Vec::with_capacity(changed_entries.len());
+    for entry in changed_entries {
+        let mut candidates = recent_index
+            .as_ref()
+            .and_then(|index| index.by_timestamp.get(&entry.latest_timestamp))
+            .cloned()
+            .unwrap_or_default();
+
+        if candidates.is_empty() {
+            for _ in 0..RECENT_MISSING_RETRY_COUNT {
+                thread::sleep(Duration::from_millis(RECENT_MISSING_RETRY_DELAY_MS));
+                *recent_index = read_recent_index_with_retry(recent_path)?;
+                candidates = recent_index
+                    .as_ref()
+                    .and_then(|index| index.by_timestamp.get(&entry.latest_timestamp))
+                    .cloned()
+                    .unwrap_or_default();
+                if !candidates.is_empty() {
+                    break;
+                }
+            }
+        }
+
+        results.push(resolve_entry_with_candidates(
+            entry,
+            alias_catalog,
+            &candidates,
+        ));
+    }
+    Ok(results)
+}
+
+fn resolve_entry_with_candidates(
+    entry: &SummaryLatestRecord,
+    alias_catalog: &AliasCatalog,
+    recent_candidates: &[RecentIndexedRecord],
+) -> NotebookResolutionResult {
+    let Some(title_search_key) = alias_catalog
+        .resolve_alias_exact(entry.musicname.as_str())
+        .cloned()
+    else {
+        return NotebookResolutionResult {
+            status: NotebookResolutionStatus::UnresolvedAlias,
+            summary: entry.clone(),
+            title_search_key: None,
+            recent: None,
+            warnings: Vec::new(),
+        };
+    };
+
+    if !alias_catalog.has_chart(
+        entry.play_style.as_str(),
+        entry.difficulty.as_str(),
+        title_search_key.as_str(),
+    ) {
+        return NotebookResolutionResult {
+            status: NotebookResolutionStatus::UnresolvedAlias,
+            summary: entry.clone(),
+            title_search_key: None,
+            recent: None,
+            warnings: Vec::new(),
+        };
+    }
+
+    match recent_candidates {
+        [] => NotebookResolutionResult {
+            status: NotebookResolutionStatus::ResolvedPartial,
+            summary: entry.clone(),
+            title_search_key: Some(title_search_key),
+            recent: None,
+            warnings: Vec::new(),
+        },
+        [candidate] => NotebookResolutionResult {
+            status: NotebookResolutionStatus::ResolvedFull,
+            summary: entry.clone(),
+            title_search_key: Some(title_search_key),
+            recent: Some(candidate.clone()),
+            warnings: collect_recent_mismatch_warnings(entry, candidate),
+        },
+        _ => NotebookResolutionResult {
+            status: NotebookResolutionStatus::AmbiguousRecent,
+            summary: entry.clone(),
+            title_search_key: Some(title_search_key),
+            recent: None,
+            warnings: Vec::new(),
+        },
+    }
+}
+
+fn collect_recent_mismatch_warnings(
+    summary: &SummaryLatestRecord,
+    recent: &RecentIndexedRecord,
+) -> Vec<String> {
+    let mut warnings = Vec::new();
+    if recent.music.trim() != summary.musicname {
+        warnings.push(format!(
+            "recent.music mismatch at {}: summary='{}' recent='{}'",
+            summary.latest_timestamp, summary.musicname, recent.music
+        ));
+    }
+    if let Some(recent_difficulty) = recent.difficulty_normalized.as_deref() {
+        if recent_difficulty != summary.difficulty {
+            warnings.push(format!(
+                "recent.difficulty mismatch at {}: summary='{}' recent='{}' (raw='{}')",
+                summary.latest_timestamp,
+                summary.difficulty,
+                recent_difficulty,
+                recent.difficulty_raw
+            ));
+        }
+    }
+    warnings
+}
+
+fn resolution_result_to_observation(
+    resolution_result: &NotebookResolutionResult,
+) -> Option<ParsedSourceObservation> {
+    if resolution_result.status != NotebookResolutionStatus::ResolvedFull {
+        return None;
+    }
+    let title_search_key = resolution_result.title_search_key.as_ref()?;
+    let recent = resolution_result.recent.as_ref()?;
+    Some(ParsedSourceObservation {
+        timestamp: resolution_result.summary.latest_timestamp.clone(),
+        play_style: Some(resolution_result.summary.play_style.clone()),
+        difficulty: resolution_result.summary.difficulty.clone(),
+        title: resolution_result.summary.musicname.clone(),
+        title_search_key: title_search_key.clone(),
+        score: recent.score,
+        misscount: recent.misscount,
     })
 }
 
-fn parse_observation(entry: &NotebookRecentEntry) -> Result<ParsedSourceObservation, String> {
-    let timestamp = parse_timestamp(entry.timestamp.as_str())?;
-    let difficulty = normalize_difficulty(entry.difficulty.as_str())?;
-    let title = normalize_title(entry.music.as_str())?;
-    let score = parse_metric_value(entry.score, "score", &timestamp)?;
-    let misscount = parse_metric_value(entry.misscount, "misscount", &timestamp)?;
+fn log_resolution_results(results: &[NotebookResolutionResult]) {
+    if results.is_empty() {
+        return;
+    }
+    let mut resolved_full = 0usize;
+    let mut resolved_partial = 0usize;
+    let mut unresolved_alias = 0usize;
+    let mut ambiguous_recent = 0usize;
 
-    Ok(ParsedSourceObservation {
-        timestamp,
-        play_style: None,
-        difficulty,
-        title_search_key: title.clone(),
-        title,
-        score,
-        misscount,
-    })
+    for result in results {
+        for warning in &result.warnings {
+            eprintln!("inf-notebook warning: {warning}");
+        }
+        match result.status {
+            NotebookResolutionStatus::ResolvedFull => resolved_full += 1,
+            NotebookResolutionStatus::ResolvedPartial => {
+                resolved_partial += 1;
+                eprintln!(
+                    "inf-notebook resolved_partial: {} / {} / {} @ {} (summary updated, recent not reflected yet)",
+                    result.summary.musicname,
+                    result.summary.play_style,
+                    result.summary.difficulty,
+                    result.summary.latest_timestamp
+                );
+            }
+            NotebookResolutionStatus::UnresolvedAlias => {
+                unresolved_alias += 1;
+                eprintln!(
+                    "inf-notebook unresolved_alias: {} / {} / {} @ {}",
+                    result.summary.musicname,
+                    result.summary.play_style,
+                    result.summary.difficulty,
+                    result.summary.latest_timestamp
+                );
+            }
+            NotebookResolutionStatus::AmbiguousRecent => {
+                ambiguous_recent += 1;
+                eprintln!(
+                    "inf-notebook ambiguous_recent: {} / {} / {} @ {}",
+                    result.summary.musicname,
+                    result.summary.play_style,
+                    result.summary.difficulty,
+                    result.summary.latest_timestamp
+                );
+            }
+        }
+    }
+
+    eprintln!(
+        "inf-notebook summary diff processed: resolved_full={resolved_full}, resolved_partial={resolved_partial}, unresolved_alias={unresolved_alias}, ambiguous_recent={ambiguous_recent}"
+    );
+}
+
+fn load_alias_catalog() -> AliasCatalog {
+    let raw_json = include_str!("../../../../worker/src/master/generated/iidx-song-master.json");
+    let snapshot = match serde_json::from_str::<WorkerChartMasterSnapshot>(raw_json) {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            eprintln!("inf-notebook: failed to load alias catalog from chart master: {error}");
+            return AliasCatalog::default();
+        }
+    };
+
+    let mut alias_to_title_search_key = HashMap::new();
+    let mut chart_index = HashSet::new();
+
+    for chart in &snapshot.charts {
+        let Some(play_style) = normalize_play_style(chart.play_style.as_str()) else {
+            continue;
+        };
+        let Some(difficulty) = normalize_chart_difficulty(chart.difficulty.as_str()) else {
+            continue;
+        };
+        let title_search_key = chart.title_search_key.trim();
+        if title_search_key.is_empty() {
+            continue;
+        }
+
+        chart_index.insert(ChartIndexKey {
+            play_style,
+            difficulty,
+            title_search_key: title_search_key.to_string(),
+        });
+        insert_alias_exact(
+            &mut alias_to_title_search_key,
+            chart.title.as_str(),
+            title_search_key,
+        );
+    }
+
+    AliasCatalog {
+        alias_to_title_search_key,
+        chart_index,
+    }
+}
+
+fn insert_alias_exact(
+    alias_to_title_search_key: &mut HashMap<String, String>,
+    raw_alias: &str,
+    raw_title_search_key: &str,
+) {
+    let alias = raw_alias.trim();
+    let title_search_key = raw_title_search_key.trim();
+    if alias.is_empty() || title_search_key.is_empty() {
+        return;
+    }
+    alias_to_title_search_key
+        .entry(alias.to_string())
+        .or_insert_with(|| title_search_key.to_string());
 }
 
 fn parse_timestamp(raw_timestamp: &str) -> Result<String, String> {
@@ -137,46 +675,12 @@ fn parse_timestamp(raw_timestamp: &str) -> Result<String, String> {
             8 => ch == '-',
             _ => ch.is_ascii_digit(),
         });
-
     if !is_valid {
         return Err(format!(
             "inf-notebook entry has an invalid timestamp: {raw_timestamp}"
         ));
     }
-
     Ok(trimmed.to_string())
-}
-
-fn normalize_difficulty(raw_difficulty: &str) -> Result<String, String> {
-    let normalized = raw_difficulty
-        .trim()
-        .nfkc()
-        .collect::<String>()
-        .to_uppercase();
-    if normalized.is_empty() {
-        return Err("inf-notebook entry is missing difficulty.".to_string());
-    }
-
-    Ok(normalized)
-}
-
-fn normalize_title(raw_title: &str) -> Result<String, String> {
-    let normalized = raw_title
-        .trim()
-        .nfkc()
-        .collect::<String>()
-        .replace('\u{3000}', " ")
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
-        .replace(" (", "(")
-        .to_lowercase();
-
-    if normalized.is_empty() {
-        return Err("inf-notebook entry is missing music title.".to_string());
-    }
-
-    Ok(normalized)
 }
 
 fn parse_metric_value(value: i64, field_name: &str, timestamp: &str) -> Result<u32, String> {
@@ -185,11 +689,29 @@ fn parse_metric_value(value: i64, field_name: &str, timestamp: &str) -> Result<u
     })
 }
 
-fn is_newer_timestamp(timestamp: &str, last_seen_timestamp: Option<&str>) -> bool {
-    match last_seen_timestamp {
-        Some(last_seen_timestamp) => timestamp > last_seen_timestamp,
-        None => true,
+fn normalize_play_style(raw_play_style: &str) -> Option<String> {
+    let normalized = raw_play_style.trim().to_uppercase();
+    match normalized.as_str() {
+        "SP" | "SINGLE" | "SINGLEPLAY" => Some("SP".to_string()),
+        "DP" | "DOUBLE" | "DOUBLEPLAY" => Some("DP".to_string()),
+        _ => None,
     }
+}
+
+fn normalize_chart_difficulty(raw_difficulty: &str) -> Option<String> {
+    let normalized = raw_difficulty
+        .trim()
+        .to_uppercase()
+        .replace([' ', '-', '_'], "");
+    let resolved = match normalized.as_str() {
+        "B" | "BEGINNER" | "SPB" | "DPB" => "BEGINNER",
+        "N" | "NORMAL" | "NOVICE" | "SPN" | "DPN" => "NORMAL",
+        "H" | "HYPER" | "SPH" | "DPH" => "HYPER",
+        "A" | "ANOTHER" | "SPA" | "DPA" => "ANOTHER",
+        "L" | "LEGGENDARIA" | "SPL" | "DPL" => "LEGGENDARIA",
+        _ => return None,
+    };
+    Some(resolved.to_string())
 }
 
 fn path_key(path: &Path) -> String {
@@ -218,6 +740,7 @@ fn path_key(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use std::{
+        collections::{HashMap, HashSet},
         env, fs,
         path::PathBuf,
         time::{SystemTime, UNIX_EPOCH},
@@ -225,158 +748,229 @@ mod tests {
 
     use crate::{
         models::SourcePathsConfig,
-        parsers::{notebook::NotebookParser, ParserInput, SourceParser},
+        parsers::{
+            notebook::{
+                build_recent_timestamp_index, extract_changed_latest_entries,
+                parse_recent_timestamp_index, parse_summary_snapshot,
+                resolve_entry_with_candidates, AliasCatalog, ChartIndexKey, NotebookParser,
+                NotebookRecentEntry, NotebookResolutionStatus, RecentIndexedRecord,
+                SummaryLatestRecord,
+            },
+            ParserInput, SourceParser,
+        },
     };
 
     #[test]
-    fn notebook_parser_emits_only_newer_entries_in_newest_first_order() {
-        let temp_dir = create_temp_dir("notebook-parser");
-        let export_recent_path = temp_dir.join("recent.json");
-        write_file(
-            &export_recent_path,
-            r#"{
-  "version": "0.19.0.0",
-  "count": 1,
-  "list": [
-    {
-      "timestamp": "20250729-201348",
-      "difficulty": "ANOTHER",
-      "music": "Old Song",
-      "score": 2000,
-      "misscount": 30
+    fn summary_diff_extracts_only_changed_latest() {
+        let previous = parse_summary_snapshot(
+            r#"{"musics":{"Song A":{"SP":{"ANOTHER":{"latest":{"timestamp":"20260101-120000"}}}}}}"#,
+        )
+        .expect("previous snapshot should parse");
+        let current = parse_summary_snapshot(
+            r#"{"musics":{"Song A":{"SP":{"ANOTHER":{"latest":{"timestamp":"20260101-120000"}}}},"Song B":{"DP":{"HYPER":{"latest":{"timestamp":"20260101-120100"}}}}}}"#,
+        )
+        .expect("current snapshot should parse");
+
+        let changed = extract_changed_latest_entries(&previous, &current);
+        assert_eq!(changed.len(), 1);
+        assert_eq!(changed[0].musicname, "Song B");
+        assert_eq!(changed[0].play_style, "DP");
+        assert_eq!(changed[0].difficulty, "HYPER");
+        assert_eq!(changed[0].latest_timestamp, "20260101-120100");
     }
-  ]
-}"#,
-        );
 
-        let mut parser = NotebookParser::new(&SourcePathsConfig {
-            notebook_export_recent_json: export_recent_path.to_string_lossy().into_owned(),
-            ..SourcePathsConfig::default()
-        });
+    #[test]
+    fn recent_timestamp_index_uses_multimap() {
+        let parsed = parse_recent_timestamp_index(
+            r#"{"list":[{"timestamp":"20260101-130000","difficulty":"ANOTHER","music":"Song A","score":2000,"misscount":30},{"timestamp":"20260101-130000","difficulty":"HYPER","music":"Song B","score":1800,"misscount":45}]}"#,
+        )
+        .expect("recent payload should parse");
 
-        write_file(
-            &export_recent_path,
-            r#"{
-  "version": "0.19.0.0",
-  "count": 3,
-  "list": [
-    {
-      "timestamp": "20250729-201348",
-      "difficulty": "ANOTHER",
-      "music": "Old Song",
-      "score": 2000,
-      "misscount": 30
-    },
-    {
-      "timestamp": "20250729-202500",
-      "difficulty": "hyper",
-      "music": "Mismatch Song",
-      "score": 2500,
-      "misscount": 40
-    },
-    {
-      "timestamp": "20250729-203000",
-      "difficulty": "ANOTHER",
-      "music": "Summer Vacation (CU mix)",
-      "score": 2878,
-      "misscount": 13
+        let candidates = parsed
+            .by_timestamp
+            .get("20260101-130000")
+            .expect("timestamp key should exist");
+        assert_eq!(candidates.len(), 2);
     }
-  ]
-}"#,
+
+    #[test]
+    fn resolve_entry_classifies_0_1_2_and_alias_cases() {
+        let catalog = build_test_catalog();
+        let summary = SummaryLatestRecord {
+            musicname: "Song A".to_string(),
+            play_style: "SP".to_string(),
+            difficulty: "ANOTHER".to_string(),
+            latest_timestamp: "20260101-130000".to_string(),
+        };
+
+        let partial = resolve_entry_with_candidates(&summary, &catalog, &[]);
+        assert_eq!(partial.status, NotebookResolutionStatus::ResolvedPartial);
+
+        let mismatch = RecentIndexedRecord {
+            music: "Different Song".to_string(),
+            difficulty_raw: "HYPER".to_string(),
+            difficulty_normalized: Some("HYPER".to_string()),
+            score: 2111,
+            misscount: 22,
+        };
+        let full = resolve_entry_with_candidates(&summary, &catalog, &[mismatch]);
+        assert_eq!(full.status, NotebookResolutionStatus::ResolvedFull);
+        assert_eq!(full.warnings.len(), 2);
+
+        let ambiguous = resolve_entry_with_candidates(
+            &summary,
+            &catalog,
+            &[
+                RecentIndexedRecord {
+                    music: "Song A".to_string(),
+                    difficulty_raw: "ANOTHER".to_string(),
+                    difficulty_normalized: Some("ANOTHER".to_string()),
+                    score: 2111,
+                    misscount: 22,
+                },
+                RecentIndexedRecord {
+                    music: "Song A".to_string(),
+                    difficulty_raw: "ANOTHER".to_string(),
+                    difficulty_normalized: Some("ANOTHER".to_string()),
+                    score: 2112,
+                    misscount: 21,
+                },
+            ],
         );
+        assert_eq!(ambiguous.status, NotebookResolutionStatus::AmbiguousRecent);
 
-        let parsed_change = parser
-            .parse(&ParserInput {
-                changed_path: export_recent_path.clone(),
-            })
-            .expect("parse should succeed")
-            .expect("parser should emit a change");
-
-        assert_eq!(parsed_change.observations.len(), 2);
-        assert_eq!(parsed_change.observations[0].timestamp, "20250729-203000");
-        assert_eq!(parsed_change.observations[0].difficulty, "ANOTHER");
+        let unresolved = SummaryLatestRecord {
+            musicname: "Unknown Song".to_string(),
+            play_style: "SP".to_string(),
+            difficulty: "ANOTHER".to_string(),
+            latest_timestamp: "20260101-130500".to_string(),
+        };
+        let unresolved_alias = resolve_entry_with_candidates(&unresolved, &catalog, &[]);
         assert_eq!(
-            parsed_change.observations[0].title_search_key,
-            "summer vacation(cu mix)"
+            unresolved_alias.status,
+            NotebookResolutionStatus::UnresolvedAlias
         );
-        assert_eq!(parsed_change.observations[0].score, 2878);
-        assert_eq!(parsed_change.observations[0].misscount, 13);
-        assert_eq!(parsed_change.observations[1].timestamp, "20250729-202500");
+    }
 
-        let repeated_change = parser
+    #[test]
+    fn notebook_parser_waits_for_next_update_when_summary_json_is_invalid() {
+        let temp_dir = create_temp_dir("notebook-invalid-summary");
+        let summary_path = temp_dir.join("summary.json");
+        let recent_path = temp_dir.join("recent.json");
+        write_file(&summary_path, "{invalid json");
+        write_file(&recent_path, r#"{"list":[]}"#);
+
+        let mut parser = NotebookParser::new_with_catalog(
+            &SourcePathsConfig {
+                notebook_export_recent_json: recent_path.to_string_lossy().into_owned(),
+                notebook_records_recent_json: summary_path.to_string_lossy().into_owned(),
+                ..SourcePathsConfig::default()
+            },
+            build_test_catalog(),
+        );
+
+        let parsed = parser
             .parse(&ParserInput {
-                changed_path: export_recent_path.clone(),
+                changed_path: summary_path.clone(),
             })
-            .expect("second parse should succeed")
-            .expect("second parse should still emit a metadata change");
-
-        assert!(repeated_change.observations.is_empty());
+            .expect("invalid summary should not fail immediately");
+        assert!(parsed.is_none());
 
         let _ = fs::remove_dir_all(temp_dir);
     }
 
     #[test]
-    fn notebook_parser_ignores_records_recent_changes_for_submission_payloads() {
-        let temp_dir = create_temp_dir("notebook-records");
-        let export_recent_path = temp_dir.join("export-recent.json");
-        let records_recent_path = temp_dir.join("records-recent.json");
+    fn notebook_parser_emits_resolved_full_observation() {
+        let temp_dir = create_temp_dir("notebook-summary");
+        let summary_path = temp_dir.join("summary.json");
+        let recent_path = temp_dir.join("recent.json");
+        write_file(
+            &summary_path,
+            r#"{"musics":{"Song A":{"SP":{"ANOTHER":{"latest":{"timestamp":"20260101-120000"}}}}}}"#,
+        );
+        write_file(
+            &recent_path,
+            r#"{"list":[{"timestamp":"20260101-130000","difficulty":"ANOTHER","music":"Song A","score":2450,"misscount":18}]}"#,
+        );
+
+        let mut parser = NotebookParser::new_with_catalog(
+            &SourcePathsConfig {
+                notebook_export_recent_json: recent_path.to_string_lossy().into_owned(),
+                notebook_records_recent_json: summary_path.to_string_lossy().into_owned(),
+                ..SourcePathsConfig::default()
+            },
+            build_test_catalog(),
+        );
 
         write_file(
-            &export_recent_path,
-            r#"{
-  "version": "0.19.0.0",
-  "count": 1,
-  "list": [
-    {
-      "timestamp": "20250729-201348",
-      "difficulty": "ANOTHER",
-      "music": "Thunderbolt",
-      "score": 2878,
-      "misscount": 13
-    }
-  ]
-}"#,
+            &summary_path,
+            r#"{"musics":{"Song A":{"SP":{"ANOTHER":{"latest":{"timestamp":"20260101-130000"}}}}}}"#,
         );
-        write_file(&records_recent_path, r#"{"list":[]}"#);
-
-        let mut parser = NotebookParser::new(&SourcePathsConfig {
-            notebook_export_recent_json: export_recent_path.to_string_lossy().into_owned(),
-            notebook_records_recent_json: records_recent_path.to_string_lossy().into_owned(),
-            ..SourcePathsConfig::default()
-        });
 
         let parsed_change = parser
             .parse(&ParserInput {
-                changed_path: records_recent_path.clone(),
+                changed_path: summary_path.clone(),
             })
             .expect("parse should succeed")
-            .expect("parser should emit a metadata change");
+            .expect("parser should emit payload");
 
-        assert!(parsed_change.observations.is_empty());
+        assert_eq!(parsed_change.observations.len(), 1);
+        assert_eq!(parsed_change.observations[0].score, 2450);
+        assert_eq!(parsed_change.observations[0].misscount, 18);
+        assert_eq!(
+            parsed_change.observations[0].play_style.as_deref(),
+            Some("SP")
+        );
+        assert_eq!(parsed_change.observations[0].difficulty, "ANOTHER");
+        assert_eq!(parsed_change.observations[0].title_search_key, "song-a");
 
         let _ = fs::remove_dir_all(temp_dir);
     }
 
     #[test]
-    fn notebook_parser_reports_invalid_json() {
-        let temp_dir = create_temp_dir("notebook-invalid");
-        let export_recent_path = temp_dir.join("recent.json");
-        write_file(&export_recent_path, "{invalid json");
+    fn build_recent_timestamp_index_skips_invalid_rows() {
+        let entries = vec![
+            NotebookRecentEntry {
+                timestamp: "20260101-140000".to_string(),
+                difficulty: "ANOTHER".to_string(),
+                music: "Song A".to_string(),
+                score: 2000,
+                misscount: 30,
+            },
+            NotebookRecentEntry {
+                timestamp: "broken".to_string(),
+                difficulty: "ANOTHER".to_string(),
+                music: "Song B".to_string(),
+                score: 1900,
+                misscount: 40,
+            },
+        ];
 
-        let mut parser = NotebookParser::new(&SourcePathsConfig {
-            notebook_export_recent_json: export_recent_path.to_string_lossy().into_owned(),
-            ..SourcePathsConfig::default()
+        let index = build_recent_timestamp_index(&entries);
+        assert_eq!(index.by_timestamp.len(), 1);
+    }
+
+    fn build_test_catalog() -> AliasCatalog {
+        let mut alias_to_title_search_key = HashMap::new();
+        alias_to_title_search_key.insert("Song A".to_string(), "song-a".to_string());
+        alias_to_title_search_key.insert("song a".to_string(), "song-a-lower".to_string());
+
+        let mut chart_index = HashSet::new();
+        chart_index.insert(ChartIndexKey {
+            play_style: "SP".to_string(),
+            difficulty: "ANOTHER".to_string(),
+            title_search_key: "song-a".to_string(),
+        });
+        chart_index.insert(ChartIndexKey {
+            play_style: "SP".to_string(),
+            difficulty: "ANOTHER".to_string(),
+            title_search_key: "song-a-lower".to_string(),
         });
 
-        let error = parser
-            .parse(&ParserInput {
-                changed_path: export_recent_path.clone(),
-            })
-            .expect_err("invalid json should fail");
-
-        assert!(error.contains("Failed to parse"));
-
-        let _ = fs::remove_dir_all(temp_dir);
+        AliasCatalog {
+            alias_to_title_search_key,
+            chart_index,
+        }
     }
 
     fn create_temp_dir(prefix: &str) -> PathBuf {

--- a/apps/client/src-tauri/src/watchers/mod.rs
+++ b/apps/client/src-tauri/src/watchers/mod.rs
@@ -408,17 +408,14 @@ fn resolve_watched_files(
             "inf_daken_counter / today_update.xml",
         )?]),
         SourceType::InfNotebook => {
-            let mut paths = vec![require_path(
+            let _ = require_path(
                 &source_paths.notebook_export_recent_json,
                 "inf-notebook / export/recent.json",
-            )?];
-
-            let optional_path = source_paths.notebook_records_recent_json.trim();
-            if !optional_path.is_empty() {
-                paths.push(PathBuf::from(optional_path));
-            }
-
-            Ok(paths)
+            )?;
+            Ok(vec![require_path(
+                &source_paths.notebook_records_recent_json,
+                "inf-notebook / records/summary.json",
+            )?])
         }
     }
 }

--- a/apps/client/src/pages/SettingsPage.tsx
+++ b/apps/client/src/pages/SettingsPage.tsx
@@ -23,11 +23,14 @@ const SOURCE_OPTIONS = [
   {
     id: "inf-notebook" as const,
     name: "リザルト手帳",
-    description: "recent.json を監視",
+    description: "summary.json を監視",
     label: "Result Notebook Directory",
     placeholder: "C:\\Users\\you\\Documents\\inf-notebook",
   },
 ];
+
+const HIDDEN_SOURCE_IDS = new Set<(typeof SOURCE_OPTIONS)[number]["id"]>(["inf_daken_counter"]);
+const VISIBLE_SOURCE_OPTIONS = SOURCE_OPTIONS.filter((option) => !HIDDEN_SOURCE_IDS.has(option.id));
 
 export function SettingsPage({ roomJoined, onNavigateToLobby }: SettingsPageProps) {
   const draft = useSettingsStore((state) => state.draft);
@@ -150,7 +153,7 @@ export function SettingsPage({ roomJoined, onNavigateToLobby }: SettingsPageProp
           </div>
 
           <div className="grid max-w-2xl gap-4 md:grid-cols-2">
-            {SOURCE_OPTIONS.map((option) => (
+            {VISIBLE_SOURCE_OPTIONS.map((option) => (
               <button
                 key={option.id}
                 type="button"
@@ -204,7 +207,7 @@ export function SettingsPage({ roomJoined, onNavigateToLobby }: SettingsPageProp
             <p className="text-xs text-gray-500">
               {draft.source === "inf_daken_counter"
                 ? "選択したフォルダ配下の today_update.xml を自動で監視します。"
-                : "選択したフォルダ配下の export/recent.json と records/recent.json を自動で監視します。"}
+                : "選択したフォルダ配下の records/summary.json を監視し、export/recent.json から score/misscount を補完します。"}
             </p>
             {validationMessage ? <p className="text-sm font-semibold text-red-400">{validationMessage}</p> : null}
           </div>

--- a/apps/client/src/stores/settings-store.ts
+++ b/apps/client/src/stores/settings-store.ts
@@ -138,7 +138,7 @@ function extractNotebookDirectory(paths: Partial<SourcePaths>): string {
 
   const withoutSuffix = candidate
     .replace(/[\\/]export[\\/]recent\.json$/i, "")
-    .replace(/[\\/]records[\\/]recent\.json$/i, "");
+    .replace(/[\\/]records[\\/]summary\.json$/i, "");
 
   return normalizeDirectory(withoutSuffix === candidate ? extractParentDirectory(candidate) : withoutSuffix);
 }
@@ -168,7 +168,7 @@ export function deriveSourcePaths(sourceDirectories: SourceDirectories): SourceP
     notebookRecordsRecentJson:
       sourceDirectories.notebookDirectory.length === 0
         ? ""
-        : joinPath(sourceDirectories.notebookDirectory, ["records", "recent.json"]),
+        : joinPath(sourceDirectories.notebookDirectory, ["records", "summary.json"]),
   };
 }
 

--- a/apps/client/src/stores/source-store.ts
+++ b/apps/client/src/stores/source-store.ts
@@ -129,6 +129,10 @@ function getMissingPathMessage(source: SourceType, paths: SourcePaths): string |
     return "Set inf-notebook / export/recent.json before starting the watcher.";
   }
 
+  if (source === "inf-notebook" && paths.notebookRecordsRecentJson.trim().length === 0) {
+    return "Set inf-notebook / records/summary.json before starting the watcher.";
+  }
+
   return null;
 }
 

--- a/docs/design/03_data_model.md
+++ b/docs/design/03_data_model.md
@@ -174,9 +174,17 @@
 - 同点は勝ち数加算なし
 - 終了時に同勝ち数なら総合引き分け
 
-## 6. タイトル同定（入力側正規化）
+## 6. タイトル同定（Ph1 v1）
 
-### 6.1 normalize_title_input(raw_title)（同定処理側）
+### 6.1 inf-notebook
+- `records/summary.json.musicname`（DB由来）を同定入力に使う
+- `music_title_alias` の exact 一致のみで解決する
+  - `alias_scope = 'inf' AND alias = ?`
+- `alias_norm` / case-fold / fuzzy は使わない
+
+### 6.2 inf_daken_counter
+従来どおり `normalize_title_input(raw_title)` を同定処理側で実施する。
+
 最低限:
 - Unicode NFKC
 - trim
@@ -185,30 +193,34 @@
 - 英字小文字化
 - 記号の標準化（最小）
 
-生成物:
-- `title_search_key_in`
-
-### 6.2 マスタ参照（iidx_all_songs_master）
-- `music_title_alias` -> `music.title_search_key` の順で解決
-- 解決失敗:
-  - UnmatchedTitleLogへ記録
-  - Ph1は「未同定＝SKIP/TIMEOUTで割り切り」（手動再割当UIは入れない）
+解決失敗:
+- UnmatchedTitleLogへ記録
+- Ph1は「未同定＝SKIP/TIMEOUTで割り切り」（手動再割当UIは入れない）
 
 ## 7. 監視ソース別の抽出仕様（Ph1）
 
 ### 7.1 リザルト手帳
 入力:
-- `export/recent.json.list[]`
+- `records/summary.json`
+- `export/recent.json.list[]`（補完専用）
 使用:
-- SCORE: `score`（EX SCORE絶対値）
-- MISSCOUNT: `misscount`
+- summary:
+  - `musicname`
+  - `playtype`
+  - `difficulty`
+  - `latest.timestamp`
+- recent:
+  - SCORE: `score`（EX SCORE絶対値）
+  - MISSCOUNT: `misscount`
 同定:
-- `difficulty` + `music`（title）
+- summary の `musicname` を alias exact 解決
+- chart は `textage_id + playtype + difficulty` で特定
 新規イベント判定:
-- `timestamp` を last_seen として保持（内容差分追跡）
+- summary の `latest` 差分のみ抽出
+- recent は `timestamp -> record[]` の multimap で突合
 
-補助（任意）:
-- `records/recent.json` は補助ログ。矛盾時は採用しない（誤採用防止）
+補助:
+- `recent.music` / `recent.difficulty` は warning 用（採否条件には使わない）
 
 ### 7.2 打鍵カウンタ
 入力:

--- a/docs/design/06_source_io_spec.md
+++ b/docs/design/06_source_io_spec.md
@@ -61,11 +61,19 @@ Ph1では以下を前提とする。
 
 ---
 
-## 1.3 タイトル正規化
-`normalize_title_input(raw_title)` を同定処理側で行う。
+## 1.3 タイトル同定
+Ph1(v1) ではソースごとに同定方式を分ける。
+
+### inf-notebook
+- `records/summary.json` の `musicname`（DB由来）をそのまま使用する
+- `music_title_alias` は **exact 一致のみ**で参照する
+  - `alias_scope = 'inf' AND alias = ?`
+- `alias_norm` / 大文字小文字の正規化検索 / fuzzy 検索は行わない
+
+### inf_daken_counter
+従来どおり `normalize_title_input(raw_title)` を同定処理側で行う。
 
 最低限含む処理:
-
 - Unicode NFKC
 - trim
 - 連続空白を1つに正規化
@@ -73,10 +81,6 @@ Ph1では以下を前提とする。
   - `Summer Vacation (CU mix)` -> `Summer Vacation(CU mix)`
 - 英字小文字化
 - 記号の最小正規化
-
-### マスタ参照順
-1. `music_title_alias`
-2. `music.title_search_key`
 
 解決失敗時:
 - `UnmatchedTitleLog` に記録
@@ -99,7 +103,7 @@ Ph1では「現在ラウンドのみ受理（accept_window=0）」であるた�
 
 - ファイルが存在しない
 - 読取失敗
-- JSON/XMLパース失敗
+- JSON/XMLパース失敗（書き込み途中が疑われる場合は短時間リトライ後に判定）
 - 必須フィールド欠落
 
 対応:
@@ -113,17 +117,34 @@ Ph1では「現在ラウンドのみ受理（accept_window=0）」であるた�
 
 ## 2.1 使用ファイル
 必須:
-- `export/recent.json`
+- `records/summary.json`（監視対象）
+- `export/recent.json`（`score` / `misscount` 補完用）
 
-補助:
-- `records/recent.json`
-
-Ph1では、**勝敗判定の一次ソースは `export/recent.json`** とする。  
-`records/recent.json` は補助ログ・デバッグ用途とする。
+Ph1(v1)では、**勝敗判定の一次ソースは `records/summary.json`** とする。  
+`export/recent.json` の `music` / `difficulty` は OCR 由来のため、照合主キーには使わない。
 
 ---
 
-## 2.2 export/recent.json 入力例
+## 2.2 records/summary.json 入力例
+```json
+{
+  "musics": {
+    "Thunderbolt": {
+      "SP": {
+        "ANOTHER": {
+          "latest": {
+            "timestamp": "20250729-201348"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+## 2.3 export/recent.json 入力例
 ```json
 {
   "version": "0.19.0.0",
@@ -151,77 +172,69 @@ Ph1では、**勝敗判定の一次ソースは `export/recent.json`** とする
 
 ---
 
-## 2.3 採用フィールド
-### 共通
-- `timestamp`
+## 2.4 summary 差分抽出
+毎回全譜面を再処理せず、前回スナップショットとの差分のみ抽出する。
+
+比較対象:
+- `musics -> <musicname> -> <playtype> -> <difficulty> -> latest`
+
+抽出条件:
+- 前回値と比較して `latest` が変化した譜面のみ
+
+抽出値:
+- `musicname`
+- `playtype`
 - `difficulty`
-- `music`
+- `latest_timestamp`
 
-### SCORE モード
-- `score`
-
-### MISSCOUNT モード
-- `misscount`
-
-### 採用しないフィールド
-- `updated_score`
-- `updated_misscount`
-- `clear`
+`best.score` / `best.misscount` は採用しない。
 
 ---
 
-## 2.4 play_style の扱い
-`export/recent.json` には play_style が含まれない。  
-そのため、ルーム設定の `play_style` を前提に observed_key を構成する。
+## 2.5 recent 補完（timestamp 主体）
+`export/recent.json` は `timestamp -> record[]` の multimap を構築して参照する。
 
-前提:
-- ルームは `SP` または `DP` のどちらか1つに固定
-- クライアントは現在参加中ルームの `play_style` を使用する
+判定:
+- 0件: 短時間リトライ後、未取得なら欠損扱い（`resolved_partial`）
+- 1件: `score` / `misscount` 採用
+- 2件以上: `ambiguous_recent` 扱いで不採用
+
+注意:
+- `recent.music` / `recent.difficulty` は warning 用の整合性チェックに限定
+- OCR 文字列一致は採用条件にしない
 
 ---
 
-## 2.5 observed_key 生成
+## 2.6 observed_key 生成
 ```text
-play_style = room.play_style
-difficulty = export/recent.json.list[].difficulty
-title_search_key = normalize_title_input(music)
+play_style = summary.playtype
+difficulty = summary.difficulty
+title_search_key = alias_scope='inf' AND alias=summary.musicname の exact 解決結果
+score/misscount = export/recent.json (timestamp一致)
 ```
 
 ---
 
-## 2.6 新規イベント判定
-Ph1では以下を採用する。
-
-- `export/recent.json.list[]` の末尾から新しい順に確認
-- `timestamp` を last_seen として保持
-- `timestamp > last_seen_timestamp` のものだけ新規候補とする
-
-候補が複数ある場合:
-- 新しいものから順に見て
-- `observed_key == expected_key` を満たす最初の1件を採用
+## 2.7 監視・再読込
+- watcher は `records/summary.json` を監視する
+- 更新検知後に短い debounce を入れて再読込する
+- parse 失敗時は即エラー確定せず、短時間リトライまたは次回更新待ちとする
 
 ---
 
-## 2.7 records/recent.json の扱い
-`records/recent.json` は以下用途に限定する。
+## 2.8 状態分類
+最低限以下を区別して扱う。
 
-- 補助ログ
-- オプション表示
-- 同定確認補助
-- デバッグ
-
-### records/recent.json から使用してよい情報
-- `play_side`
-- `option`
-- `music`
-- `difficulty`
-
-### 勝敗判定には使わない
-- `update_score`
-- `update_miss_count`
-
-理由:
-- 差分値であり、絶対値として使えないため
+- `resolved_full`:
+  - alias 解決成功
+  - recent 一意突合成功（`score` / `misscount` あり）
+- `resolved_partial`:
+  - alias 解決成功
+  - recent 欠損（再試行後も0件）
+- `unresolved_alias`:
+  - alias exact 0件
+- `ambiguous_recent`:
+  - 同一 timestamp の recent 候補が2件以上
 
 ---
 
@@ -340,8 +353,8 @@ Ph1では以下を採用する。
 - `today_update.xml`
 
 ### inf-notebook
+- `records/summary.json`
 - `export/recent.json`
-- 必要なら `records/recent.json`
 
 ---
 
@@ -362,7 +375,7 @@ Ph1では以下を採用する。
 ### 5.3 採用失敗時
 - key mismatch: 採用しない
 - metric欠落: 採用しない
-- parse失敗: `SOURCE_UNAVAILABLE` 扱い
+- parse失敗（再試行後も継続）: `SOURCE_UNAVAILABLE` 扱い
 
 ---
 
@@ -384,7 +397,8 @@ Ph1では未同定を手動補正して再投入する機能は持たない。
 ## 7. 将来拡張余地
 Ph2以降で以下を追加可能。
 
-- `records/recent.json` の補助利用強化
+- `export/recent.json` の補助利用強化
+- `summary/recent` 反映タイミング差の推定改善
 - source自動診断
 - file watcher + polling のフォールバック
 - 未同定タイトルの管理UI

--- a/scripts/start-local-two-clients.ps1
+++ b/scripts/start-local-two-clients.ps1
@@ -115,7 +115,7 @@ function New-ClientSpec([int]$Index, [string]$RuntimeRoot, [string]$ConfigRoot, 
     WindowTitle = "INFINITAS BPL Client ($label)"
     DakenFile = Join-Path $dakenDir "today_update.xml"
     NotebookExportFile = Join-Path $notebookExportDir "recent.json"
-    NotebookRecordsFile = Join-Path $notebookRecordsDir "recent.json"
+    NotebookRecordsFile = Join-Path $notebookRecordsDir "summary.json"
     CargoTargetDir = Join-Path $RuntimeRoot "cargo-target\$id"
     ConfigPath = Join-Path $ConfigRoot "$id.tauri.dev.json"
     LogPath = Join-Path $LogRoot "$id-tauri.log"

--- a/tasks/v1-inf-notebook-summary-watcher.md
+++ b/tasks/v1-inf-notebook-summary-watcher.md
@@ -1,0 +1,65 @@
+# Plan: v1-inf-notebook-summary-watcher
+
+## 作業宣言
+- worktree: `C:\work\infinitas_arena\infinitas_bpl`
+- branch: `v1`
+- base branch: `v1`
+- BASE_SHA: `025ad49208df2652d6441aad0b21e8640d59c8d5`
+
+## 目的
+- `inf-notebook` 監視ロジックを `records/summary.json` 起点へ切り替える。
+- `export/recent.json` は timestamp 参照で `score` / `misscount` 補完専用にする。
+- 差分抽出・状態管理・再試行を実装し、誤判定を避ける。
+
+## 非目的
+- `inf_daken_counter` 側の仕様変更。
+- OCR 精度改善、fuzzy / alias_norm 検索。
+- Worker / DO / shared のWS契約変更。
+
+## 変更点
+- `records/summary.json` を監視対象として debounce + 再読込処理を実装。
+- 前回スナップショットとの差分（`latest` 変化のみ）抽出を実装。
+- `export/recent.json` を timestamp multimap で参照し、0/1/2+件を分岐処理。
+- recent 0件時の短時間リトライを実装。
+- alias 解決（exact）/ chart 特定 / 状態分類（`resolved_full` など）を parser 内で明示管理。
+- source directory validation と設定文言を `records/summary.json` 前提へ更新。
+- 設計ドキュメントの該当節を先行更新。
+
+## 影響範囲
+- ユーザー:
+  - `inf-notebook` 自動提出の安定性が向上し、OCR由来不一致での不採用を減らす。
+- データ:
+  - watcher の入力解釈のみ変更。保存フォーマットは変更しない。
+- 互換性:
+  - WS message schema は維持。
+- Cloudflare:
+  - 影響なし。
+
+## 対象ファイル / 対象レイヤ
+- `docs/design/06_source_io_spec.md`（必要最小限で `03_data_model.md` も）
+- `apps/client/src-tauri/src/parsers/notebook.rs`
+- `apps/client/src-tauri/src/watchers/mod.rs`
+- `apps/client/src-tauri/src/commands/source_directory_validation.rs`
+- `apps/client/src/stores/settings-store.ts`
+- `apps/client/src/stores/source-store.ts`
+- `apps/client/src/pages/SettingsPage.tsx`
+- `tasks/v1-inf-notebook-summary-watcher.md`
+
+## テスト観点
+- `summary.json` の `latest` 変化譜面のみ抽出される。
+- `recent` timestamp multimap が重複 timestamp を保持できる。
+- 0件 / 1件 / 2件以上 分岐が正しく動く。
+- recent 0件時に短時間リトライし、最終的に `resolved_partial` へ遷移できる。
+- alias exact 0件で `unresolved_alias` 扱いになる。
+- `recent.music` / `recent.difficulty` 不一致は warning のみで不採用条件にならない。
+- `cargo test -p infinitas-client-tauri notebook`
+- `npm --workspace @infinitas/client run typecheck`
+
+## ロールバック方針
+- 本タスク差分を revert して、`export/recent.json` 起点の既存監視へ戻す。
+
+## Commit Plan（コミット分割計画）
+1. Plan 追加（本ファイル）。
+2. 設計ドキュメント更新。
+3. Rust parser / watcher / validation の実装と単体テスト。
+4. client 設定文言・パス整合の最小更新と検証。


### PR DESCRIPTION
## 目的\n- inf-notebook の監視判定を ecords/summary.json の latest 差分基準へ切り替える\n- xport/recent.json は timestamp 突合による score / misscount 補完専用にする\n- OCR由来文字列を採否条件から外し、状態を明示管理する\n\n## 変更点\n- Plan Mode 用タスクを追加\n- 規範ドキュメントを summary-first 仕様へ更新\n- Rust parser を再実装\n  - ecords/summary.json 監視 + debounce + parse retry\n  - 前回スナップショットとの差分抽出（latest 変化のみ）\n  - xport/recent.json の timestamp multimap (	imestamp -> record[])\n  - 0/1/2+件分岐、short retry、esolved_full/resolved_partial/unresolved_alias/ambiguous_recent\n  - ecent.music / ecent.difficulty は warning のみ\n- watcher / source validation を ecords/summary.json 前提へ更新\n- 設定UI・設定パス・ローカル起動スクリプトを summary 前提へ更新\n- Settings 画面で「打鍵カウンタ」選択肢を一時非表示\n\n## 非変更点\n- 打鍵カウンタ解析ロジック本体\n- Worker/DO/WS schema\n- alias_norm / fuzzy 検索\n\n## 影響範囲\n- ユーザー: inf-notebook の自動提出判定\n- データ: 監視入力解釈のみ変更（保存形式変更なし）\n- 互換性: WS契約は維持\n- Cloudflare: 影響なし\n\n## テスト内容\n- cargo test notebook (apps/client/src-tauri)\n- 
pm --workspace @infinitas/client run typecheck\n\n## 回帰確認項目\n- summary.json の latest 変化譜面のみ抽出される\n- timestamp multimap で重複 timestamp を誤採用しない\n- 0/1/2+件の分岐と short retry が機能する\n- alias exact 0件で unresolved 扱い\n- ecent.music / ecent.difficulty 不一致は warning のみ\n\n## ロールバック方針\n- このPRをrevertし、xport/recent.json 起点の既存監視に戻す\n\n## docs/design 更新\n- あり (docs/design/06_source_io_spec.md, docs/design/03_data_model.md)\n