### PR TITLE
inf-notebook未解決ケースのダイアログ追加と手動E2E fixture整備

### DIFF
--- a/apps/client/src-tauri/src/models/mod.rs
+++ b/apps/client/src-tauri/src/models/mod.rs
@@ -3,7 +3,8 @@ mod source_watcher;
 
 pub use local_result::{SaveLocalResultRequest, SaveLocalResultResponse};
 pub use source_watcher::{
-    now_ms, ParsedSourceChange, ParsedSourceObservation, SourcePathsConfig, SourceType,
-    SourceWatcherEventKind, SourceWatcherEventPayload, SourceWatcherStatePayload,
-    SourceWatcherStatus, StartSourceWatcherRequest, SOURCE_WATCHER_EVENT_NAME,
+    now_ms, ParsedSourceChange, ParsedSourceObservation, ParsedSourceUnresolvedCase,
+    ParsedSourceUnresolvedCaseKind, SourcePathsConfig, SourceType, SourceWatcherEventKind,
+    SourceWatcherEventPayload, SourceWatcherStatePayload, SourceWatcherStatus,
+    StartSourceWatcherRequest, SOURCE_WATCHER_EVENT_NAME,
 };

--- a/apps/client/src-tauri/src/models/source_watcher.rs
+++ b/apps/client/src-tauri/src/models/source_watcher.rs
@@ -81,12 +81,34 @@ pub struct ParsedSourceObservation {
 }
 
 #[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ParsedSourceUnresolvedCaseKind {
+    ResolvedPartial,
+    AmbiguousRecent,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ParsedSourceUnresolvedCase {
+    pub kind: ParsedSourceUnresolvedCaseKind,
+    pub timestamp: String,
+    pub play_style: String,
+    pub difficulty: String,
+    pub title: String,
+    pub title_search_key: Option<String>,
+    pub score: Option<u32>,
+    pub misscount: Option<u32>,
+    pub recent_candidate_count: Option<u32>,
+}
+
+#[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ParsedSourceChange {
     pub source: SourceType,
     pub file_path: String,
     pub file_size_bytes: u64,
     pub observations: Vec<ParsedSourceObservation>,
+    pub unresolved_cases: Vec<ParsedSourceUnresolvedCase>,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/apps/client/src-tauri/src/parsers/daken.rs
+++ b/apps/client/src-tauri/src/parsers/daken.rs
@@ -54,6 +54,7 @@ impl SourceParser for DakenParser {
                 file_path: input.changed_path.to_string_lossy().into_owned(),
                 file_size_bytes: metadata.len(),
                 observations: Vec::new(),
+                unresolved_cases: Vec::new(),
             }));
         }
 
@@ -76,6 +77,7 @@ impl SourceParser for DakenParser {
             file_path: self.xml_path.to_string_lossy().into_owned(),
             file_size_bytes: metadata.len(),
             observations,
+            unresolved_cases: Vec::new(),
         }))
     }
 }

--- a/apps/client/src-tauri/src/parsers/notebook.rs
+++ b/apps/client/src-tauri/src/parsers/notebook.rs
@@ -10,7 +10,10 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use crate::{
-    models::{ParsedSourceChange, ParsedSourceObservation, SourcePathsConfig, SourceType},
+    models::{
+        ParsedSourceChange, ParsedSourceObservation, ParsedSourceUnresolvedCase,
+        ParsedSourceUnresolvedCaseKind, SourcePathsConfig, SourceType,
+    },
     parsers::{ParserInput, SourceParser},
 };
 
@@ -66,11 +69,20 @@ struct SummaryLatestRecord {
     play_style: String,
     difficulty: String,
     latest_timestamp: String,
+    score: Option<u32>,
+    misscount: Option<u32>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SummaryLatestValue {
+    latest_timestamp: String,
+    score: Option<u32>,
+    misscount: Option<u32>,
 }
 
 #[derive(Clone, Debug, Default)]
 struct SummarySnapshot {
-    latest_by_chart: HashMap<SummaryChartKey, String>,
+    latest_by_chart: HashMap<SummaryChartKey, SummaryLatestValue>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -128,6 +140,7 @@ struct NotebookResolutionResult {
     summary: SummaryLatestRecord,
     title_search_key: Option<String>,
     recent: Option<RecentIndexedRecord>,
+    recent_candidate_count: Option<u32>,
     warnings: Vec<String>,
 }
 
@@ -175,6 +188,7 @@ impl SourceParser for NotebookParser {
                 file_path: input.changed_path.to_string_lossy().into_owned(),
                 file_size_bytes: metadata.len(),
                 observations: Vec::new(),
+                unresolved_cases: Vec::new(),
             }));
         }
 
@@ -193,6 +207,7 @@ impl SourceParser for NotebookParser {
                 file_path: self.summary_path.to_string_lossy().into_owned(),
                 file_size_bytes: metadata.len(),
                 observations: Vec::new(),
+                unresolved_cases: Vec::new(),
             }));
         }
 
@@ -209,12 +224,17 @@ impl SourceParser for NotebookParser {
             .iter()
             .filter_map(resolution_result_to_observation)
             .collect::<Vec<_>>();
+        let unresolved_cases = resolution_results
+            .iter()
+            .filter_map(resolution_result_to_unresolved_case)
+            .collect::<Vec<_>>();
 
         Ok(Some(ParsedSourceChange {
             source: SourceType::InfNotebook,
             file_path: self.summary_path.to_string_lossy().into_owned(),
             file_size_bytes: metadata.len(),
             observations,
+            unresolved_cases,
         }))
     }
 }
@@ -283,11 +303,7 @@ fn parse_summary_snapshot(raw_json: &str) -> Result<SummarySnapshot, String> {
                 let Some(difficulty) = normalize_chart_difficulty(difficulty_raw) else {
                     continue;
                 };
-                let Some(latest_timestamp_raw) = extract_latest_timestamp(chart_record_value)
-                else {
-                    continue;
-                };
-                let Ok(latest_timestamp) = parse_timestamp(latest_timestamp_raw) else {
+                let Some(latest_value) = extract_latest_value(chart_record_value) else {
                     continue;
                 };
                 latest_by_chart.insert(
@@ -296,7 +312,7 @@ fn parse_summary_snapshot(raw_json: &str) -> Result<SummarySnapshot, String> {
                         play_style: play_style.clone(),
                         difficulty,
                     },
-                    latest_timestamp,
+                    latest_value,
                 );
             }
         }
@@ -304,12 +320,51 @@ fn parse_summary_snapshot(raw_json: &str) -> Result<SummarySnapshot, String> {
     Ok(SummarySnapshot { latest_by_chart })
 }
 
