### PR TITLE
PR-3: Room DO close/reconnect を一時切断猶予モデルへ整理

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "test": "tsx --test src/durable/room-state.test.mjs src/master/chart-master.test.mjs",
+    "test": "tsx --test src/durable/room-state.test.mjs src/durable/room-object.test.mjs src/master/chart-master.test.mjs",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "devDependencies": {

--- a/apps/worker/src/durable/room-object.test.mjs
+++ b/apps/worker/src/durable/room-object.test.mjs
@@ -1,0 +1,180 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { RoomDurableObject } from "./room-object.ts";
+
+class TestStorage {
+  #records = new Map();
+  #alarm = null;
+
+  async get(key) {
+    return this.#records.get(key);
+  }
+
+  async put(key, value) {
+    this.#records.set(key, value);
+  }
+
+  async deleteAlarm() {
+    this.#alarm = null;
+  }
+
+  async setAlarm(value) {
+    this.#alarm = value instanceof Date ? value.getTime() : value;
+  }
+}
+
+class TestDurableObjectState {
+  storage = new TestStorage();
+  #sockets = [];
+
+  async blockConcurrencyWhile(callback) {
+    return callback();
+  }
+
+  acceptWebSocket(socket) {
+    this.#sockets.push(socket);
+  }
+
+  getWebSockets() {
+    return [...this.#sockets];
+  }
+}
+
+class TestSocket {
+  readyState = 1;
+  sent = [];
+  closeCalls = [];
+  #attachment = null;
+
+  send(payload) {
+    this.sent.push(JSON.parse(payload));
+  }
+
+  close(code, reason) {
+    this.closeCalls.push({ code, reason });
+    this.readyState = 3;
+  }
+
+  serializeAttachment(attachment) {
+    this.#attachment = structuredClone(attachment);
+  }
+
+  deserializeAttachment() {
+    return this.#attachment;
+  }
+}
+
+function buildSettings() {
+  return {
+    visibility: "PUBLIC",
+    join_code: "ABCDEFGH",
+    mode: "ARENA",
+    win_metric: "SCORE",
+    play_style: "SP",
+    level_filter: "ANY",
+    room_comment: "room object test",
+    max_players: 4,
+  };
+}
+
+function createEnv() {
+  const okResponse = () => new Response(JSON.stringify({ ok: true }), { status: 200 });
+  return {
+    ROOM_DO: {
+      idFromName(name) {
+        return { toString: () => name };
+      },
+      get() {
+        return {
+          fetch: async () => okResponse(),
+        };
+      },
+    },
+    LOBBY_DIRECTORY_DO: {
+      idFromName(name) {
+        return { toString: () => name };
+      },
+      get() {
+        return {
+          fetch: async () => okResponse(),
+        };
+      },
+    },
+  };
+}
+
+async function createRoomObject() {
+  const state = new TestDurableObjectState();
+  const roomObject = new RoomDurableObject(state, createEnv());
+  await roomObject.readyPromise;
+
+  roomObject.roomState.initialize({
+    room_id: "room-1",
+    created_at: "2026-03-08T00:00:00.000Z",
+    settings: buildSettings(),
+  });
+
+  return roomObject;
+}
+
+function createJoinMessage(playerId, clientMessageId) {
+  return {
+    type: "ROOM_JOIN",
+    client_msg_id: clientMessageId,
+    room_id: "room-1",
+    player_id: playerId,
+    payload: {
+      display_name: playerId.toUpperCase(),
+      source: "inf-notebook",
+    },
+  };
+}
+
+async function joinPlayer(roomObject, socket, playerId, clientMessageId) {
+  const session = roomObject.registerSocketSession(socket);
+  await roomObject.handleRoomJoin(session, createJoinMessage(playerId, clientMessageId));
+  return session;
+}
+
+test("webSocketClose marks player as temporarily disconnected", async () => {
+  const roomObject = await createRoomObject();
+  const hostSocket = new TestSocket();
+  const guestSocket = new TestSocket();
+
+  await joinPlayer(roomObject, hostSocket, "host", "msg-1");
+  await joinPlayer(roomObject, guestSocket, "guest", "msg-2");
+
+  await roomObject.webSocketClose(guestSocket, 1006, "abnormal close", false);
+
+  const guest = roomObject.roomState.toSnapshot().players.find((player) => player.player_id === "guest");
+  assert.ok(guest);
+  assert.equal(guest.connected, false);
+  assert.notEqual(guest.left_at, null);
+  assert.notEqual(guest.rejoin_until, null);
+});
+
+test("reconnect replaces old socket and stale close does not mark player disconnected again", async () => {
+  const roomObject = await createRoomObject();
+  const oldSocket = new TestSocket();
+
+  await joinPlayer(roomObject, oldSocket, "host", "msg-1");
+  roomObject.roomState.markPlayerDisconnected("host", new Date());
+
+  const reconnectSocket = new TestSocket();
+  await joinPlayer(roomObject, reconnectSocket, "host", "msg-2");
+
+  assert.equal(oldSocket.closeCalls.length, 1);
+  assert.equal(oldSocket.closeCalls[0]?.code, 4002);
+
+  let host = roomObject.roomState.toSnapshot().players.find((player) => player.player_id === "host");
+  assert.ok(host);
+  assert.equal(host.connected, true);
+  assert.equal(host.left_at, null);
+  assert.equal(host.rejoin_until, null);
+
+  await roomObject.webSocketClose(oldSocket, 1000, "replaced", true);
+
+  host = roomObject.roomState.toSnapshot().players.find((player) => player.player_id === "host");
+  assert.ok(host);
+  assert.equal(host.connected, true);
+});

--- a/apps/worker/src/durable/room-object.ts
+++ b/apps/worker/src/durable/room-object.ts
@@ -41,6 +41,8 @@ type RoomSocketAttachment = {
   playerId: string | null;
   joinedAt: string | null;
   role: RoomSocketRole | null;
+  connectionId: string | null;
+  attachedAt: string | null;
 };
 
 interface RoomSocketSession {
@@ -48,6 +50,8 @@ interface RoomSocketSession {
   playerId: string | null;
   joinedAt: string | null;
   role: RoomSocketRole | null;
+  connectionId: string | null;
+  attachedAt: string | null;
 }
 
 interface HibernationWebSocketLike extends WebSocket {
@@ -403,7 +407,15 @@ function parseRoomSocketAttachment(value: unknown): RoomSocketAttachment | null 
   const playerId = value.playerId;
   const joinedAt = value.joinedAt;
   const rawRole = value.role;
+  const rawConnectionId = value.connectionId;
+  const rawAttachedAt = value.attachedAt;
   if ((typeof playerId !== "string" && playerId !== null) || (typeof joinedAt !== "string" && joinedAt !== null)) {
+    return null;
+  }
+  if (
+    (typeof rawConnectionId !== "string" && rawConnectionId !== null && rawConnectionId !== undefined) ||
+    (typeof rawAttachedAt !== "string" && rawAttachedAt !== null && rawAttachedAt !== undefined)
+  ) {
     return null;
   }
 
@@ -412,6 +424,8 @@ function parseRoomSocketAttachment(value: unknown): RoomSocketAttachment | null 
       playerId,
       joinedAt,
       role: null,
+      connectionId: typeof rawConnectionId === "string" ? rawConnectionId : null,
+      attachedAt: typeof rawAttachedAt === "string" ? rawAttachedAt : null,
     };
   }
 
@@ -424,12 +438,15 @@ function parseRoomSocketAttachment(value: unknown): RoomSocketAttachment | null 
     playerId,
     joinedAt,
     role,
+    connectionId: typeof rawConnectionId === "string" ? rawConnectionId : null,
+    attachedAt: typeof rawAttachedAt === "string" ? rawAttachedAt : null,
   };
 }
 
 export class RoomDurableObject {
   private readonly roomState = new RoomLobbyState(workerChartMaster);
   private readonly sessionsBySocket = new Map<WebSocket, RoomSocketSession>();
+  private readonly activeSocketByPlayerId = new Map<string, WebSocket>();
   private readonly seenClientMessageIds = new Map<string, Set<string>>();
   private readonly processedRequestKeySet = new Set<string>();
   private processedRequestKeys: string[] = [];
@@ -570,6 +587,8 @@ export class RoomDurableObject {
       playerId: null,
       joinedAt: null,
       role: null,
+      connectionId: null,
+      attachedAt: null,
     };
   }
 
