### PR TITLE
feat(worker): durable message dedupe in RoomDurableObject

### DIFF
--- a/apps/worker/src/durable/room-object.ts
+++ b/apps/worker/src/durable/room-object.ts
@@ -702,6 +702,7 @@ export class RoomDurableObject {
       if (this.isDuplicateMessage(message.player_id, message.client_msg_id)) {
         return;
       }
+      await this.persistRoomRecord();
 
       if (message.type !== "ROOM_JOIN" && session.playerId === null) {
         this.sendError(socket, "INVALID_STATE", "Send ROOM_JOIN before this message.");

--- a/apps/worker/src/durable/room-object.ts
+++ b/apps/worker/src/durable/room-object.ts
@@ -82,10 +82,78 @@ const OPEN_WEBSOCKET_STATE = 1;
 const SWITCHING_PROTOCOLS_STATUS = 101;
 const ROOM_RECORD_STORAGE_KEY = "room-record";
 
+type SeenClientMessageIdsRecord = Record<string, string[]>;
+
 interface RoomDurableRecord {
   room_state: RoomStatePersistenceRecord;
   processed_request_keys: string[];
+  seen_client_message_ids?: SeenClientMessageIdsRecord;
   next_event_seq: number;
+}
+
+function normalizeSeenClientMessageIds(rawMessageIds: unknown[]): string[] {
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+  for (let index = rawMessageIds.length - 1; index >= 0; index -= 1) {
+    const rawMessageId = rawMessageIds[index];
+    if (typeof rawMessageId !== "string") {
+      continue;
+    }
+
+    if (rawMessageId.trim().length === 0 || seen.has(rawMessageId)) {
+      continue;
+    }
+
+    seen.add(rawMessageId);
+    normalized.push(rawMessageId);
+    if (normalized.length >= IDEMPOTENCY_LOG_LIMIT) {
+      break;
+    }
+  }
+
+  normalized.reverse();
+  return normalized;
+}
+
+function deserializeSeenClientMessageIds(value: unknown): Map<string, Set<string>> {
+  const seenClientMessageIds = new Map<string, Set<string>>();
+  if (!isRecord(value)) {
+    return seenClientMessageIds;
+  }
+
+  for (const [rawPlayerId, rawMessageIds] of Object.entries(value)) {
+    if (rawPlayerId.trim().length === 0 || !Array.isArray(rawMessageIds)) {
+      continue;
+    }
+
+    const normalized = normalizeSeenClientMessageIds(rawMessageIds);
+    if (normalized.length === 0) {
+      continue;
+    }
+
+    seenClientMessageIds.set(rawPlayerId, new Set(normalized));
+  }
+
+  return seenClientMessageIds;
+}
+
+function serializeSeenClientMessageIds(
+  seenClientMessageIds: Map<string, Set<string>>,
+): SeenClientMessageIdsRecord {
+  const serialized: SeenClientMessageIdsRecord = {};
+  for (const [rawPlayerId, messageIds] of seenClientMessageIds) {
+    if (rawPlayerId.trim().length === 0 || messageIds.size === 0) {
+      continue;
+    }
+
+    const normalized = normalizeSeenClientMessageIds(Array.from(messageIds));
+    if (normalized.length === 0) {
+      continue;
+    }
+
+    serialized[rawPlayerId] = normalized;
+  }
+  return serialized;
 }
 
 function isWebSocketUpgradeRequest(request: Request): boolean {
@@ -362,7 +430,7 @@ function parseRoomSocketAttachment(value: unknown): RoomSocketAttachment | null 
 export class RoomDurableObject {
   private readonly roomState = new RoomLobbyState(workerChartMaster);
   private readonly sessionsBySocket = new Map<WebSocket, RoomSocketSession>();
-  private readonly seenClientMessageIds = new Map<string, string[]>();
+  private readonly seenClientMessageIds = new Map<string, Set<string>>();
   private readonly processedRequestKeySet = new Set<string>();
   private processedRequestKeys: string[] = [];
   private nextEventSeq = 0;
@@ -379,6 +447,10 @@ export class RoomDurableObject {
         this.processedRequestKeys = [...record.processed_request_keys];
         for (const key of this.processedRequestKeys) {
           this.processedRequestKeySet.add(key);
+        }
+        const hydratedSeenClientMessageIds = deserializeSeenClientMessageIds(record.seen_client_message_ids);
+        for (const [playerId, messageIds] of hydratedSeenClientMessageIds) {
+          this.seenClientMessageIds.set(playerId, messageIds);
         }
         this.nextEventSeq = record.next_event_seq;
       }
@@ -1258,17 +1330,43 @@ export class RoomDurableObject {
   }
 
   private isDuplicateMessage(playerId: string, clientMessageId: string): boolean {
-    const seenIds = this.seenClientMessageIds.get(playerId) ?? [];
-    if (seenIds.includes(clientMessageId)) {
+    if (this.hasSeenClientMessageId(playerId, clientMessageId)) {
       return true;
     }
 
-    seenIds.push(clientMessageId);
-    if (seenIds.length > IDEMPOTENCY_LOG_LIMIT) {
-      seenIds.shift();
-    }
-    this.seenClientMessageIds.set(playerId, seenIds);
+    this.rememberClientMessageId(playerId, clientMessageId);
     return false;
+  }
+
+  private hasSeenClientMessageId(playerId: string, clientMessageId: string): boolean {
+    const seenIds = this.seenClientMessageIds.get(playerId);
+    return seenIds?.has(clientMessageId) ?? false;
+  }
+
+  private rememberClientMessageId(playerId: string, clientMessageId: string): void {
+    let seenIds = this.seenClientMessageIds.get(playerId);
+    if (seenIds === undefined) {
+      seenIds = new Set<string>();
+      this.seenClientMessageIds.set(playerId, seenIds);
+    }
+
+    if (seenIds.has(clientMessageId)) {
+      return;
+    }
+
+    seenIds.add(clientMessageId);
+    while (seenIds.size > IDEMPOTENCY_LOG_LIMIT) {
+      const oldest = seenIds.values().next().value;
+      if (typeof oldest !== "string") {
+        break;
+      }
+
+      seenIds.delete(oldest);
+    }
+  }
+
+  private clearSeenClientMessageIds(): void {
+    this.seenClientMessageIds.clear();
   }
 
   private buildRequestKey(playerId: string, type: string, requestId: string): string {
@@ -1334,9 +1432,15 @@ export class RoomDurableObject {
   }
 
   private async persistRoomRecord(): Promise<void> {
+    if (this.roomState.getRoomState() === "CLOSED") {
+      // CLOSED means the room lifecycle ended, so message-level dedupe history is discarded.
+      this.clearSeenClientMessageIds();
+    }
+
     const record: RoomDurableRecord = {
       room_state: this.roomState.toPersistenceRecord(),
       processed_request_keys: [...this.processedRequestKeys],
+      seen_client_message_ids: serializeSeenClientMessageIds(this.seenClientMessageIds),
       next_event_seq: this.nextEventSeq,
     };
     await this.state.storage.put(ROOM_RECORD_STORAGE_KEY, record);

--- a/tasks/pr-2-room-do-durable-dedupe.md
+++ b/tasks/pr-2-room-do-durable-dedupe.md
@@ -1,0 +1,55 @@
+# pr-2-room-do-durable-dedupe
+
+## Purpose
+- `RoomDurableObject` の `seenClientMessageIds` を durable 化し、constructor 再実行後も重複メッセージ抑止を継続できるようにする。
+
+## Non-goals
+- `ctx.acceptWebSocket()` への基盤移行
+- reconnect 猶予仕様変更
+- WS schema/type/payload の変更
+- LobbyDirectoryDO や SQL API への拡張
+- room 全体状態モデル再設計
+
+## Changes
+- `RoomDurableRecord` に `seen_client_message_ids` を追加し、serialize/deserialize を導入する。
+- constructor hydrate で durable state から `seenClientMessageIds` を復元する（不正データは安全に無視）。
+- message dedupe を durable 復元済み state ベースに変更する（`playerId -> Set` をメモリ表現として使用）。
+- `RETURN_TO_LOBBY` では clear せず、`CLOSED` 遷移と record 削除相当時のみ clear する。
+- `seenClientMessageIds[playerId]` に上限を設け、古い ID を先頭から削除して永続化サイズを bounded に保つ。
+- 既存 `processedRequestKeys` ベース idempotency を維持する。
+
+## Impact
+- Users: 目に見える UI 変更なし。hibernation 復帰後の重複再送挙動が安定化。
+- Data: `room-record` に `seen_client_message_ids` が追加される。
+- Compatibility: 旧 record（当該フィールド欠落）を受理し空として扱う後方互換。
+- Cloudflare: Durable Object storage record 更新のみ。KV/Lobby contract 変更なし。
+
+## Target Files / Layers
+- Files:
+  - `apps/worker/src/durable/room-object.ts`
+  - （必要最小限で）関連テストファイル
+- Layers:
+  - worker (Durable Object)
+
+## Test Focus
+- QUALITY 1: worker build/typecheck, lint, 既存テスト実行（対象範囲）
+- QUALITY 2: 目的外 diff 無し、UTF-8 no BOM / LF 逸脱無し
+- QUALITY 3: idempotency（client_msg_id）重複排除、`RETURN_TO_LOBBY` 後の dedupe 継続、`CLOSED` 後の clear
+- QUALITY 4: 対象外（監視ソース I/O 非変更）
+- QUALITY 5: 対象外（E2E は今回スコープ外。必要時は別途）
+
+## Rollback Plan
+- 本差分を revert し、`room-record` の追加フィールドを無視する既存挙動へ戻す。
+- 旧 record は optional decode で扱うため、ロールバック時の互換性リスクは低い。
+
+## Commit Split Plan
+1. `RoomDurableRecord` 拡張と serialize/deserialize・hydrate/clear 実装
+2. message dedupe 呼び出し更新と最小限の検証/テスト更新
+
+## Checklist
+- [x] Design doc alignment confirmed (contract changeなし)
+- [x] Impact scope identified
+- [x] Implementation completed
+- [x] Tests completed
+- [x] Regression checks completed
+- [x] Documentation updates completed (not required)


### PR DESCRIPTION
## 目的
- `RoomDurableObject` の `seenClientMessageIds` を durable 化し、DO hibernation / constructor 再実行後も message dedupe を継続できるようにする。

## 変更点
- `RoomDurableRecord` に `seen_client_message_ids` を追加。
- `playerId -> string[]` の persist 形式と `Map<string, Set<string>>` のメモリ形式を分離し、serialize/deserialize helper を追加。
- constructor hydrate 時に `seen_client_message_ids` を decode/validate して復元（欠落・不正値は安全に無視）。
- dedupe lookup を復元済み state ベースに変更し、`client_msg_id` 初見時に durable record を保存。
- `RETURN_TO_LOBBY` では clear せず、`CLOSED` の persist 経路で `seenClientMessageIds` を clear。
- `IDEMPOTENCY_LOG_LIMIT` により player ごとの保存件数を bounded に維持（古いものから削除）。
- 既存 `processedRequestKeys`（request_id ベース idempotency）は維持。

## 非変更点
- WebSocket schema/type/payload 契約
- reconnect 猶予仕様
- LobbyDirectoryDO / KV ロビー一覧仕様
- SQL API への移行

## 影響範囲
- Users: UI変更なし。hibernation 復帰後の重複再送抑止の安定性のみ向上。
- Data: `room-record` に `seen_client_message_ids` が追加。
- 互換性: 旧 record（フィールド欠落）を空として扱うため後方互換あり。
- Cloudflare: Room DO の storage record 更新のみ（KV/route 変更なし）。

## テスト内容
- `npm run typecheck`
- `npm run lint`
- `npm --workspace @infinitas/worker run typecheck`
- `npm --workspace @infinitas/worker run test`
- `npx eslint apps/worker/src/durable/room-object.ts`

## 回帰確認項目
- `client_msg_id` 重複が room 存続中に再送抑止されること。
- `RETURN_TO_LOBBY` 後も dedupe 履歴が保持されること。
- `CLOSED` persist 時に dedupe 履歴が破棄されること。
- request_id ベース idempotency が既存通り動作すること。

## ロールバック方針
- 本PRの2コミットを revert して復旧可能。

## 互換性影響の有無
- あり（storage record に optional フィールド追加）ただし後方互換あり。

## Cloudflare resources 影響
- Durable Object storage の record サイズ増加（bounded 制御あり）。

## docs/design 更新有無
- なし（既存契約内の実装改善）。

## 補足
- Base SHA: `476f1c9`