-fn extract_latest_timestamp(chart_record: &Value) -> Option<&str> {
-    let latest_node = chart_record.get("latest")?;
-    latest_node
-        .as_str()
-        .or_else(|| latest_node.get("timestamp").and_then(Value::as_str))
-        .or_else(|| chart_record.get("latest_timestamp").and_then(Value::as_str))
+fn extract_latest_value(chart_record: &Value) -> Option<SummaryLatestValue> {
+    let latest_node = chart_record.get("latest");
+    let latest_timestamp_raw = latest_node
+        .and_then(|node| {
+            node.as_str()
+                .or_else(|| node.get("timestamp").and_then(Value::as_str))
+        })
+        .or_else(|| chart_record.get("latest_timestamp").and_then(Value::as_str))?;
+    let latest_timestamp = parse_timestamp(latest_timestamp_raw).ok()?;
+
+    let score = parse_optional_summary_metric(
+        latest_node.and_then(|node| node.get("score")),
+        "score",
+        &latest_timestamp,
+    );
+    let misscount = parse_optional_summary_metric(
+        latest_node.and_then(|node| node.get("misscount")),
+        "misscount",
+        &latest_timestamp,
+    );
+
+    Some(SummaryLatestValue {
+        latest_timestamp,
+        score,
+        misscount,
+    })
+}
+
+fn parse_optional_summary_metric(
+    raw_value: Option<&Value>,
+    field_name: &str,
+    timestamp: &str,
+) -> Option<u32> {
+    let value = raw_value?;
+    let Some(raw_metric_value) = value.as_i64() else {
+        return None;
+    };
+
+    match parse_metric_value(raw_metric_value, field_name, timestamp) {
+        Ok(metric_value) => Some(metric_value),
+        Err(error) => {
+            eprintln!("inf-notebook: ignored latest.{field_name} at {timestamp}: {error}");
+            None
+        }
+    }
 }
 
 fn extract_changed_latest_entries(
@@ -319,16 +374,21 @@ fn extract_changed_latest_entries(
     let mut changed_entries = current_snapshot
         .latest_by_chart
         .iter()
-        .filter_map(|(key, latest_timestamp)| {
-            let previous = previous_snapshot.latest_by_chart.get(key);
-            if previous == Some(latest_timestamp) {
+        .filter_map(|(key, latest_value)| {
+            let previous_timestamp = previous_snapshot
+                .latest_by_chart
+                .get(key)
+                .map(|value| value.latest_timestamp.as_str());
+            if previous_timestamp == Some(latest_value.latest_timestamp.as_str()) {
                 return None;
             }
             Some(SummaryLatestRecord {
                 musicname: key.musicname.clone(),
                 play_style: key.play_style.clone(),
                 difficulty: key.difficulty.clone(),
-                latest_timestamp: latest_timestamp.clone(),
+                latest_timestamp: latest_value.latest_timestamp.clone(),
+                score: latest_value.score,
+                misscount: latest_value.misscount,
             })
         })
         .collect::<Vec<_>>();
@@ -472,6 +532,7 @@ fn resolve_entry_with_candidates(
             summary: entry.clone(),
             title_search_key: None,
             recent: None,
+            recent_candidate_count: Some(recent_candidates.len() as u32),
             warnings: Vec::new(),
         };
     };
@@ -486,6 +547,7 @@ fn resolve_entry_with_candidates(
             summary: entry.clone(),
             title_search_key: None,
             recent: None,
+            recent_candidate_count: Some(recent_candidates.len() as u32),
             warnings: Vec::new(),
         };
     }
@@ -496,6 +558,7 @@ fn resolve_entry_with_candidates(
             summary: entry.clone(),
             title_search_key: Some(title_search_key),
             recent: None,
+            recent_candidate_count: Some(0),
             warnings: Vec::new(),
         },
         [candidate] => NotebookResolutionResult {
@@ -503,6 +566,7 @@ fn resolve_entry_with_candidates(
             summary: entry.clone(),
             title_search_key: Some(title_search_key),
             recent: Some(candidate.clone()),
+            recent_candidate_count: Some(1),
             warnings: collect_recent_mismatch_warnings(entry, candidate),
         },
         _ => NotebookResolutionResult {
@@ -510,6 +574,7 @@ fn resolve_entry_with_candidates(
             summary: entry.clone(),
             title_search_key: Some(title_search_key),
             recent: None,
+            recent_candidate_count: Some(recent_candidates.len() as u32),
             warnings: Vec::new(),
         },
     }
@@ -556,6 +621,36 @@ fn resolution_result_to_observation(
         title_search_key: title_search_key.clone(),
         score: recent.score,
         misscount: recent.misscount,
+    })
+}
+
+fn resolution_result_to_unresolved_case(
+    resolution_result: &NotebookResolutionResult,
+) -> Option<ParsedSourceUnresolvedCase> {
+    let kind = match resolution_result.status {
+        NotebookResolutionStatus::ResolvedPartial => ParsedSourceUnresolvedCaseKind::ResolvedPartial,
+        NotebookResolutionStatus::AmbiguousRecent => {
+            ParsedSourceUnresolvedCaseKind::AmbiguousRecent
+        }
+        _ => return None,
+    };
+
+    Some(ParsedSourceUnresolvedCase {
+        kind,
+        timestamp: resolution_result.summary.latest_timestamp.clone(),
+        play_style: resolution_result.summary.play_style.clone(),
+        difficulty: resolution_result.summary.difficulty.clone(),
+        title: resolution_result.summary.musicname.clone(),
+        title_search_key: resolution_result.title_search_key.clone(),
+        score: resolution_result
+            .summary
+            .score
+            .or_else(|| resolution_result.recent.as_ref().map(|recent| recent.score)),
+        misscount: resolution_result
+            .summary
+            .misscount
+            .or_else(|| resolution_result.recent.as_ref().map(|recent| recent.misscount)),
+        recent_candidate_count: resolution_result.recent_candidate_count,
     })
 }
 
@@ -807,6 +902,8 @@ mod tests {
             play_style: "SP".to_string(),
             difficulty: "ANOTHER".to_string(),
             latest_timestamp: "20260101-130000".to_string(),
+            score: None,
+            misscount: None,
         };
 
         let partial = resolve_entry_with_candidates(&summary, &catalog, &[]);
@@ -850,6 +947,8 @@ mod tests {
             play_style: "SP".to_string(),
             difficulty: "ANOTHER".to_string(),
             latest_timestamp: "20260101-130500".to_string(),
+            score: None,
+            misscount: None,
         };
         let unresolved_alias = resolve_entry_with_candidates(&unresolved, &catalog, &[]);
         assert_eq!(
@@ -946,6 +1045,7 @@ mod tests {
             .expect("parser should emit payload");
 
         assert_eq!(parsed_change.observations.len(), 1);
+        assert!(parsed_change.unresolved_cases.is_empty());
         assert_eq!(parsed_change.observations[0].score, 2450);
         assert_eq!(parsed_change.observations[0].misscount, 18);
         assert_eq!(

--- a/apps/client/src/app/App.tsx
+++ b/apps/client/src/app/App.tsx
@@ -4,6 +4,7 @@ import { AppSidebar, type AppView } from "../components/AppSidebar";
 import { captureElementAsPng } from "../dev/visual-capture";
 import { getVisualScenario } from "../dev/visual-scenarios";
 import { ErrorDialog } from "../components/ErrorDialog";
+import { SourceUnresolvedDialog } from "../components/SourceUnresolvedDialog";
 import { LobbyPage } from "../pages/LobbyPage";
 import { RoomPage } from "../pages/RoomPage";
 import { SettingsPage } from "../pages/SettingsPage";
@@ -14,7 +15,7 @@ import { statsArchiveService } from "../services/stats-archive";
 import { voiceAnnouncerService } from "../services/voice-announcer";
 import { lobbyStore } from "../stores/lobby-store";
 import { roomStore, useRoomStore } from "../stores/room-store";
-import { sourceStore } from "../stores/source-store";
+import { sourceStore, useSourceStore } from "../stores/source-store";
 import { isRoomEntryReady, settingsStore, useSettingsStore } from "../stores/settings-store";
 
 export function App() {
@@ -22,6 +23,7 @@ export function App() {
   const roomSnapshot = useRoomStore((state) => state.snapshot);
   const roomConnectionStatus = useRoomStore((state) => state.connectionStatus);
   const dialog = useRoomStore((state) => state.errorDialog);
+  const sourceUnresolvedDialog = useSourceStore((state) => state.activeUnresolvedDialog);
   const [activeView, setActiveView] = useState<AppView>("lobby");
   const [mockScenario] = useState(() =>
     runtimeConfig.mockScenarioId ? getVisualScenario(runtimeConfig.mockScenarioId) : null,
@@ -124,6 +126,10 @@ export function App() {
     roomStore.clearError();
   }
 
+  function resolveSourceUnresolvedDialog(action: "accept" | "skip" | "close"): void {
+    sourceStore.resolveActiveUnresolvedDialog(action);
+  }
+
   async function handleCapture(): Promise<void> {
     const captureRoot = document.getElementById("visual-capture-root");
     if (!(captureRoot instanceof HTMLElement)) {
@@ -181,6 +187,12 @@ export function App() {
         ) : null}
       </section>
 
+      {sourceUnresolvedDialog ? (
+        <SourceUnresolvedDialog
+          dialog={sourceUnresolvedDialog}
+          onAction={resolveSourceUnresolvedDialog}
+        />
+      ) : null}
       {dialog ? <ErrorDialog dialog={dialog} onClose={dismissDialog} /> : null}
       {shouldShowSetupDialog ? (
         <div className="fixed inset-0 z-[2800] flex items-center justify-center bg-black/85 p-4 backdrop-blur-md">

--- a/apps/client/src/components/SourceUnresolvedDialog.tsx
+++ b/apps/client/src/components/SourceUnresolvedDialog.tsx
@@ -1,0 +1,178 @@
+import type { SourceUnresolvedDialog } from "../stores/source-store";
+
+interface SourceUnresolvedDialogProps {
+  dialog: SourceUnresolvedDialog;
+  onAction: (action: "accept" | "skip" | "close") => void;
+}
+
+function renderChartInfoBlock(
+  label: string,
+  chart: {
+    title: string;
+    playStyle: string;
+    difficulty: string;
+    metricLabel: string;
+    metricValue: number | null;
+  },
+) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-black/20 p-4 text-left">
+      <p className="mb-3 text-[10px] font-black uppercase tracking-[0.3em] text-cyan-300">{label}</p>
+      <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-2 text-sm text-gray-200">
+        <dt className="text-gray-400">曲名</dt>
+        <dd className="font-semibold">{chart.title}</dd>
+        <dt className="text-gray-400">プレイスタイル</dt>
+        <dd className="font-semibold">{chart.playStyle}</dd>
+        <dt className="text-gray-400">難易度</dt>
+        <dd className="font-semibold">{chart.difficulty}</dd>
+        <dt className="text-gray-400">{chart.metricLabel}</dt>
+        <dd className="font-semibold">{chart.metricValue === null ? "不明" : chart.metricValue}</dd>
+      </dl>
+    </div>
+  );
+}
+
+export function SourceUnresolvedDialog({ dialog, onAction }: SourceUnresolvedDialogProps) {
+  if (dialog.kind === "unresolved_alias") {
+    return (
+      <div
+        className="fixed inset-0 z-[2900] flex items-center justify-center bg-black/90 p-4 backdrop-blur-md"
+        role="presentation"
+      >
+        <div
+          className="w-full max-w-[720px] overflow-hidden rounded-3xl border border-amber-500/25 bg-[#18181b] shadow-[0_30px_90px_rgba(0,0,0,0.9)]"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="source-unresolved-title"
+        >
+          <div className="border-b border-white/10 p-6 text-center">
+            <p className="mb-3 text-[10px] font-black uppercase tracking-[0.35em] text-amber-300">inf-notebook</p>
+            <h2 id="source-unresolved-title" className="text-2xl font-black tracking-tight text-white">
+              登録先の譜面が一致しません
+            </h2>
+            <p className="mt-3 text-sm text-gray-300">受信したリザルトは現在の選曲情報と一致しません。</p>
+            <p className="mt-1 text-sm text-gray-300">現在のラウンド譜面に対してこのスコアを登録しますか。</p>
+          </div>
+
+          <div className="grid gap-4 p-6 md:grid-cols-2">
+            {renderChartInfoBlock("A. 現在の登録先", dialog.expectedTarget)}
+            {renderChartInfoBlock("B. 受信リザルトの解釈結果", dialog.parsedResult)}
+          </div>
+
+          <div className="px-6 pb-2">
+            <p className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm font-semibold text-red-200">
+              C. {dialog.mismatchReason}
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3 p-6 pt-4">
+            <button
+              type="button"
+              onClick={() => onAction("accept")}
+              className="rounded-2xl bg-amber-500 py-4 text-xs font-black uppercase tracking-[0.2em] text-black transition-all hover:bg-amber-400"
+            >
+              登録する
+            </button>
+            <button
+              type="button"
+              autoFocus
+              onClick={() => onAction("skip")}
+              className="rounded-2xl border border-white/20 bg-white/5 py-4 text-xs font-black uppercase tracking-[0.2em] text-white transition-all hover:bg-white/10"
+            >
+              今回は登録しない
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (dialog.kind === "resolved_partial") {
+    return (
+      <div
+        className="fixed inset-0 z-[2900] flex items-center justify-center bg-black/90 p-4 backdrop-blur-md"
+        role="presentation"
+      >
+        <div
+          className="w-full max-w-[560px] overflow-hidden rounded-3xl border border-slate-500/20 bg-[#18181b] shadow-[0_30px_90px_rgba(0,0,0,0.9)]"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="source-unresolved-title"
+        >
+          <div className="p-6 text-center">
+            <p className="mb-3 text-[10px] font-black uppercase tracking-[0.35em] text-slate-300">inf-notebook</p>
+            <h2 id="source-unresolved-title" className="text-2xl font-black tracking-tight text-white">
+              スコアを特定できませんでした
+            </h2>
+            <p className="mt-3 text-sm text-gray-300">曲は特定できましたが、対応する recent データを取得できませんでした。</p>
+            <p className="mt-1 text-sm text-gray-300">今回の登録は行いません。</p>
+            <p className="mt-1 text-sm text-gray-300">再度リザルトを登録してください。</p>
+          </div>
+
+          <div className="px-6 pb-4">
+            {renderChartInfoBlock("受信内容", dialog.chart)}
+          </div>
+
+          <div className="px-6 pb-6">
+            <button
+              type="button"
+              autoFocus
+              onClick={() => onAction("close")}
+              className="w-full rounded-2xl bg-slate-200 py-4 text-xs font-black uppercase tracking-[0.2em] text-black transition-all hover:bg-white"
+            >
+              閉じる
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[2900] flex items-center justify-center bg-black/90 p-4 backdrop-blur-md"
+      role="presentation"
+    >
+      <div
+        className="w-full max-w-[560px] overflow-hidden rounded-3xl border border-red-500/20 bg-[#18181b] shadow-[0_30px_90px_rgba(0,0,0,0.9)]"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="source-unresolved-title"
+      >
+        <div className="p-6 text-center">
+          <p className="mb-3 text-[10px] font-black uppercase tracking-[0.35em] text-red-300">inf-notebook</p>
+          <h2 id="source-unresolved-title" className="text-2xl font-black tracking-tight text-white">
+            スコアを一意に特定できませんでした
+          </h2>
+          <p className="mt-3 text-sm text-gray-300">
+            同一時刻の recent 候補が複数見つかったため、今回の登録は行いません。
+          </p>
+          <p className="mt-1 text-sm text-gray-300">
+            この問題が続く場合は開発側での確認が必要です。
+          </p>
+          <p className="mt-3 text-xs font-black uppercase tracking-[0.2em] text-red-300">
+            エラーコード: {dialog.errorCode}
+          </p>
+        </div>
+
+        <div className="px-6 pb-4">
+          {renderChartInfoBlock("受信内容", dialog.chart)}
+          <p className="mt-3 rounded-xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-gray-200">
+            候補数: <strong>{dialog.candidateCount}</strong>
+          </p>
+        </div>
+
+        <div className="px-6 pb-6">
+          <button
+            type="button"
+            autoFocus
+            onClick={() => onAction("close")}
+            className="w-full rounded-2xl bg-slate-200 py-4 text-xs font-black uppercase tracking-[0.2em] text-black transition-all hover:bg-white"
+          >
+            閉じる
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/services/source-submission.ts
+++ b/apps/client/src/services/source-submission.ts
@@ -7,6 +7,7 @@ import { settingsStore } from "../stores/settings-store";
 export interface SourceSubmitOutcome {
   ok: boolean;
   message: string;
+  pendingUnresolvedAlias?: NotebookUnresolvedAliasDialogRequest;
 }
 
 interface InactiveRoundResult {
@@ -25,6 +26,43 @@ interface ActiveRoundContext {
   savedSettings: ReturnType<typeof settingsStore.getState>["saved"];
 }
 
+export type MetricLabel = "EXSCORE" | "MISSCOUNT";
+
+export interface NotebookDialogChartInfo {
+  title: string;
+  titleSearchKey: string;
+  playStyle: "SP" | "DP";
+  difficulty: string;
+  metricLabel: MetricLabel;
+  metricValue: number;
+}
+
+export interface NotebookForcedRegistrationPayload {
+  roundIndex: number;
+  expectedKey: ExpectedKey;
+  expectedTarget: NotebookDialogChartInfo;
+  parsedResult: NotebookDialogChartInfo;
+  mismatchReason: string;
+  source: ParsedSourceChangePayload["source"];
+  sourceMeta: {
+    timestamp: string;
+    difficulty: string;
+    title: string;
+    titleSearchKey: string;
+    score: number;
+    misscount: number;
+    filePath: string;
+  };
+}
+
+export interface NotebookUnresolvedAliasDialogRequest {
+  kind: "unresolved_alias";
+  expectedTarget: NotebookDialogChartInfo;
+  parsedResult: NotebookDialogChartInfo;
+  mismatchReason: string;
+  forcePayload: NotebookForcedRegistrationPayload;
+}
+
 function observationMatchesExpected(
   observation: ParsedSourceObservationPayload,
   expectedKey: ExpectedKey,
@@ -37,65 +75,96 @@ function observationMatchesExpected(
   );
 }
 
-function observationMatchesRoundWithoutTitleKey(
-  observation: ParsedSourceObservationPayload,
-  expectedKey: ExpectedKey,
-): boolean {
-  const observedPlayStyle = observation.playStyle ?? expectedKey.play_style;
-  return observedPlayStyle === expectedKey.play_style && observation.difficulty === expectedKey.difficulty;
+function metricLabelFromWinMetric(winMetric: "SCORE" | "MISSCOUNT"): MetricLabel {
+  return winMetric === "SCORE" ? "EXSCORE" : "MISSCOUNT";
 }
 
-function findObservationForCurrentRound(
-  parsedChange: ParsedSourceChangePayload,
-  expectedKey: ExpectedKey,
-): { observation: ParsedSourceObservationPayload; fallbackUsed: boolean } | null {
-  const strictMatch = parsedChange.observations.find((observation) =>
-    observationMatchesExpected(observation, expectedKey),
+function getExpectedRoundTitle(context: ActiveRoundContext): string {
+  const expectedRound = context.snapshot.frozen_rounds.find(
+    (round) => round.round_index === context.currentRound.round_index,
   );
-  if (strictMatch) {
-    return {
-      observation: strictMatch,
-      fallbackUsed: false,
-    };
+  return expectedRound?.display.title ?? context.currentRound.expected_key.title_search_key;
+}
+
+function buildMismatchReason(
+  expectedKey: ExpectedKey,
+  observation: ParsedSourceObservationPayload,
+): string | null {
+  const observedPlayStyle = observation.playStyle ?? expectedKey.play_style;
+  const observedTitleSearchKey = observation.titleSearchKey.trim();
+  const mismatchedItems: string[] = [];
+  if (observedTitleSearchKey !== expectedKey.title_search_key) {
+    mismatchedItems.push("曲名");
+  }
+  if (observedPlayStyle !== expectedKey.play_style) {
+    mismatchedItems.push("プレイスタイル");
+  }
+  if (observation.difficulty !== expectedKey.difficulty) {
+    mismatchedItems.push("難易度");
   }
 
+  return mismatchedItems.length > 0 ? `不一致: ${mismatchedItems.join(" / ")}` : null;
+}
+
+function buildNotebookUnresolvedAliasDialogRequest(
+  parsedChange: ParsedSourceChangePayload,
+  context: ActiveRoundContext,
+): NotebookUnresolvedAliasDialogRequest | null {
   if (parsedChange.source !== "inf-notebook" || parsedChange.observations.length !== 1) {
     return null;
   }
 
   const candidate = parsedChange.observations[0]!;
-  if (!observationMatchesRoundWithoutTitleKey(candidate, expectedKey)) {
+  const expectedKey = context.currentRound.expected_key;
+  const mismatchReason = buildMismatchReason(expectedKey, candidate);
+  if (mismatchReason === null) {
     return null;
   }
-  const observedTitleSearchKey = candidate.titleSearchKey.trim();
-  if (
-    observedTitleSearchKey.length > 0 &&
-    observedTitleSearchKey !== expectedKey.title_search_key
-  ) {
-    return null;
-  }
+
+  const metricLabel = metricLabelFromWinMetric(context.snapshot.settings.win_metric);
+  const metricValue =
+    context.snapshot.settings.win_metric === "SCORE" ? candidate.score : candidate.misscount;
+
+  const expectedTarget: NotebookDialogChartInfo = {
+    title: getExpectedRoundTitle(context),
+    titleSearchKey: expectedKey.title_search_key,
+    playStyle: expectedKey.play_style,
+    difficulty: expectedKey.difficulty,
+    metricLabel,
+    metricValue,
+  };
+  const parsedResult: NotebookDialogChartInfo = {
+    title: candidate.title.trim().length > 0 ? candidate.title : candidate.titleSearchKey,
+    titleSearchKey: candidate.titleSearchKey,
+    playStyle: candidate.playStyle ?? expectedKey.play_style,
+    difficulty: candidate.difficulty,
+    metricLabel,
+    metricValue,
+  };
 
   return {
-    observation: candidate,
-    fallbackUsed: true,
+    kind: "unresolved_alias",
+    expectedTarget,
+    parsedResult,
+    mismatchReason,
+    forcePayload: {
+      roundIndex: context.currentRound.round_index,
+      expectedKey,
+      expectedTarget,
+      parsedResult,
+      mismatchReason,
+      source: parsedChange.source,
+      sourceMeta: {
+        timestamp: candidate.timestamp,
+        difficulty: candidate.difficulty,
+        title: candidate.title,
+        titleSearchKey: candidate.titleSearchKey,
+        score: candidate.score,
+        misscount: candidate.misscount,
+        filePath: parsedChange.filePath,
+      },
+    },
   };
-}
-
-function isNotebookChartMismatch(
-  parsedChange: ParsedSourceChangePayload,
-  expectedKey: ExpectedKey,
-): boolean {
-  if (parsedChange.source !== "inf-notebook" || parsedChange.observations.length !== 1) {
-    return false;
-  }
-
-  const candidate = parsedChange.observations[0]!;
-  if (!observationMatchesRoundWithoutTitleKey(candidate, expectedKey)) {
-    return false;
-  }
-
-  const observedTitleSearchKey = candidate.titleSearchKey.trim();
-  return observedTitleSearchKey.length > 0 && observedTitleSearchKey !== expectedKey.title_search_key;
 }
 
 function getActiveRoundContext(): ActiveRoundContextResult | InactiveRoundResult {
@@ -203,6 +272,7 @@ function buildDebugParsedChange(
     filePath: `debug://${template.case_name}.json`,
     fileSizeBytes: 0,
     observations: [observation],
+    unresolvedCases: [],
   };
 }
 
@@ -234,24 +304,28 @@ export function submitParsedSourceChange(
     };
   }
 
-  const matchedObservationResult = findObservationForCurrentRound(
-    parsedChange,
-    context.currentRound.expected_key,
+  const matchedObservation = parsedChange.observations.find((observation) =>
+    observationMatchesExpected(observation, context.currentRound.expected_key),
   );
-  if (!matchedObservationResult) {
-    if (isNotebookChartMismatch(parsedChange, context.currentRound.expected_key)) {
+  if (!matchedObservation) {
+    const unresolvedAliasDialog = buildNotebookUnresolvedAliasDialogRequest(
+      parsedChange,
+      context,
+    );
+    if (unresolvedAliasDialog !== null) {
       return {
         ok: false,
         message:
-          "inf-notebook observation was skipped because title_search_key does not match the current round.",
+          "inf-notebook observation is pending because the parsed chart does not match the current round.",
+        pendingUnresolvedAlias: unresolvedAliasDialog,
       };
     }
+
     return {
       ok: false,
       message: "No observation matched the current round expected key.",
     };
   }
-  const matchedObservation = matchedObservationResult.observation;
 
   const metricValue =
     context.snapshot.settings.win_metric === "SCORE"
@@ -264,15 +338,12 @@ export function submitParsedSourceChange(
 
   const observedPlayStyle =
     matchedObservation.playStyle ?? context.currentRound.expected_key.play_style;
-  const observedTitleSearchKey = matchedObservationResult.fallbackUsed
-    ? context.currentRound.expected_key.title_search_key
-    : matchedObservation.titleSearchKey;
   const sent = roomStore.submitResult({
     round_index: context.currentRound.round_index,
     observed_key: {
       play_style: observedPlayStyle,
       difficulty: matchedObservation.difficulty,
-      title_search_key: observedTitleSearchKey,
+      title_search_key: matchedObservation.titleSearchKey,
     },
     metric_value: metricValue,
     source_meta: {
@@ -295,15 +366,86 @@ export function submitParsedSourceChange(
 
   const timestampLabel =
     matchedObservation.timestamp.trim().length > 0 ? ` (${matchedObservation.timestamp})` : "";
-  if (matchedObservationResult.fallbackUsed) {
-    roomStore.noteLocalEvent(
-      "inf-notebook fallback matched by playStyle/difficulty; expected title_search_key applied.",
-    );
-  }
   const message =
     `Auto-submitted ${context.snapshot.settings.win_metric} from ${originLabel}${timestampLabel}.`;
   roomStore.noteLocalEvent(message);
 
+  return {
+    ok: true,
+    message,
+  };
+}
+
+function expectedKeyMatches(left: ExpectedKey, right: ExpectedKey): boolean {
+  return (
+    left.play_style === right.play_style &&
+    left.difficulty === right.difficulty &&
+    left.title_search_key === right.title_search_key
+  );
+}
+
+export function submitNotebookForcedRegistration(
+  payload: NotebookForcedRegistrationPayload,
+  originLabel: string,
+): SourceSubmitOutcome {
+  const activeRoundContext = getActiveRoundContext();
+  if (!activeRoundContext.ok) {
+    return activeRoundContext;
+  }
+
+  const { context } = activeRoundContext;
+  if (
+    context.currentRound.round_index !== payload.roundIndex ||
+    !expectedKeyMatches(context.currentRound.expected_key, payload.expectedKey)
+  ) {
+    return {
+      ok: false,
+      message: "The current round changed before confirmation. Registration was cancelled.",
+    };
+  }
+
+  if (
+    context.currentRound.confirmed.some(
+      (entry) => entry.player_id === context.savedSettings.playerId,
+    )
+  ) {
+    return {
+      ok: false,
+      message: "This player has already been confirmed for the current round.",
+    };
+  }
+
+  const metricValidation = ensureMetricValue(payload.expectedTarget.metricValue, "Forced metric");
+  if (metricValidation !== null) {
+    return metricValidation;
+  }
+
+  const sent = roomStore.submitResult({
+    round_index: payload.roundIndex,
+    observed_key: payload.expectedKey,
+    metric_value: payload.expectedTarget.metricValue,
+    source_meta: {
+      source: payload.source,
+      timestamp: payload.sourceMeta.timestamp,
+      difficulty: payload.sourceMeta.difficulty,
+      title: payload.sourceMeta.title,
+      title_search_key: payload.sourceMeta.titleSearchKey,
+      score: payload.sourceMeta.score,
+      misscount: payload.sourceMeta.misscount,
+      file_path: payload.sourceMeta.filePath,
+    },
+  });
+  if (!sent) {
+    return {
+      ok: false,
+      message: "Failed to send RESULT_SUBMIT for the unresolved_alias confirmation.",
+    };
+  }
+
+  const timestampLabel =
+    payload.sourceMeta.timestamp.trim().length > 0 ? ` (${payload.sourceMeta.timestamp})` : "";
+  const message = `Auto-submitted ${payload.expectedTarget.metricLabel} from ${originLabel}${timestampLabel}.`;
+  roomStore.noteLocalEvent(message);
   return {
     ok: true,
     message,

--- a/apps/client/src/services/tauri-bridge.ts
+++ b/apps/client/src/services/tauri-bridge.ts
@@ -24,11 +24,29 @@ export interface ParsedSourceObservationPayload {
   misscount: number;
 }
 
+export type ParsedSourceUnresolvedCaseKind =
+  | "unresolved_alias"
+  | "resolved_partial"
+  | "ambiguous_recent";
+
+export interface ParsedSourceUnresolvedCasePayload {
+  kind: ParsedSourceUnresolvedCaseKind;
+  timestamp: string;
+  playStyle: PlayStyle;
+  difficulty: string;
+  title: string;
+  titleSearchKey: string | null;
+  score: number | null;
+  misscount: number | null;
+  recentCandidateCount: number | null;
+}
+
 export interface ParsedSourceChangePayload {
   source: SourceType;
   filePath: string;
   fileSizeBytes: number;
   observations: ParsedSourceObservationPayload[];
+  unresolvedCases?: ParsedSourceUnresolvedCasePayload[];
 }
 
 export interface SourceWatcherEventPayload {

--- a/apps/client/src/stores/source-store.ts
+++ b/apps/client/src/stores/source-store.ts
@@ -4,6 +4,7 @@ import {
   isTauriRuntime,
   listenToSourceWatcherEvents,
   type ParsedSourceChangePayload,
+  type ParsedSourceUnresolvedCasePayload,
   startSourceWatcher,
   stopSourceWatcher,
   type SourceWatcherEventKind,
@@ -11,7 +12,12 @@ import {
   type SourceWatcherStatePayload,
   type SourceWatcherStatus,
 } from "../services/tauri-bridge";
-import { submitParsedSourceChange } from "../services/source-submission";
+import {
+  submitNotebookForcedRegistration,
+  submitParsedSourceChange,
+  type NotebookDialogChartInfo,
+  type NotebookForcedRegistrationPayload,
+} from "../services/source-submission";
 import { roomStore } from "./room-store";
 import { createExternalStore, useExternalStore } from "./create-store";
 import { type ClientSettings, type SourcePaths } from "./settings-store";
@@ -35,8 +41,52 @@ export interface SourceWatcherEventLogEntry {
 export interface SourceStoreState {
   watcherState: SourceWatcherState;
   lastEvent: SourceWatcherEventLogEntry | null;
+  activeUnresolvedDialog: SourceUnresolvedDialog | null;
+  unresolvedDialogQueue: SourceUnresolvedDialog[];
   runtimeReady: boolean;
 }
+
+type DialogAction = "accept" | "skip" | "close";
+
+interface SourceDialogChartInfo {
+  title: string;
+  titleSearchKey: string | null;
+  playStyle: "SP" | "DP";
+  difficulty: string;
+  metricLabel: "EXSCORE" | "MISSCOUNT";
+  metricValue: number | null;
+}
+
+interface SourceUnresolvedDialogBase {
+  id: string;
+  source: SourceType;
+  originLabel: string;
+}
+
+export interface SourceUnresolvedAliasDialog extends SourceUnresolvedDialogBase {
+  kind: "unresolved_alias";
+  expectedTarget: SourceDialogChartInfo;
+  parsedResult: SourceDialogChartInfo;
+  mismatchReason: string;
+  forcePayload: NotebookForcedRegistrationPayload;
+}
+
+export interface SourceResolvedPartialDialog extends SourceUnresolvedDialogBase {
+  kind: "resolved_partial";
+  chart: SourceDialogChartInfo;
+}
+
+export interface SourceAmbiguousRecentDialog extends SourceUnresolvedDialogBase {
+  kind: "ambiguous_recent";
+  chart: SourceDialogChartInfo;
+  candidateCount: number;
+  errorCode: "NB-AMBIGUOUS-RECENT";
+}
+
+export type SourceUnresolvedDialog =
+  | SourceUnresolvedAliasDialog
+  | SourceResolvedPartialDialog
+  | SourceAmbiguousRecentDialog;
 
 interface StartOptions {
   force?: boolean;
@@ -45,6 +95,7 @@ interface StartOptions {
 let attachedListener: (() => void) | null = null;
 let attachPromise: Promise<void> | null = null;
 let appliedConfigKey: string | null = null;
+let unresolvedDialogSequence = 0;
 
 const initialState: SourceStoreState = {
   watcherState: {
@@ -55,6 +106,8 @@ const initialState: SourceStoreState = {
     lastEventAt: null,
   },
   lastEvent: null,
+  activeUnresolvedDialog: null,
+  unresolvedDialogQueue: [],
   runtimeReady: false,
 };
 
@@ -95,6 +148,148 @@ function mapWatcherEvent(payload: SourceWatcherEventPayload): SourceWatcherEvent
   };
 }
 
+function nextUnresolvedDialogId(): string {
+  unresolvedDialogSequence += 1;
+  return `source-unresolved-${Date.now()}-${unresolvedDialogSequence}`;
+}
+
+function getActiveRoundMetricContext():
+  | { winMetric: "SCORE" | "MISSCOUNT"; metricLabel: "EXSCORE" | "MISSCOUNT" }
+  | null {
+  const snapshot = roomStore.getState().snapshot;
+  if (snapshot === null || snapshot.room_state !== "PLAYING" || snapshot.current_round === null) {
+    return null;
+  }
+
+  return {
+    winMetric: snapshot.settings.win_metric,
+    metricLabel: snapshot.settings.win_metric === "SCORE" ? "EXSCORE" : "MISSCOUNT",
+  };
+}
+
+function normalizePlayStyle(value: string): "SP" | "DP" {
+  return value === "DP" ? "DP" : "SP";
+}
+
+function buildDialogChartInfo(
+  unresolvedCase: ParsedSourceUnresolvedCasePayload,
+  metricContext: { winMetric: "SCORE" | "MISSCOUNT"; metricLabel: "EXSCORE" | "MISSCOUNT" },
+): SourceDialogChartInfo {
+  const metricValue =
+    metricContext.winMetric === "SCORE" ? unresolvedCase.score : unresolvedCase.misscount;
+  return {
+    title:
+      unresolvedCase.title.trim().length > 0
+        ? unresolvedCase.title
+        : (unresolvedCase.titleSearchKey ?? "(unknown)"),
+    titleSearchKey: unresolvedCase.titleSearchKey,
+    playStyle: normalizePlayStyle(unresolvedCase.playStyle),
+    difficulty: unresolvedCase.difficulty,
+    metricLabel: metricContext.metricLabel,
+    metricValue,
+  };
+}
+
+function buildUnresolvedDialogsFromParserOutput(
+  parserOutput: ParsedSourceChangePayload,
+): SourceUnresolvedDialog[] {
+  const metricContext = getActiveRoundMetricContext();
+  if (metricContext === null) {
+    return [];
+  }
+
+  const unresolvedCases = parserOutput.unresolvedCases ?? [];
+  const dialogs: SourceUnresolvedDialog[] = [];
+  for (const unresolvedCase of unresolvedCases) {
+    if (unresolvedCase.kind === "resolved_partial") {
+      dialogs.push({
+        id: nextUnresolvedDialogId(),
+        kind: "resolved_partial",
+        source: parserOutput.source,
+        originLabel: parserOutput.source,
+        chart: buildDialogChartInfo(unresolvedCase, metricContext),
+      });
+      continue;
+    }
+
+    if (unresolvedCase.kind === "ambiguous_recent") {
+      dialogs.push({
+        id: nextUnresolvedDialogId(),
+        kind: "ambiguous_recent",
+        source: parserOutput.source,
+        originLabel: parserOutput.source,
+        chart: buildDialogChartInfo(unresolvedCase, metricContext),
+        candidateCount: Math.max(2, unresolvedCase.recentCandidateCount ?? 2),
+        errorCode: "NB-AMBIGUOUS-RECENT",
+      });
+    }
+  }
+
+  return dialogs;
+}
+
+function buildUnresolvedAliasDialog(
+  source: SourceType,
+  pending: {
+    expectedTarget: NotebookDialogChartInfo;
+    parsedResult: NotebookDialogChartInfo;
+    mismatchReason: string;
+    forcePayload: NotebookForcedRegistrationPayload;
+  },
+): SourceUnresolvedAliasDialog {
+  return {
+    id: nextUnresolvedDialogId(),
+    kind: "unresolved_alias",
+    source,
+    originLabel: source,
+    expectedTarget: pending.expectedTarget,
+    parsedResult: pending.parsedResult,
+    mismatchReason: pending.mismatchReason,
+    forcePayload: pending.forcePayload,
+  };
+}
+
+function enqueueUnresolvedDialogs(newDialogs: SourceUnresolvedDialog[]): void {
+  if (newDialogs.length === 0) {
+    return;
+  }
+
+  internalStore.setState((state) => {
+    const queue = [...state.unresolvedDialogQueue, ...newDialogs];
+    if (state.activeUnresolvedDialog !== null) {
+      return {
+        ...state,
+        unresolvedDialogQueue: queue,
+      };
+    }
+
+    const [nextDialog, ...remainingQueue] = queue;
+    return {
+      ...state,
+      activeUnresolvedDialog: nextDialog ?? null,
+      unresolvedDialogQueue: remainingQueue,
+    };
+  });
+}
+
+function advanceUnresolvedDialogQueue(): void {
+  internalStore.setState((state) => {
+    if (state.unresolvedDialogQueue.length === 0) {
+      return {
+        ...state,
+        activeUnresolvedDialog: null,
+      };
+    }
+
+    const [nextDialog, ...remainingQueue] = state.unresolvedDialogQueue;
+    return {
+      ...state,
+      activeUnresolvedDialog: nextDialog ?? null,
+      unresolvedDialogQueue: remainingQueue,
+    };
+  });
+}
+
 function handleWatcherError(payload: SourceWatcherEventPayload): void {
   if (payload.kind !== "ERROR") {
     return;
@@ -117,8 +312,17 @@ function handleWatcherEvent(payload: SourceWatcherEventPayload): void {
     return;
   }
 
+  const unresolvedDialogs = buildUnresolvedDialogsFromParserOutput(payload.parserOutput);
   const outcome = submitParsedSourceChange(payload.parserOutput, payload.parserOutput.source);
-  if (!outcome.ok) {
+  if (outcome.pendingUnresolvedAlias) {
+    unresolvedDialogs.push(
+      buildUnresolvedAliasDialog(payload.parserOutput.source, outcome.pendingUnresolvedAlias),
+    );
+  }
+
+  enqueueUnresolvedDialogs(unresolvedDialogs);
+
+  if (!outcome.ok && outcome.pendingUnresolvedAlias === undefined && unresolvedDialogs.length === 0) {
     roomStore.noteLocalEvent(`Source auto-submit skipped: ${outcome.message}`);
   }
 }
@@ -180,10 +384,64 @@ async function ensureAttached(): Promise<void> {
   await attachPromise;
 }
 
+function logUnresolvedAliasDecision(
+  dialog: SourceUnresolvedAliasDialog,
+  userAccepted: boolean,
+): void {
+  const logPayload: {
+    expected_target: SourceUnresolvedAliasDialog["expectedTarget"];
+    parsed_result: SourceUnresolvedAliasDialog["parsedResult"];
+    mismatch_reason: string;
+    user_accepted: boolean;
+    user_skipped?: boolean;
+  } = {
+    expected_target: dialog.expectedTarget,
+    parsed_result: dialog.parsedResult,
+    mismatch_reason: dialog.mismatchReason,
+    user_accepted: userAccepted,
+  };
+  if (!userAccepted) {
+    logPayload.user_skipped = true;
+  }
+  console.info("inf-notebook unresolved_alias decision", logPayload);
+}
+
 export const sourceStore = {
   ...internalStore,
   async attach(): Promise<void> {
     await ensureAttached();
+  },
+  resolveActiveUnresolvedDialog(action: DialogAction): void {
+    const activeDialog = internalStore.getState().activeUnresolvedDialog;
+    if (activeDialog === null) {
+      return;
+    }
+
+    if (activeDialog.kind === "unresolved_alias") {
+      const userAccepted = action === "accept";
+      logUnresolvedAliasDecision(activeDialog, userAccepted);
+      if (userAccepted) {
+        const outcome = submitNotebookForcedRegistration(
+          activeDialog.forcePayload,
+          activeDialog.originLabel,
+        );
+        if (!outcome.ok) {
+          roomStore.noteLocalEvent(`Source auto-submit skipped: ${outcome.message}`);
+        }
+      } else {
+        roomStore.noteLocalEvent("Source auto-submit skipped: unresolved_alias was not approved.");
+      }
+    } else if (activeDialog.kind === "resolved_partial") {
+      roomStore.noteLocalEvent(
+        "Source auto-submit skipped: inf-notebook resolved_partial requires re-registration.",
+      );
+    } else {
+      roomStore.noteLocalEvent(
+        `Source auto-submit skipped: ${activeDialog.errorCode} (candidates=${activeDialog.candidateCount}).`,
+      );
+    }
+
+    advanceUnresolvedDialogQueue();
   },
   detach(): void {
     attachedListener?.();
@@ -192,6 +450,8 @@ export const sourceStore = {
     internalStore.setState((state) => ({
       ...state,
       runtimeReady: false,
+      activeUnresolvedDialog: null,
+      unresolvedDialogQueue: [],
     }));
   },
   async start(

--- a/scripts/apply-notebook-unresolved-fixture.ps1
+++ b/scripts/apply-notebook-unresolved-fixture.ps1
@@ -1,0 +1,58 @@
+param(
+  [ValidateSet("baseline", "unresolved_alias", "resolved_partial", "ambiguous_recent")]
+  [string]$Scenario = "baseline",
+  [string]$Instance = "p1",
+  [string]$RuntimeRoot = "testdata/runtime"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Ensure-Directory([string]$Path) {
+  if (-not (Test-Path -LiteralPath $Path)) {
+    New-Item -ItemType Directory -Path $Path -Force | Out-Null
+  }
+}
+
+function Write-Utf8NoBomFile([string]$Path, [string]$Content) {
+  $directory = Split-Path -Parent $Path
+  if ($directory) {
+    Ensure-Directory $directory
+  }
+
+  $encoding = [System.Text.UTF8Encoding]::new($false)
+  $normalized = $Content -replace "`r?`n", "`n"
+  [System.IO.File]::WriteAllText($Path, $normalized, $encoding)
+}
+
+function Read-Utf8Text([string]$Path) {
+  $encoding = [System.Text.UTF8Encoding]::new($false, $true)
+  return [System.IO.File]::ReadAllText($Path, $encoding)
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$fixtureRoot = Join-Path $repoRoot "testdata/notebook-unresolved-dialogs/$Scenario"
+$fixtureSummaryPath = Join-Path $fixtureRoot "records/summary.json"
+$fixtureRecentPath = Join-Path $fixtureRoot "export/recent.json"
+
+if (-not (Test-Path -LiteralPath $fixtureSummaryPath)) {
+  throw "Fixture summary.json not found: $fixtureSummaryPath"
+}
+if (-not (Test-Path -LiteralPath $fixtureRecentPath)) {
+  throw "Fixture recent.json not found: $fixtureRecentPath"
+}
+
+$runtimeRootPath = if ([System.IO.Path]::IsPathRooted($RuntimeRoot)) {
+  $RuntimeRoot
+} else {
+  Join-Path $repoRoot $RuntimeRoot
+}
+$targetRoot = Join-Path $runtimeRootPath "instances/$Instance/inf-notebook"
+$targetSummaryPath = Join-Path $targetRoot "records/summary.json"
+$targetRecentPath = Join-Path $targetRoot "export/recent.json"
+
+Write-Utf8NoBomFile -Path $targetSummaryPath -Content (Read-Utf8Text $fixtureSummaryPath)
+Write-Utf8NoBomFile -Path $targetRecentPath -Content (Read-Utf8Text $fixtureRecentPath)
+
+Write-Host "Applied fixture: $Scenario" -ForegroundColor Green
+Write-Host "Target summary: $targetSummaryPath"
+Write-Host "Target recent : $targetRecentPath"

--- a/scripts/verify-notebook-unresolved-dialogs.ps1
+++ b/scripts/verify-notebook-unresolved-dialogs.ps1
@@ -1,0 +1,222 @@
+param(
+  [string]$Instance = "p1",
+  [string]$RuntimeRoot = "testdata/runtime",
+  [int]$LogWaitSeconds = 12,
+  [switch]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+
+function Ensure-Directory([string]$Path) {
+  if (-not (Test-Path -LiteralPath $Path)) {
+    New-Item -ItemType Directory -Path $Path -Force | Out-Null
+  }
+}
+
+function Write-Utf8NoBomFile([string]$Path, [string]$Content) {
+  $directory = Split-Path -Parent $Path
+  if ($directory) {
+    Ensure-Directory $directory
+  }
+
+  $encoding = [System.Text.UTF8Encoding]::new($false)
+  $normalized = $Content -replace "`r?`n", "`n"
+  [System.IO.File]::WriteAllText($Path, $normalized, $encoding)
+}
+
+function Apply-Fixture([string]$Scenario) {
+  & $applyScriptPath -Scenario $Scenario -Instance $Instance -RuntimeRoot $RuntimeRoot
+}
+
+function Get-LogLineCount([string]$Path) {
+  if (-not (Test-Path -LiteralPath $Path)) {
+    return 0
+  }
+
+  return (Get-Content -LiteralPath $Path -Encoding UTF8).Count
+}
+
+function Wait-LogEvidence(
+  [string]$Path,
+  [int]$LineCountBefore,
+  [string]$ExpectedToken,
+  [string]$ExpectedTimestamp
+) {
+  if (-not (Test-Path -LiteralPath $Path)) {
+    return [pscustomobject]@{
+      Passed = $false
+      Message = "log file not found: $Path"
+    }
+  }
+
+  $deadline = (Get-Date).AddSeconds($LogWaitSeconds)
+  while ((Get-Date) -lt $deadline) {
+    $lines = Get-Content -LiteralPath $Path -Encoding UTF8
+    if ($lines.Count -gt $LineCountBefore) {
+      $newLines = $lines[$LineCountBefore..($lines.Count - 1)]
+      foreach ($line in $newLines) {
+        if ($line -like "*$ExpectedToken*" -and $line -like "*$ExpectedTimestamp*") {
+          return [pscustomobject]@{
+            Passed = $true
+            Message = $line
+          }
+        }
+      }
+    }
+    Start-Sleep -Milliseconds 400
+  }
+
+  return [pscustomobject]@{
+    Passed = $false
+    Message = "no matching log line found within ${LogWaitSeconds}s (token='$ExpectedToken', timestamp='$ExpectedTimestamp')."
+  }
+}
+
+function Ask-CheckResult([string]$Prompt) {
+  while ($true) {
+    $inputValue = (Read-Host "$Prompt [y/n]").Trim().ToLowerInvariant()
+    if ($inputValue -eq "y" -or $inputValue -eq "n") {
+      return $inputValue
+    }
+  }
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$applyScriptPath = Join-Path $repoRoot "scripts/apply-notebook-unresolved-fixture.ps1"
+if (-not (Test-Path -LiteralPath $applyScriptPath)) {
+  throw "apply script not found: $applyScriptPath"
+}
+
+$runtimeRootPath = if ([System.IO.Path]::IsPathRooted($RuntimeRoot)) {
+  $RuntimeRoot
+} else {
+  Join-Path $repoRoot $RuntimeRoot
+}
+$logPath = Join-Path $runtimeRootPath "logs/$Instance-tauri.log"
+
+$steps = @(
+  [pscustomobject]@{
+    Name = "unresolved_alias (skip)"
+    Scenario = "unresolved_alias"
+    ExpectedToken = "inf-notebook unresolved_alias:"
+    ExpectedTimestamp = "20260313-010100"
+    ManualCheck = @(
+      "Dialog title: Registered chart does not match",
+      "Mismatch reason text: Mismatch: Song title / Difficulty",
+      "Default focus: Skip this time",
+      "Action: click Skip this time"
+    )
+  },
+  [pscustomobject]@{
+    Name = "unresolved_alias (accept)"
+    Scenario = "unresolved_alias"
+    ExpectedToken = "inf-notebook unresolved_alias:"
+    ExpectedTimestamp = "20260313-010100"
+    ManualCheck = @(
+      "The same dialog appears again",
+      "Action: click Register",
+      "Expected: one-time register to current round expected chart"
+    )
+  },
+  [pscustomobject]@{
+    Name = "resolved_partial"
+    Scenario = "resolved_partial"
+    ExpectedToken = "inf-notebook resolved_partial:"
+    ExpectedTimestamp = "20260313-010200"
+    ManualCheck = @(
+      "Dialog title: Could not identify score",
+      "Button: Close only",
+      "Expected: not registered"
+    )
+  },
+  [pscustomobject]@{
+    Name = "ambiguous_recent"
+    Scenario = "ambiguous_recent"
+    ExpectedToken = "inf-notebook ambiguous_recent:"
+    ExpectedTimestamp = "20260313-010300"
+    ManualCheck = @(
+      "Dialog title: Could not identify score uniquely",
+      "Error code: NB-AMBIGUOUS-RECENT",
+      "Candidate count is displayed",
+      "Expected: not registered"
+    )
+  }
+)
+
+Write-Host "Preparing baseline fixture..." -ForegroundColor Cyan
+Apply-Fixture "baseline"
+
+Write-Host ""
+Write-Host "Manual prerequisites before continuing:" -ForegroundColor Yellow
+Write-Host "1. room_state = PLAYING"
+Write-Host "2. source = inf-notebook"
+Write-Host "3. Recommended current round expected: Thunderbolt / SP / ANOTHER (for clear unresolved_alias check)"
+if ($DryRun) {
+  Write-Host ""
+  Write-Host "DryRun mode: no interactive prompts." -ForegroundColor Cyan
+  foreach ($step in $steps) {
+    Write-Host "- $($step.Name) -> scenario=$($step.Scenario), token=$($step.ExpectedToken), timestamp=$($step.ExpectedTimestamp)"
+  }
+  exit 0
+}
+Read-Host "Press Enter when ready"
+
+$results = @()
+foreach ($step in $steps) {
+  Write-Host ""
+  Write-Host "=== $($step.Name) ===" -ForegroundColor Cyan
+  $beforeCount = Get-LogLineCount $logPath
+  Apply-Fixture $step.Scenario
+  $logResult = Wait-LogEvidence -Path $logPath -LineCountBefore $beforeCount -ExpectedToken $step.ExpectedToken -ExpectedTimestamp $step.ExpectedTimestamp
+
+  Write-Host "Manual check points:" -ForegroundColor Yellow
+  foreach ($line in $step.ManualCheck) {
+    Write-Host " - $line"
+  }
+
+  $manualResult = Ask-CheckResult "Enter y if UI matches expected"
+  $notes = Read-Host "Notes (optional)"
+
+  $results += [pscustomobject]@{
+    name = $step.Name
+    scenario = $step.Scenario
+    log_passed = $logResult.Passed
+    log_evidence = $logResult.Message
+    ui_passed = ($manualResult -eq "y")
+    notes = $notes
+  }
+}
+
+$timestamp = (Get-Date).ToString("yyyyMMdd-HHmmss")
+$reportPath = Join-Path $runtimeRootPath "logs/notebook-unresolved-dialog-check-$Instance-$timestamp.md"
+
+$reportLines = @(
+  "# notebook unresolved dialogs manual check",
+  "",
+  "- instance: $Instance",
+  "- log: $logPath",
+  "- generated_at: $([DateTimeOffset]::Now.ToString('o'))",
+  "",
+  "## Results"
+)
+
+foreach ($result in $results) {
+  $reportLines += ""
+  $reportLines += "### $($result.name)"
+  $reportLines += "- scenario: $($result.scenario)"
+  $reportLines += "- log_check: $(if ($result.log_passed) { "pass" } else { "fail" })"
+  $reportLines += "- ui_check: $(if ($result.ui_passed) { "pass" } else { "fail" })"
+  $reportLines += "- log_evidence: $($result.log_evidence)"
+  if ([string]::IsNullOrWhiteSpace($result.notes)) {
+    $reportLines += "- notes: (none)"
+  } else {
+    $reportLines += "- notes: $($result.notes)"
+  }
+}
+
+$reportContent = ($reportLines -join "`n") + "`n"
+Write-Utf8NoBomFile -Path $reportPath -Content $reportContent
+
+Write-Host ""
+Write-Host "Verification report written:" -ForegroundColor Green
+Write-Host $reportPath

--- a/tasks/v1-inf-notebook-unresolved-case-dialogs.md
+++ b/tasks/v1-inf-notebook-unresolved-case-dialogs.md
@@ -1,0 +1,52 @@
+# v1-inf-notebook-unresolved-case-dialogs
+
+## Purpose
+- `inf-notebook summary diff processed` 後に発生する未解決ケースを握りつぶさず、1件ずつダイアログ表示する。
+- `unresolved_alias` は DO 送信前に停止し、今回限りの強制登録のみ許可する。
+
+## Non-goals
+- Worker / DO の WS schema や FSM の変更は行わない。
+- alias 学習・恒久保存は行わない。
+
+## Changes
+- 監視差分処理サイクル完了時に未解決ケース表示イベントをキュー化し、1件ずつダイアログ表示する。
+- `unresolved_alias` は「現在ラウンド登録先」と「受信リザルト解釈結果」の不一致確認 UI を出し、承認時のみ現在ラウンド譜面へ今回限りで登録する。
+- `resolved_partial` / `ambiguous_recent` は登録不能通知ダイアログのみ表示し、DO 送信しない。
+- `unresolved_alias` 承認・スキップ結果を必要ログ（`expected_target`, `parsed_result`, `mismatch_reason`, `user_accepted`）として残す。
+
+## Impact
+- Users: 未解決ケースの理由と結果が明示され、誤登録を抑止できる。
+- Data: `unresolved_alias` の誤送信を防ぎ、承認時のみ限定的な登録を許可する。
+- Compatibility: 既存 WS schema / 保存形式への互換性影響なし。
+- Cloudflare: なし（client 側の送信前制御と UI 追加）。
+
+## Target Files / Layers
+- Files:
+  - `apps/client/src/services/source-submission.ts`
+  - `apps/client/src/features/result/*`（既存の未解決ケース表示/ダイアログ実装箇所）
+  - `apps/client/src/store/*`（必要時: ダイアログキュー管理）
+- Layers: client（TS/UI）
+
+## Test Focus
+- 技術的検証: client 側 typecheck/lint/test。
+- 差分検証: 目的外差分なし、UTF-8 no BOM / LF 維持。
+- 監視ソース検証（該当）:
+  - `unresolved_alias` で DO 送信前に停止する。
+  - 承認時のみ現在ラウンド譜面へ今回限り登録される。
+  - `resolved_partial` / `ambiguous_recent` は登録不能通知のみとなる。
+  - 同一サイクルで複数対象があっても 1件ずつ表示される。
+
+## Rollback Plan
+- 未解決ケースキューとダイアログ分岐を差し戻し、既存の送信フローへ戻す。
+
+## Commit Split Plan
+1. 未解決ケースイベントキューと `unresolved_alias` 承認フロー実装
+2. `resolved_partial` / `ambiguous_recent` 通知ダイアログ実装と検証
+
+## Checklist
+- [x] Design doc alignment confirmed (if required)
+- [x] Impact scope identified
+- [x] Implementation completed
+- [x] Tests completed
+- [x] Regression checks completed
+- [ ] Documentation updates completed (if required)

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -7,6 +7,9 @@
 - `debug-input/`
   ローカル debug UI から直接注入するための正規化済みテンプレート JSON。
   現在ラウンドの expected key に合わせて展開されるため、毎回ファイル監視入力を作り直さずに再利用できます。
+- `notebook-unresolved-dialogs/`
+  `inf-notebook` watcher の未解決ケース（`unresolved_alias` / `resolved_partial` / `ambiguous_recent`）を
+  手動 E2E で再現するための `records/summary.json` / `export/recent.json` 固定 fixture。
 - `runtime/`
   `scripts/start-local-two-clients.ps1` が生成する一時設定、ログ、インスタンス別 watcher ディレクトリ。
   Git 管理対象外です。
@@ -21,6 +24,11 @@
   `SKIP_SELF` 相当を送る
 
 必要になれば、将来的に raw watcher 入力 (`today_update.xml`, `recent.json`) を別ディレクトリで追加できます。
+
+`notebook-unresolved-dialogs/` については以下を利用できます。
+
+- `scripts/apply-notebook-unresolved-fixture.ps1`
+- `scripts/verify-notebook-unresolved-dialogs.ps1`
 
 ## 代表ケース
 

--- a/testdata/notebook-unresolved-dialogs/README.md
+++ b/testdata/notebook-unresolved-dialogs/README.md
@@ -1,0 +1,45 @@
+# notebook-unresolved-dialogs
+
+`inf-notebook` watcher の未解決ケースダイアログを手動 E2E で再現するための固定 fixture です。
+
+## 目的
+
+- `unresolved_alias`
+- `resolved_partial`
+- `ambiguous_recent`
+
+の 3 ケースを再現し、UI ダイアログ表示と操作を確認する。
+
+## 前提
+
+- `scripts/start-local-two-clients.ps1` などで Tauri クライアントを起動済み
+- 対象クライアントの source は `inf-notebook`
+- watcher 参照先は `testdata/runtime/instances/<instance>/inf-notebook`（既定）
+
+## 構成
+
+- `baseline/`
+  - watcher 起動直後の基準状態
+- `unresolved_alias/`
+  - `records/summary.json` 側は有効譜面だが、現在ラウンド expected と一致しない観測を作るケース
+- `resolved_partial/`
+  - alias は解決するが `recent` が 0 件のケース
+- `ambiguous_recent/`
+  - 同一 timestamp の `recent` が 2 件あるケース
+
+各フォルダ内:
+
+- `records/summary.json`
+- `export/recent.json`
+
+## 推奨手順
+
+1. baseline を適用
+2. `unresolved_alias` を適用してダイアログ確認
+3. `resolved_partial` を適用してダイアログ確認
+4. `ambiguous_recent` を適用してダイアログ確認
+
+実行補助:
+
+- `scripts/apply-notebook-unresolved-fixture.ps1`
+- `scripts/verify-notebook-unresolved-dialogs.ps1`

--- a/testdata/notebook-unresolved-dialogs/ambiguous_recent/export/recent.json
+++ b/testdata/notebook-unresolved-dialogs/ambiguous_recent/export/recent.json
@@ -1,0 +1,33 @@
+{
+  "version": "0.19.0.0",
+  "count": 2,
+  "score": 6410,
+  "misscount": 31,
+  "updated_score": 0,
+  "updated_misscount": 0,
+  "clear": 2,
+  "list": [
+    {
+      "timestamp": "20260313-010300",
+      "difficulty": "ANOTHER",
+      "music": "Thunderbolt",
+      "new": true,
+      "score": 3200,
+      "misscount": 11,
+      "updated_score": 0,
+      "updated_misscount": 0,
+      "clear": true
+    },
+    {
+      "timestamp": "20260313-010300",
+      "difficulty": "ANOTHER",
+      "music": "Thunderbolt",
+      "new": true,
+      "score": 3210,
+      "misscount": 20,
+      "updated_score": 0,
+      "updated_misscount": 0,
+      "clear": true
+    }
+  ]
+}

--- a/testdata/notebook-unresolved-dialogs/ambiguous_recent/records/summary.json
+++ b/testdata/notebook-unresolved-dialogs/ambiguous_recent/records/summary.json
@@ -1,0 +1,23 @@
+{
+  "musics": {
+    "Thunderbolt": {
+      "SP": {
+        "ANOTHER": {
+          "latest": {
+            "timestamp": "20260313-010300",
+            "score": 3200,
+            "misscount": 11
+          }
+        }
+      }
+    },
+    "22DUNK": {
+      "SP": {
+        "HYPER": {
+          "latest": null
+        }
+      }
+    }
+  },
+  "last_allimported": "0.20.0"
+}

--- a/testdata/notebook-unresolved-dialogs/baseline/export/recent.json
+++ b/testdata/notebook-unresolved-dialogs/baseline/export/recent.json
@@ -1,0 +1,22 @@
+{
+  "version": "0.19.0.0",
+  "count": 1,
+  "score": 3000,
+  "misscount": 10,
+  "updated_score": 0,
+  "updated_misscount": 0,
+  "clear": 1,
+  "list": [
+    {
+      "timestamp": "20260313-010000",
+      "difficulty": "ANOTHER",
+      "music": "Thunderbolt",
+      "new": true,
+      "score": 3000,
+      "misscount": 10,
+      "updated_score": 0,
+      "updated_misscount": 0,
+      "clear": true
+    }
+  ]
+}

--- a/testdata/notebook-unresolved-dialogs/baseline/records/summary.json
+++ b/testdata/notebook-unresolved-dialogs/baseline/records/summary.json
@@ -1,0 +1,23 @@
+{
+  "musics": {
+    "Thunderbolt": {
+      "SP": {
+        "ANOTHER": {
+          "latest": {
+            "timestamp": "20260313-010000",
+            "score": 3000,
+            "misscount": 10
+          }
+        }
+      }
+    },
+    "22DUNK": {
+      "SP": {
+        "HYPER": {
+          "latest": null
+        }
+      }
+    }
+  },
+  "last_allimported": "0.20.0"
+}

--- a/testdata/notebook-unresolved-dialogs/resolved_partial/export/recent.json
+++ b/testdata/notebook-unresolved-dialogs/resolved_partial/export/recent.json
@@ -1,0 +1,22 @@
+{
+  "version": "0.19.0.0",
+  "count": 1,
+  "score": 3000,
+  "misscount": 10,
+  "updated_score": 0,
+  "updated_misscount": 0,
+  "clear": 1,
+  "list": [
+    {
+      "timestamp": "20260313-010000",
+      "difficulty": "ANOTHER",
+      "music": "Thunderbolt",
+      "new": false,
+      "score": 3000,
+      "misscount": 10,
+      "updated_score": 0,
+      "updated_misscount": 0,
+      "clear": true
+    }
+  ]
+}

--- a/testdata/notebook-unresolved-dialogs/resolved_partial/records/summary.json
+++ b/testdata/notebook-unresolved-dialogs/resolved_partial/records/summary.json
@@ -1,0 +1,23 @@
+{
+  "musics": {
+    "Thunderbolt": {
+      "SP": {
+        "ANOTHER": {
+          "latest": {
+            "timestamp": "20260313-010200",
+            "score": 3111,
+            "misscount": 12
+          }
+        }
+      }
+    },
+    "22DUNK": {
+      "SP": {
+        "HYPER": {
+          "latest": null
+        }
+      }
+    }
+  },
+  "last_allimported": "0.20.0"
+}

--- a/testdata/notebook-unresolved-dialogs/unresolved_alias/export/recent.json
+++ b/testdata/notebook-unresolved-dialogs/unresolved_alias/export/recent.json
@@ -1,0 +1,33 @@
+{
+  "version": "0.19.0.0",
+  "count": 2,
+  "score": 5560,
+  "misscount": 28,
+  "updated_score": 0,
+  "updated_misscount": 0,
+  "clear": 2,
+  "list": [
+    {
+      "timestamp": "20260313-010100",
+      "difficulty": "HYPER",
+      "music": "22DUNK",
+      "new": true,
+      "score": 2560,
+      "misscount": 18,
+      "updated_score": 0,
+      "updated_misscount": 0,
+      "clear": true
+    },
+    {
+      "timestamp": "20260313-010000",
+      "difficulty": "ANOTHER",
+      "music": "Thunderbolt",
+      "new": false,
+      "score": 3000,
+      "misscount": 10,
+      "updated_score": 0,
+      "updated_misscount": 0,
+      "clear": true
+    }
+  ]
+}

--- a/testdata/notebook-unresolved-dialogs/unresolved_alias/records/summary.json
+++ b/testdata/notebook-unresolved-dialogs/unresolved_alias/records/summary.json
@@ -1,0 +1,27 @@
+{
+  "musics": {
+    "Thunderbolt": {
+      "SP": {
+        "ANOTHER": {
+          "latest": {
+            "timestamp": "20260313-010000",
+            "score": 3000,
+            "misscount": 10
+          }
+        }
+      }
+    },
+    "22DUNK": {
+      "SP": {
+        "HYPER": {
+          "latest": {
+            "timestamp": "20260313-010100",
+            "score": 2560,
+            "misscount": 18
+          }
+        }
+      }
+    }
+  },
+  "last_allimported": "0.20.0"
+}


### PR DESCRIPTION
## 目的
- `inf-notebook summary diff processed` 後の未解決ケース（`unresolved_alias` / `resolved_partial` / `ambiguous_recent`）を握りつぶさず、1件ずつダイアログで通知・確認できるようにする。
- `unresolved_alias` は DO 送信前に停止し、ユーザー承認時のみ今回限りで登録する。
- 実機 watcher 入力の手動 E2E を再現しやすくする固定 fixture と検証スクリプトを追加する。

## 変更点
- Rust parser 出力を拡張し、`resolved_partial` / `ambiguous_recent` を `unresolvedCases` として TS 側へ渡すようにした。
- `source-submission` を更新し、`unresolved_alias`（期待譜面 vs 受信解釈不一致）を DO 送信前に保留するフローへ変更。
- `source-store` に未解決ダイアログキューを追加し、複数件を 1 件ずつ表示・処理するようにした。
- `SourceUnresolvedDialog` を追加し、3ケースの仕様に沿った表示・ボタン挙動を実装。
- `unresolved_alias` 承認/スキップ時に `expected_target` / `parsed_result` / `mismatch_reason` / `user_accepted`（必要時 `user_skipped`）をログ出力。
- `testdata/notebook-unresolved-dialogs/*` に baseline + 3ケースの固定 `summary.json` / `recent.json` を追加。
- `scripts/apply-notebook-unresolved-fixture.ps1` と `scripts/verify-notebook-unresolved-dialogs.ps1` を追加。

## 非変更点
- Worker / DO の WS schema や FSM は変更しない。
- alias 学習・恒久保存は行わない。

## 影響範囲
- Users: 未解決時の理由が明示され、誤登録を抑止できる。
- Data: `unresolved_alias` は承認時のみ登録される。
- Compatibility: 既存 WS schema / 保存形式への互換性影響なし。
- Cloudflare: なし（client 側変更のみ）。

## テスト内容
- `cargo test --manifest-path apps/client/src-tauri/Cargo.toml`
- `pnpm -C apps/client --package=typescript dlx tsc --noEmit -p tsconfig.json`
- `pnpm -C apps/client build`
- `powershell -ExecutionPolicy Bypass -File scripts/verify-notebook-unresolved-dialogs.ps1 -Instance p1 -DryRun`

## 回帰確認項目
- `unresolved_alias` で DO 送信前に止まること。
- `今回は登録しない` が既定フォーカスであること。
- 不一致理由が `曲名 / プレイスタイル / 難易度` 文言で表示されること。
- `resolved_partial` は再登録依頼ダイアログのみで未登録終了すること。
- `ambiguous_recent` はエラーコード付き通知のみで未登録終了すること。
- 複数対象時でも 1 件ずつ順番表示されること。

## ロールバック方針
- 本PRの2コミットをrevertして、未解決ケースダイアログ導入前の挙動に戻す。

## 互換性影響
- なし。

## Cloudflare resources 影響
- なし。

## docs/design 更新有無
- なし（既存設計範囲内の実装）。