@@ -625,6 +644,8 @@ export class RoomDurableObject {
       playerId: attachment.playerId,
       joinedAt: attachment.joinedAt,
       role: attachment.role,
+      connectionId: attachment.connectionId,
+      attachedAt: attachment.attachedAt,
     };
     this.sessionsBySocket.set(socket, session);
     return session;
@@ -641,9 +662,12 @@ export class RoomDurableObject {
 
   private rebuildSessionsFromWebSockets(): void {
     this.sessionsBySocket.clear();
+    this.activeSocketByPlayerId.clear();
     for (const socket of this.state.getWebSockets()) {
       this.registerSocketSession(socket);
     }
+
+    this.rebuildActiveSocketIndex();
   }
 
   private syncSocketAttachment(session: RoomSocketSession): void {
@@ -651,11 +675,84 @@ export class RoomDurableObject {
       playerId: session.playerId,
       joinedAt: session.joinedAt,
       role: session.role,
+      connectionId: session.connectionId,
+      attachedAt: session.attachedAt,
     });
   }
 
   private resolveSocketRole(playerId: string): RoomSocketRole {
     return this.roomState.getHostPlayerId() === playerId ? "HOST" : "PLAYER";
+  }
+
+  private parseAttachmentTimestamp(value: string | null): number {
+    if (typeof value !== "string") {
+      return Number.NEGATIVE_INFINITY;
+    }
+
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
+  }
+
+  private rebuildActiveSocketIndex(): void {
+    this.activeSocketByPlayerId.clear();
+    const newestAttachedAtByPlayerId = new Map<string, number>();
+
+    for (const session of this.sessionsBySocket.values()) {
+      if (session.playerId === null) {
+        continue;
+      }
+
+      const attachedAt = this.parseAttachmentTimestamp(session.attachedAt);
+      const knownAttachedAt = newestAttachedAtByPlayerId.get(session.playerId) ?? Number.NEGATIVE_INFINITY;
+      if (attachedAt >= knownAttachedAt) {
+        newestAttachedAtByPlayerId.set(session.playerId, attachedAt);
+        this.activeSocketByPlayerId.set(session.playerId, session.socket);
+      }
+    }
+  }
+
+  private isCurrentSocketForPlayer(playerId: string, socket: WebSocket): boolean {
+    return this.activeSocketByPlayerId.get(playerId) === socket;
+  }
+
+  private clearActiveSocketForPlayer(playerId: string, socket: WebSocket): void {
+    if (this.activeSocketByPlayerId.get(playerId) === socket) {
+      this.activeSocketByPlayerId.delete(playerId);
+    }
+  }
+
+  private clearSessionPlayerBinding(session: RoomSocketSession): void {
+    if (session.playerId !== null) {
+      this.clearActiveSocketForPlayer(session.playerId, session.socket);
+    }
+
+    session.playerId = null;
+    session.joinedAt = null;
+    session.role = null;
+    session.connectionId = null;
+    session.attachedAt = null;
+    this.syncSocketAttachment(session);
+  }
+
+  private assignSessionToPlayer(session: RoomSocketSession, playerId: string, joinedAt: string, attachedAt: string): void {
+    session.playerId = playerId;
+    session.joinedAt = joinedAt;
+    session.role = this.resolveSocketRole(playerId);
+    session.connectionId = crypto.randomUUID();
+    session.attachedAt = attachedAt;
+    this.syncSocketAttachment(session);
+    this.activeSocketByPlayerId.set(playerId, session.socket);
+  }
+
+  private replacePlayerSocket(playerId: string, currentSession: RoomSocketSession): void {
+    for (const session of this.sessionsBySocket.values()) {
+      if (session.socket === currentSession.socket || session.playerId !== playerId) {
+        continue;
+      }
+
+      this.clearSessionPlayerBinding(session);
+      this.safeCloseSocket(session.socket, 4002, "Replaced by a new connection.");
+    }
   }
 
   private async handleSocketMessage(
@@ -763,13 +860,15 @@ export class RoomDurableObject {
     context: SocketCloseContext,
   ): Promise<void> {
     const session = this.getOrCreateSocketSession(socket);
+    const playerId = session.playerId;
+    const isCurrentSocket = playerId !== null && this.isCurrentSocketForPlayer(playerId, socket);
 
     const roomId = this.roomState.isInitialized()
       ? this.roomState.getRoomId()
       : "(uninitialized)";
     console.info("[room-do] socket closed", {
       roomId,
-      playerId: session.playerId,
+      playerId,
       roomState: this.roomState.getRoomState(),
       trigger: context.trigger,
       code: context.code,
@@ -779,7 +878,20 @@ export class RoomDurableObject {
     });
 
     this.sessionsBySocket.delete(socket);
-    await this.handleRoomLeave(session, false);
+    if (playerId === null || !isCurrentSocket) {
+      return;
+    }
+
+    this.clearActiveSocketForPlayer(playerId, socket);
+    const leaveResult = this.roomState.markPlayerDisconnected(playerId, new Date());
+    if (!leaveResult.changed) {
+      return;
+    }
+
+    await this.persistRoomRecord();
+    await this.syncAlarm();
+    await this.syncLobbyDirectory();
+    this.broadcastRoomUpdated();
   }
 
   private async handleRoomJoin(session: RoomSocketSession, message: ClientMessage<"ROOM_JOIN">): Promise<void> {
@@ -788,15 +900,21 @@ export class RoomDurableObject {
       return;
     }
 
-    const payload = parseRoomJoinPayload(message.payload);
-    if (payload === null) {
-      this.sendJoinRejected(session.socket, "INVALID_JOIN_PAYLOAD");
+    if (
+      session.playerId === message.player_id &&
+      this.roomState.isPlayerConnected(message.player_id) &&
+      this.isCurrentSocketForPlayer(message.player_id, session.socket)
+    ) {
+      this.send(session.socket, "ROOM_JOIN_ACCEPTED", {
+        room_state_snapshot: this.roomState.toSnapshot(),
+      });
+      this.sendResultReadyIfAvailable(session.socket);
       return;
     }
 
-    const existingSession = this.findSessionByPlayerId(message.player_id);
-    if (existingSession && existingSession.socket !== session.socket) {
-      this.sendJoinRejected(session.socket, "PLAYER_ALREADY_CONNECTED");
+    const payload = parseRoomJoinPayload(message.payload);
+    if (payload === null) {
+      this.sendJoinRejected(session.socket, "INVALID_JOIN_PAYLOAD");
       return;
     }
 
@@ -810,11 +928,12 @@ export class RoomDurableObject {
       }
     }
 
+    const now = new Date();
     const joinResult = this.roomState.joinPlayer({
       player_id: message.player_id,
       display_name: payload.display_name,
       source: payload.source,
-      now: new Date(),
+      now,
     });
     if (!joinResult.ok) {
       this.sendJoinRejected(session.socket, joinResult.reason ?? "ROOM_JOIN_REJECTED");
@@ -823,12 +942,12 @@ export class RoomDurableObject {
 
     const snapshot = this.roomState.toSnapshot();
     const joinedPlayer = snapshot.players.find((player) => player.player_id === message.player_id);
-    session.playerId = message.player_id;
-    session.joinedAt = typeof joinedPlayer?.joined_at === "string"
+    const attachedAt = now.toISOString();
+    const joinedAt = typeof joinedPlayer?.joined_at === "string"
       ? joinedPlayer.joined_at
-      : new Date().toISOString();
-    session.role = this.resolveSocketRole(message.player_id);
-    this.syncSocketAttachment(session);
+      : attachedAt;
+    this.assignSessionToPlayer(session, message.player_id, joinedAt, attachedAt);
+    this.replacePlayerSocket(message.player_id, session);
     await this.persistRoomRecord();
     await this.syncLobbyDirectory();
 
@@ -841,10 +960,7 @@ export class RoomDurableObject {
 
   private async handleRoomLeave(session: RoomSocketSession, closeSocket: boolean): Promise<void> {
     const playerId = session.playerId;
-    session.playerId = null;
-    session.joinedAt = null;
-    session.role = null;
-    this.syncSocketAttachment(session);
+    this.clearSessionPlayerBinding(session);
 
     if (playerId === null) {
       if (closeSocket) {
@@ -1184,16 +1300,6 @@ export class RoomDurableObject {
     await this.publishRoundTransition(result);
   }
 
-  private findSessionByPlayerId(playerId: string): RoomSocketSession | null {
-    for (const session of this.sessionsBySocket.values()) {
-      if (session.playerId === playerId) {
-        return session;
-      }
-    }
-
-    return null;
-  }
-
   private sendStateSnapshot(socket: WebSocket): void {
     this.send(socket, "STATE_SNAPSHOT", {
       room_state_snapshot: this.roomState.toSnapshot(),
@@ -1402,12 +1508,10 @@ export class RoomDurableObject {
   private disconnectAll(code: number, reason: string): void {
     const sessions = Array.from(this.sessionsBySocket.values());
     this.sessionsBySocket.clear();
+    this.activeSocketByPlayerId.clear();
 
     for (const session of sessions) {
-      session.playerId = null;
-      session.joinedAt = null;
-      session.role = null;
-      this.syncSocketAttachment(session);
+      this.clearSessionPlayerBinding(session);
       this.safeCloseSocket(session.socket, code, reason);
     }
   }

--- a/apps/worker/src/durable/room-state.test.mjs
+++ b/apps/worker/src/durable/room-state.test.mjs
@@ -279,6 +279,48 @@ test("HOST_DISCONNECTED does not close immediately and can recover within cooldo
   assert.equal(state.getRoomState(), "LOBBY");
 });
 
+test("reconnect is rejected after rejoin window expires", () => {
+  const state = createState();
+  state.leavePlayer("host", new Date("2026-03-08T00:05:00.000Z"), "HOST_DISCONNECTED");
+
+  const joinResult = state.joinPlayer({
+    player_id: "host",
+    display_name: "Host",
+    source: "inf-notebook",
+    now: new Date("2026-03-08T00:05:11.000Z"),
+  });
+
+  assert.deepEqual(joinResult, { ok: false, reason: "REJOIN_WINDOW_EXPIRED" });
+});
+
+test("markPlayerDisconnected keeps slot and allows reconnect within grace", () => {
+  const state = createState();
+  const disconnectedAt = new Date("2026-03-08T00:05:00.000Z");
+  const disconnectResult = state.markPlayerDisconnected("guest", disconnectedAt);
+
+  assert.deepEqual(disconnectResult, { changed: true, was_host: false, room_was_closed: false });
+
+  const disconnectedGuest = state.toSnapshot().players.find((player) => player.player_id === "guest");
+  assert.ok(disconnectedGuest);
+  assert.equal(disconnectedGuest.connected, false);
+  assert.notEqual(disconnectedGuest.left_at, null);
+  assert.notEqual(disconnectedGuest.rejoin_until, null);
+
+  const reconnectResult = state.joinPlayer({
+    player_id: "guest",
+    display_name: "Guest",
+    source: "inf_daken_counter",
+    now: new Date("2026-03-08T00:05:05.000Z"),
+  });
+  assert.deepEqual(reconnectResult, { ok: true, join_type: "RECONNECT" });
+
+  const reconnectedGuest = state.toSnapshot().players.find((player) => player.player_id === "guest");
+  assert.ok(reconnectedGuest);
+  assert.equal(reconnectedGuest.connected, true);
+  assert.equal(reconnectedGuest.left_at, null);
+  assert.equal(reconnectedGuest.rejoin_until, null);
+});
+
 test("HOST_DISCONNECTED closes room when cooldown expires", () => {
   const state = createState();
   const disconnectedAt = new Date("2026-03-08T00:05:00.000Z");

--- a/apps/worker/src/durable/room-state.ts
+++ b/apps/worker/src/durable/room-state.ts
@@ -67,7 +67,13 @@ export interface JoinPlayerInput {
 
 export interface JoinPlayerResult {
   ok: boolean;
-  reason?: "ROOM_CLOSED" | "ROOM_FULL" | "ROOM_JOIN_LOCKED";
+  reason?:
+    | "ROOM_CLOSED"
+    | "ROOM_FULL"
+    | "ROOM_JOIN_LOCKED"
+    | "PLAYER_ALREADY_CONNECTED"
+    | "REJOIN_WINDOW_EXPIRED";
+  join_type?: "NEW" | "RECONNECT";
 }
 
 export interface LeavePlayerResult {
@@ -495,12 +501,24 @@ export class RoomLobbyState {
     }
 
     if (existing) {
+      if (existing.connected) {
+        return { ok: false, reason: "PLAYER_ALREADY_CONNECTED" };
+      }
+
+      if (existing.rejoin_until === null) {
+        return { ok: false, reason: "ROOM_JOIN_LOCKED" };
+      }
+
+      if (input.now.getTime() > existing.rejoin_until.getTime()) {
+        return { ok: false, reason: "REJOIN_WINDOW_EXPIRED" };
+      }
+
       existing.display_name = input.display_name;
       existing.source = input.source;
       existing.connected = true;
       existing.left_at = null;
       existing.rejoin_until = null;
-      return { ok: true };
+      return { ok: true, join_type: "RECONNECT" };
     }
 
     let role: PlayerRole = "GUEST";
@@ -521,7 +539,22 @@ export class RoomLobbyState {
       rejoin_until: null,
     });
 
-    return { ok: true };
+    return { ok: true, join_type: "NEW" };
+  }
+
+  markPlayerDisconnected(playerId: string, now: Date): LeavePlayerResult {
+    const player = this.players.get(playerId);
+    if (!player) {
+      return { changed: false, was_host: false, room_was_closed: this.roomState === "CLOSED" };
+    }
+
+    const wasHost = this.hostPlayerId === playerId;
+    const roomWasClosed = this.roomState === "CLOSED";
+    player.connected = false;
+    player.left_at = now;
+    player.rejoin_until = computeRejoinUntil(now);
+
+    return { changed: true, was_host: wasHost, room_was_closed: roomWasClosed };
   }
 
   leavePlayer(


### PR DESCRIPTION
## 目的
`RoomDurableObject` の WebSocket close / reconnect 挙動を整理し、close を即退室ではなく一時切断として扱うことで、`rejoin_until` 猶予内の再接続復帰を可能にする。

## 変更点
- `webSocketClose()` を即退室処理から分離し、一時切断更新へ変更
  - current socket 判定を追加し、stale socket close では state を更新しない
  - close 時に `connected=false`, `left_at=now`, `rejoin_until=now+grace` を persistence 反映
- `ROOM_JOIN` の責務を整理
  - 新規参加 / 再接続 / 競合 join を room state (`connected`, `rejoin_until`) 基準で判定
  - 再接続受理時に `connected=true`, `left_at=null`, `rejoin_until=null` を復元
- 同一 `playerId` の socket 置換を安全化
  - `playerId -> active socket` を index 管理
  - 新 socket を正として旧 socket をクローズ
  - attachment に `connectionId`, `attachedAt` を持たせ、hibernation 復帰後も active 判定を再構築可能化
- 既存 durable dedupe 永続化ロジック（`seen_client_message_ids`）と両立するよう統合
- close/reconnect 回帰テストを追加・更新

## 非変更点
- room phase 遷移仕様の変更
- heartbeat 廃止 / timer 最適化
- `ctx.acceptWebSocket()` 基盤移行
- `LobbyDirectoryDO` の仕様変更
- WS schema (type/payload) 変更

## 影響範囲
- ユーザー: 一時切断後の同一 player 再接続で seat/state を維持した継続が可能
- データ: 既存 `connected/left_at/rejoin_until` を利用（保存形式の破壊的変更なし）
- 互換性: 既存 WS schema 維持
- Cloudflare: Room DO 内部の close/join/session 処理のみ変更

## ロールバック方針
- `room-object.ts` の close/join 分岐と socket 置換ロジックを従来実装に戻す
- `room-state.ts` の reconnect 条件 / disconnect helper を戻す
- 追加テストを削除して旧挙動へ復帰

## 互換性影響
- なし（プロトコル互換は維持）

## Cloudflare resources 影響
- Durable Object bindings 構成変更なし
- `wrangler deploy --dry-run` で build/binding 解決を確認

## docs/design 更新有無
- なし（既存契約範囲内の整理）

## テスト内容
- `npm --workspace @infinitas/worker run typecheck`
- `npm --workspace @infinitas/worker run test`
- `npm run lint`
- `npm --workspace @infinitas/worker run deploy -- --dry-run`

## 回帰確認項目
- close で即退室確定しない
- close 後に `connected=false`, `left_at`, `rejoin_until` が設定される
- `rejoin_until` 内再JOINが reconnect として受理される
- reconnect 時に `connected=true`, `left_at=null`, `rejoin_until=null` へ復元される
- old socket close が new socket の接続状態を壊さない
