### PR TITLE
Align room flow spec sources before release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ Unless the task explicitly requires it:
 ### 2.2 Server
 - Cloudflare Workers (HTTP entry)
 - Durable Objects (Room FSM + timers + aggregation + WS broadcast)
-- Cloudflare KV (Lobby list lightweight metadata only)
+- `LobbyDirectoryDO`（公開ロビー一覧の軽量サマリ正本）
 
 ### 2.3 Sources (fixed per device)
 - `inf_daken_counter` (today_update.xml)
@@ -81,7 +81,9 @@ These design docs are normative. Implementation MUST match them.
 - docs/design/06_source_io_spec.md
 - docs/design/07_constants.md
 - docs/design/08_repo_structure.md
-- docs/design/09_implementation_plan.md (Ph1 plan; freeze after Ph1 done)
+
+Historical only:
+- docs/design/09_implementation_plan.md (frozen reference; not a normative spec source)
 
 Rule:
 - If implementation must deviate, update the relevant design doc(s) first, then implement.
@@ -176,17 +178,17 @@ Required behavior:
 ## 8. Cloudflare-specific Execution Rules
 
 ### 8.1 Worker vs DO responsibilities
-- Worker routes must remain thin (routing + KV list).
+- Worker routes must remain thin (routing + lobby directory access).
 - DO owns: FSM, timers, idempotency, expected_key enforcement, aggregation, broadcast.
 
 ### 8.2 Idempotency
 - Client MUST send `client_msg_id` for every WS message.
 - DO MUST de-duplicate by `(player_id, client_msg_id)`.
 
-### 8.3 Lobby (KV)
-- KV stores only lightweight metadata (no full room state, no secrets).
-- `expires_at` is set at creation time; list API excludes expired entries.
-- DO closure attempts KV deletion; list API still excludes by expires_at as safety.
+### 8.3 Lobby (`LobbyDirectoryDO`)
+- 公開ロビー一覧の正本は `LobbyDirectoryDO` storage に保持する。
+- 一覧は軽量サマリのみを保持し、ルーム本体状態や secrets は置かない。
+- 一覧取得時/更新時に TTL 清掃を行い、公開・非満員・`LOBBY`・TTL 未超過のみ返す。
 
 ### 8.4 Failure mode
 - If DO state is lost, the room is closed with `ROOM_STATE_LOST` and clients show a blocking error dialog.

--- a/QUALITY.md
+++ b/QUALITY.md
@@ -37,12 +37,12 @@
 
 ## 3. FSM/Protocol検証（該当変更時のみ必須）
 変更がある場合は必ず確認する:
-- RoomState 遷移（LOBBY->READY_CHECK->PICKING->PLAYING->RESULT->CLOSED）
-- タイマー（20min/5min/30min/5min）動作
+- RoomState 遷移（LOBBY内ready管理 -> PICKING -> PLAYING -> RESULT -> CLOSED）
+- タイマー（ready_check 20min / picking 120s / round_soft_ttl 5min / match_ttl 30min）動作
 - expected_key enforcement（accept_window=0）
 - idempotency（client_msg_id）重複排除
-- host権限（START/force advance/host skip）
-- KV listing（expires_at / limit=10 / cursor）
+- host権限（START_MATCH / RETURN_TO_LOBBY / FORCE_ADVANCE）
+- LobbyDirectory 一覧（公開・非満員・LOBBY・TTL 未超過）
 
 ---
 
@@ -59,7 +59,7 @@
 - 2人で BPL(BO3): 同様
 - 重複ピックの差し替え
 - TIMEOUT（soft ttl）と FORCE_ADVANCE
-- host代理SKIP（unlock後）
+- `SKIP_HOST_ASSIGN` が v1 では拒否され、強制確定は `FORCE_ADVANCE` で扱われる
 - DO state loss -> ROOM_STATE_LOST -> room close
 
 ---
@@ -67,4 +67,4 @@
 ## 6. リリース前確認（Ph1）
 - バージョン整合性
 - CHANGELOG（ある場合）
-- ルーム一覧(KV)のexpires運用確認
+- `LobbyDirectoryDO` の一覧フィルタ / TTL 運用確認

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -47,9 +47,9 @@
 - Durable Objects の FSM / タイマー / 集計 / 権限制御変更
 - WebSocket message schema 変更（type/payload）
 - 監視ソース I/O 仕様変更（`inf_daken_counter` / `inf-notebook`）
-- ロビー一覧（KV）のスキーマ / 取得 / ページング変更
+- ロビー一覧（`LobbyDirectoryDO`）のスキーマ / 取得 / フィルタ変更
 - 保存形式 / 互換性に影響する変更（settings / result snapshot）
-- CI / デプロイ変更（Wrangler / Workers / DO / KV）
+- CI / デプロイ変更（Wrangler / Workers / DO）
 - 依存関係更新（lockfile含む）
 - client / worker / shared をまたぐクロスレイヤ変更
 - セキュリティ・再現性・整合性に影響する変更
@@ -81,7 +81,7 @@
 ### 記載形式（例）
 
 - [ ] 設計確認（該当 docs/design の確認）
-- [ ] 影響範囲特定（client / worker / shared / KV）
+- [ ] 影響範囲特定（client / worker / shared / lobby directory）
 - [ ] 実装
 - [ ] テスト
 - [ ] 回帰確認
@@ -168,7 +168,7 @@
 - FSM/Protocol 検証
 - 監視ソース検証
 - 最低限のE2E
-- DO state loss / KV listing / expected_key enforcement / idempotency
+- DO state loss / lobby listing / expected_key enforcement / idempotency
 
 ---
 

--- a/apps/worker/src/durable/lobby-directory-object.ts
+++ b/apps/worker/src/durable/lobby-directory-object.ts
@@ -112,7 +112,7 @@ function isExpired(room: LobbyRoomSummary, now: number): boolean {
     return false;
   }
 
-  if (room.status === "LOBBY" || room.status === "READY_CHECK") {
+  if (room.status === "LOBBY") {
     return age > READY_CHECK_TTL_MS;
   }
 
@@ -128,7 +128,7 @@ function isListVisible(room: LobbyRoomSummary, now: number): boolean {
     return false;
   }
 
-  return room.status === "LOBBY" || room.status === "READY_CHECK";
+  return room.status === "LOBBY";
 }
 
 function buildStoredRooms(input: unknown): Map<string, LobbyRoomSummary> {

--- a/apps/worker/src/durable/room-state.ts
+++ b/apps/worker/src/durable/room-state.ts
@@ -214,7 +214,7 @@ export interface RoomStatePersistenceRecord {
   version: 1;
   initialized: boolean;
   room_id: string;
-  room_state: RoomState | "READY_CHECK";
+  room_state: RoomState;
   settings: RoomSettings;
   host_player_id: string | null;
   created_at: string;
@@ -1236,7 +1236,9 @@ export class RoomLobbyState {
 
     this.initialized = true;
     this.roomId = record.room_id;
-    this.roomState = record.room_state === "READY_CHECK" ? "LOBBY" : record.room_state;
+    // Legacy pre-release snapshots may still contain READY_CHECK; fold them into LOBBY on restore.
+    const persistedRoomState = record.room_state as RoomState | "READY_CHECK";
+    this.roomState = persistedRoomState === "READY_CHECK" ? "LOBBY" : persistedRoomState;
     this.settings = normalizeSettingsVisibility({ ...record.settings });
     this.hostPlayerId = record.host_player_id;
     this.createdAt = parseRequiredDate(record.created_at);

--- a/docs/design/01_fsm.md
+++ b/docs/design/01_fsm.md
@@ -26,7 +26,7 @@
 
 ### 状態遷移（概要）
 - ルーム作成完了時は `LOBBY` に入る
-- `LOBBY` -> `PICKING`（ホスト `START`。条件: players>=2 かつ全員READY）
+- `LOBBY` -> `PICKING`（ホスト `START_MATCH`。条件: players>=2 かつ全員READY）
 - `PICKING` -> `PLAYING`（DOが確定譜面リストを凍結して遷移）
 - `PLAYING` -> `PLAYING`（全員確定で次ラウンドへ）
 - `PLAYING` -> `RESULT`（全ラウンド消化時。`RESULT_READY` を保持）
@@ -48,7 +48,7 @@
 - `ready_check_ttl = 20min`（LOBBY開始または `RESULT -> LOBBY` 復帰から。超過で解散）
 - `picking_ttl = 120s`（PICKING開始から。超過で未pick者をランダム補完して凍結）
 - `round_soft_ttl = 5min`（`count_go` 以降。超過で未確定者をTIMEOUT確定）
-- `host_skip_unlock_seconds = 240s`（現行v1では代理SKIP無効。将来拡張用の予約値）
+- `host_skip_unlock_seconds = 240s`（`SKIP_HOST_ASSIGN` 用の予約値。現行v1では操作を受理しない）
 - `match_ttl = 30min`（`START_MATCH` 成功時、すなわち `PICKING` 開始時から固定）
 - `rejoin_cooldown = 10s`（退出後の同一ルーム再入室抑止。ホスト非明示切断時の再接続猶予にも使用）
 
@@ -72,10 +72,10 @@
 - 一覧表示条件（`GET /api/lobby`）
   - `isPublic = true`
   - `isFull = false`
-  - `status in [LOBBY, READY_CHECK]`
+  - `status = LOBBY`
   - TTL 未超過
 - TTL 判定
-  - `status in [LOBBY, READY_CHECK]`: `now - ttlStartedAt > ready_check_ttl` で期限切れ
+  - `status = LOBBY`: `now - ttlStartedAt > ready_check_ttl` で期限切れ
   - `status in [PICKING, PLAYING, RESULT]`: `now - ttlStartedAt > match_ttl` で期限切れ
 - `LobbyDirectoryDO` は一覧取得時/更新時に期限切れルームを清掃する
 - ルーム終了（CLOSED）時は `LobbyDirectoryDO` から削除する
@@ -83,9 +83,9 @@
 ## 6. LOBBY（参加・設定閲覧）
 - 参加/退出は自由（最大 `max_players`）
 - ready 管理は `LOBBY` の内部状態として扱う
-- 全員が `ready=true` になって初めて `START` 条件を満たせる
+- 全員が `ready=true` になって初めて `START_MATCH` 条件を満たせる
 - ホスト自身も `ready=true` 必須
-- ホストのみ `START` を実行できる。`START` ボタンは常時表示し、条件未達時は遷移させず不足理由を表示する
+- ホストのみ `START_MATCH` を実行できる。UI の `START` ボタンは常時表示し、条件未達時は遷移させず不足理由を表示する
 - `visibility=PRIVATE` の場合は join_code必須（入口のWorkerで弾くか、DOで弾くかを統一）
 - `RESULT -> LOBBY` 復帰時には以下をクリアする
   - 全員の ready 状態
@@ -98,11 +98,11 @@
   - `match_ttl` を含む前マッチの寿命管理情報
 
 ### 開始条件
-- `players < 2` の間は `START` 成功不可
-- `ready=false` の参加者が 1 人でもいる間は `START` 成功不可
-- `START` はホストのみ
-- `START` 実行で以後参加不可（席ロック）。退出は可能（退出者は以後TIMEOUT扱い）
-- 前マッチ揮発状態が未クリアなら `START` を拒否する
+- `players < 2` の間は `START_MATCH` 成功不可
+- `ready=false` の参加者が 1 人でもいる間は `START_MATCH` 成功不可
+- `START_MATCH` はホストのみ
+- `START_MATCH` 実行で以後参加不可（席ロック）。退出は可能（退出者は以後TIMEOUT扱い）
+- 前マッチ揮発状態が未クリアなら `START_MATCH` を拒否する
 
 ## 8. PICKING（指名・凍結）
 ### 8.1 指名ルール
@@ -139,13 +139,13 @@
 
 ### 9.4 SKIP（自己申告のみ）
 - SKIP は常に本人のみ実行可能（`SKIP_SELF`）
-- 他プレイヤーへの代理 SKIP（`SKIP_HOST_ASSIGN`）は受理しない
+- 他プレイヤーへの代理 SKIP（`SKIP_HOST_ASSIGN`）は現行v1では受理しない
 - SKIP理由は必須: `UNOWNED | TECH | OTHER`
 
-### 9.5 強制進行（FORCE_ADVANCE）
+### 9.5 強制進行（`FORCE_ADVANCE` / force finalize）
 - ホストのみ
 - クライアントは確認ダイアログ必須
-- DOは未確定者を全員 `TIMEOUT` として確定し次ラウンドへ（最終ならRESULTへ）
+- DOは未確定者を全員 `TIMEOUT`（`submitted_by=SYSTEM`）として確定し次ラウンドへ進める（最終ならRESULTへ）
 
 ### 9.6 タイムアウト処理
 - `round_soft_ttl` 到達で未確定者は `TIMEOUT`

--- a/docs/design/02_ws_protocol.md
+++ b/docs/design/02_ws_protocol.md
@@ -62,8 +62,9 @@
   - payload: `{ request_id: string, round_index: number, observed_key: ExpectedKey, metric_value: number, source_meta?: object }`
 - `SKIP_SELF`
   - payload: `{ request_id: string, round_index: number, reason: "UNOWNED"|"TECH"|"OTHER" }`
-- `SKIP_HOST_ASSIGN`（ホスト）
+- `SKIP_HOST_ASSIGN`（ホスト / 予約）
   - payload: `{ request_id: string, round_index: number, target_player_id: string, reason: "UNOWNED"|"TECH"|"OTHER" }`
+  - 備考: 現行v1では受理しない。未確定者の強制確定は `FORCE_ADVANCE` を用いる
 - `FORCE_ADVANCE`（ホスト）
   - payload: `{ request_id: string }`
 
@@ -182,12 +183,15 @@
 }
 ```
 
+- `timers.result_deadline` は Ph1 現行フローでは通常 `null` 固定の予約欄
+
 ## 6. DO側ガード（必須）
 - 状態ガード: 状態に合わない操作は `ERROR` または `*_REJECTED`
 - 冪等化: `(player_id, client_msg_id)` は二重適用しない
 - 操作系は `(player_id, type, request_id)` でも二重適用しない
 - 先着順: `PICK_SUBMIT` の採用順はDO受信順（DOがaccepted_at付与）
-- 代理SKIP: `now - round_started_at >= 240s` かつ target未確定のみ許可
+- `SKIP_HOST_ASSIGN`: 現行v1では `INVALID_STATE` を返して受理しない
+- `FORCE_ADVANCE`: `room_state=PLAYING` かつ未確定者ありのときのみ許可し、未確定者を `TIMEOUT` / `submitted_by=SYSTEM` で確定する
 - START_MATCH: `players >= 2` かつ `room_state=LOBBY` かつ全員READY かつ前マッチ揮発状態クリア済みのみ
 - RETURN_TO_LOBBY: `room_state=RESULT` のみ。復帰時は全員readyと前マッチ揮発状態をリセットする
 - RESULT_SUBMIT: `observed_key == expected_key` かつ `round_index == current_round_index` のみ採用（accept_window=0）

--- a/docs/design/03_data_model.md
+++ b/docs/design/03_data_model.md
@@ -24,7 +24,7 @@
 - `ready_check_deadline: datetime|null`（LOBBY ready 管理用。ルーム作成時と `RESULT -> LOBBY` 復帰時に張り直す）
 - `picking_deadline: datetime|null`
 - `match_deadline: datetime|null`（`START_MATCH` 成功時、すなわち `PICKING` 開始時点で初めて確定）
-- `result_deadline: datetime|null`（互換用。通常フローでは `null`）
+- `result_deadline: datetime|null`（Ph1未使用。現行フローでは通常 `null` 固定の予約欄）
 - `closed_at: datetime|null`
 - `close_reason: ALL_ROUNDS_COMPLETED|MATCH_TTL_EXPIRED|READY_CHECK_TTL_EXPIRED|HOST_DISCONNECTED|HOST_ABORTED|PICKING_ABORTED|FORCE_CLOSED|null`
 - `result_ready_payload: object|null`（`RESULT` 中は保持し、`RESULT -> LOBBY` 復帰時にクリア。`summary.is_rated / rated_block_reason / rating_*` を含む）
@@ -58,7 +58,6 @@
 - `round_index: int`
 - `expected_key: ExpectedKey`
 - `display: { title: string, level: int|null }`
-- `started_at: datetime|null`（PLAYINGで開始時に埋める）
 - `started_at: datetime|null`（`ROUND_BEGIN` 時点。演出開始時刻）
 - `soft_ttl_seconds: int = 300`
 
@@ -119,7 +118,7 @@ type LobbyRoomSummary = {
   currentPlayers: number;
   maxPlayers: 2 | 3 | 4;
   isFull: boolean;
-  status: "LOBBY" | "READY_CHECK" | "PICKING" | "PLAYING" | "RESULT";
+  status: "LOBBY" | "PICKING" | "PLAYING" | "RESULT";
   ttlStartedAt: number;
   createdAt: number;
   updatedAt: number;
@@ -128,7 +127,6 @@ type LobbyRoomSummary = {
 
 ### 3.2 更新タイミング
 - ルーム作成: `status=LOBBY`, `ttlStartedAt=now` で upsert
-- `LOBBY -> READY_CHECK`: status のみ更新（`ttlStartedAt` は維持）
 - `START_MATCH` 成功（`PICKING` 開始）: `ttlStartedAt=now` に更新して upsert
 - `PLAYING` / `RESULT`: status のみ更新（`ttlStartedAt` は維持）
 - `RESULT -> LOBBY`: `ttlStartedAt=now` に更新して upsert
@@ -137,12 +135,12 @@ type LobbyRoomSummary = {
 ### 3.3 TTL / 一覧導出
 - `ttlStartedAt` は TTL 判定の唯一の起点時刻とする（`updatedAt` はTTL判定に使わない）
 - 期限判定:
-  - `status in [LOBBY, READY_CHECK]`: `now - ttlStartedAt > ready_check_ttl`
+  - `status = LOBBY`: `now - ttlStartedAt > ready_check_ttl`
   - `status in [PICKING, PLAYING, RESULT]`: `now - ttlStartedAt > match_ttl`
 - `GET /api/lobby` は返却前に期限切れを清掃し、以下のみ返す
   - `isPublic = true`
   - `isFull = false`
-  - `status in [LOBBY, READY_CHECK]`
+  - `status = LOBBY`
   - TTL 未超過
 
 ## 4. キー設計

--- a/docs/design/04_tech_stack.md
+++ b/docs/design/04_tech_stack.md
@@ -121,12 +121,12 @@ Ph1 では以下を重視する。
 ### Durable Object の責務
 - ルーム状態の保持
 - FSM 遷移
-- READY_CHECK / PICKING / PLAYING / RESULT 制御
+- LOBBY 内 ready 管理 / PICKING / PLAYING / RESULT 制御
 - タイマー管理
 - 提出受理
 - expected一致判定
-- FORCE_ADVANCE
-- ホスト代理SKIP
+- FORCE_ADVANCE（未確定者の強制 `TIMEOUT` 確定）
+- `SKIP_HOST_ASSIGN` は予約メッセージとして保持するが、現行v1では無効
 - 結果集計
 - ルーム内ブロードキャスト
 - 一覧要約（`LobbyRoomSummary`）の生成と `LobbyDirectoryDO` への通知
@@ -135,7 +135,7 @@ Ph1 では以下を重視する。
 ### LobbyDirectoryDO の責務
 - 公開ロビー一覧の正本保持（storage 永続化 / constructor 復元）
 - 一覧取得時と更新時の TTL 清掃
-- 表示条件（公開・非満員・LOBBY/READY_CHECK・TTL 未超過）のフィルタ
+- 表示条件（公開・非満員・LOBBY・TTL 未超過）のフィルタ
 - `upsertRoom` / `removeRoom` による RoomDO からの更新受理
 
 ---

--- a/docs/design/05_screen_list.md
+++ b/docs/design/05_screen_list.md
@@ -89,7 +89,7 @@ Ph1 の画面は以下とする。
 - 一覧には以下をすべて満たすルームのみ表示する
   - `isPublic = true`
   - `isFull = false`
-  - `status in [LOBBY, READY_CHECK]`
+  - `status = LOBBY`
   - TTL 未超過
 - `PICKING` / `PLAYING` / `RESULT` は一覧非表示とする
 
@@ -182,17 +182,17 @@ Ph1 の画面は以下とする。
   - READY切替
   - 退出
 - ホスト:
-  - START
+  - START ボタン（送信操作: `START_MATCH`）
   - RESULT から戻った後の再戦開始
   - 解散
 - 非ホスト:
 - START ボタンは表示しない
 
 ## 6.4 制約
-- ホストのみ START 実行可能
-- `players < 2` は START 成功不可
-- `ready=false` の参加者がいる間は START 成功不可
-- `max_players` は募集枠であり、開始人数は START 時点の参加人数で確定
+- ホストのみ `START_MATCH` 実行可能
+- `players < 2` は `START_MATCH` 成功不可
+- `ready=false` の参加者がいる間は `START_MATCH` 成功不可
+- `max_players` は募集枠であり、開始人数は `START_MATCH` 時点の参加人数で確定
 - `RESULT -> LOBBY` 復帰時は全員 ready が解除される
 - LOBBY ready ttl 20分超過で解散
 

--- a/docs/design/06_source_io_spec.md
+++ b/docs/design/06_source_io_spec.md
@@ -386,7 +386,7 @@ Ph1では以下を採用する。
 - `UnmatchedTitleLog` に記録
 - ラウンドが進行した場合は最終的に
   - 本人SKIP
-  - ホスト代理SKIP
+  - `FORCE_ADVANCE` による `TIMEOUT` 確定
   - TIMEOUT
   のいずれかで確定
 

--- a/docs/design/07_constants.md
+++ b/docs/design/07_constants.md
@@ -12,7 +12,7 @@ Ph1で固定するタイマー値、制約値、表示/運用上の定数を整�
 - `READY_CHECK_TTL_MINUTES = 20`
   - LOBBY開始または `RESULT -> LOBBY` 復帰から20分で解散
 - `START_MIN_PLAYERS = 2`
-  - `players < 2` の間はホストSTART不可
+  - `players < 2` の間はホスト `START_MATCH` 不可
 - `PICKING_TTL_SECONDS = 120`
   - PICKING開始から120秒で未pickをランダム補完
 
@@ -123,7 +123,7 @@ Ph1で固定するタイマー値、制約値、表示/運用上の定数を整�
 ## 6.2 LobbyDirectory 一覧保持
 - `LOBBY_READY_CHECK_TTL_MS = 20 * 60 * 1000`
 - `LOBBY_MATCH_TTL_MS = 30 * 60 * 1000`
-- `LOBBY_STATUS_VISIBLE = ["LOBBY", "READY_CHECK"]`
+- `LOBBY_STATUS_VISIBLE = ["LOBBY"]`
 - TTL 判定は `ttlStartedAt` のみを使う
 
 ---

--- a/docs/design/08_repo_structure.md
+++ b/docs/design/08_repo_structure.md
@@ -271,11 +271,9 @@ HTTP / WS Upgrade の入口。
 apps/worker/src/durable/
   room-object.ts
   lobby-directory-object.ts
-  room-fsm.ts
   room-state.ts
-  room-timers.ts
-  room-broadcast.ts
-  room-aggregation.ts
+  result-rating.ts
+  ws-codec.ts
 ```
 
 ### room-object.ts
@@ -285,35 +283,21 @@ apps/worker/src/durable/
 * クライアント接続管理
 * メッセージ受信入口
 
-### room-fsm.ts
-
-* RoomState 遷移
-* READY_CHECK/PICKING/PLAYING/RESULT/CLOSED 制御
-
 ### room-state.ts
 
 * DO内部状態管理
 * players / picks / rounds / submissions / deadlines
+* LOBBY 内 ready 管理 / PICKING / PLAYING / RESULT の進行データ
 
-### room-timers.ts
+### result-rating.ts
 
-* READY_CHECK TTL
-* round soft TTL
-* host skip unlock
-* match TTL
-* result TTL
+* rated 可否判定
+* ARENA 配点 / BPL BO3 集計
+* RESULT_READY 用のレーティング情報生成
 
-### room-broadcast.ts
+### ws-codec.ts
 
-* ルーム内イベント配信
-* snapshot送信
-* 状態更新通知
-
-### room-aggregation.ts
-
-* ARENA 配点
-* BPL BO3 集計
-* RESULT生成
+* WS envelope の decode/encode 補助
 
 ---
 
@@ -379,7 +363,7 @@ packages/shared/
 * ExpectedKey
 * FrozenRound
 * Submission
-* RoomSnapshot
+* RoomStateSnapshot
 * UnmatchedTitleLog
 
 ### ws

--- a/docs/design/09_implementation_plan.md
+++ b/docs/design/09_implementation_plan.md
@@ -1,5 +1,10 @@
 # 実装計画書（Ph1）
 
+Status: Frozen
+
+Ph1 実装計画の履歴資料。現行仕様の正本ではない。
+現行仕様は `docs/design/01_fsm.md` から `docs/design/08_repo_structure.md` を参照すること。
+
 ## 0. 目的
 Ph1 の実装範囲、作業順序、PR 分割、完了条件を定義する。  
 本計画は以下の設計文書を前提とする。

--- a/docs/release_preflight_checklist.md
+++ b/docs/release_preflight_checklist.md
@@ -156,7 +156,6 @@ npm run lint
   - `CLOUDFLARE_WORKERS_SUBDOMAIN`
 - [ ] `wrangler.toml` の本番設定を確認した
 - [ ] Durable Object migration tag が意図通り
-- [ ] KV namespace の本番 ID を確認した
 - [ ] preview と production の混同がない
 - [ ] 本番 deploy 実行者と権限を確認した
 - [ ] ロールバック時に戻すバージョンを控えた
@@ -166,7 +165,7 @@ npm run lint
 - `apps/worker/wrangler.toml`
 - `.github/workflows/deploy-worker.yml`
 - `apps/worker/README.md`
-- Cloudflare dashboard の DO / KV / Worker
+- Cloudflare dashboard の DO / Worker
 
 手動 deploy コマンド:
 
@@ -200,11 +199,11 @@ Smoke check: /api/charts?play_style=SP&level_filter=ANY
 
 ### 5.1 FSM / Protocol
 
-- [ ] `LOBBY -> READY_CHECK -> PICKING -> PLAYING -> RESULT -> CLOSED` を確認
+- [ ] `LOBBY` 内 ready 管理から `PICKING -> PLAYING -> RESULT -> CLOSED` への遷移を確認
 - [ ] `client_msg_id` による重複排除を確認
 - [ ] `expected_key` enforcement を確認
 - [ ] host 権限制御を確認
-- [ ] `expires_at` による KV 一覧除外を確認
+- [ ] `LobbyDirectoryDO` の公開・非満員・`LOBBY`・TTL フィルタを確認
 
 参照:
 
@@ -254,7 +253,7 @@ Smoke check: /api/charts?play_style=SP&level_filter=ANY
 - [ ] 重複 pick の差し替え
 - [ ] `TIMEOUT` 発生
 - [ ] `FORCE_ADVANCE` 動作
-- [ ] host 代理 SKIP 動作
+- [ ] `SKIP_HOST_ASSIGN` が v1 では拒否され、強制確定は `FORCE_ADVANCE` で扱うことを確認
 - [ ] `ROOM_STATE_LOST` 表示と room close
 
 記録テンプレート:

--- a/packages/shared/src/models/lobby-room-summary.ts
+++ b/packages/shared/src/models/lobby-room-summary.ts
@@ -3,7 +3,6 @@ import type { RoomSettings } from "./room-settings";
 
 export const LOBBY_ROOM_STATUSES = [
   "LOBBY",
-  "READY_CHECK",
   "PICKING",
   "PLAYING",
   "RESULT",

--- a/tasks/codex-design-fsm-doc-align.md
+++ b/tasks/codex-design-fsm-doc-align.md
@@ -1,0 +1,81 @@
+# codex-design-fsm-doc-align
+
+## Purpose
+- Align governance, design docs, and minimal shared/worker types with the current intended v1 room-flow contract.
+- Remove obsolete `READY_CHECK` state semantics from current contracts while preserving only explicit legacy compatibility where still needed.
+- Clarify that host-side forced finalization is represented by `FORCE_ADVANCE`, and do not silently change `SKIP_HOST_ASSIGN` behavior without matching implementation intent.
+
+## Non-goals
+- Do not introduce a new room-flow behavior beyond the current intended v1 contract.
+- Do not refactor unrelated worker/client architecture.
+- Do not expand into source I/O or rating behavior changes unless required by contract cleanup.
+
+## Base
+- Base branch: `v1`
+- Base SHA: `0bb71a1ca4dfa1b7f15ff8854d7c0dc532e929be`
+- Worktree: `C:/work/infinitas_arena/infinitas_bpl__design_fsm_doc_align`
+- Branch: `codex/design-fsm-doc-align`
+
+## Changes
+- Update governance/design docs so `01-08` are the active spec source and `09_implementation_plan.md` is frozen or retired as historical material.
+- Align design terminology with code where intended: `START_MATCH`, `GET /api/lobby`, `RoomStateSnapshot`, `LOBBY`-internal ready management.
+- Remove current-contract references to `READY_CHECK` from lobby visibility/status semantics and shared/worker types if they are no longer part of the intended v1 model.
+- Decide and implement the minimal safe handling for `result_ttl` / `result_deadline` based on current code usage.
+- Document forced-finalize behavior around `FORCE_ADVANCE` and keep `SKIP_HOST_ASSIGN` contract consistent with implementation unless an explicit behavior change is made.
+
+## Impact
+- Users: Clarifies room-flow behavior and prevents UI/protocol drift before release.
+- Data: May change shared snapshot/persistence shape if `result_deadline` or legacy `READY_CHECK` compatibility is removed.
+- Compatibility: Pre-release only, but shared types and worker persistence need careful alignment.
+- Cloudflare: Worker/DO contract and lobby summary behavior may be touched; routes stay thin.
+
+## Target Files / Layers
+- Files:
+  - `AGENTS.md`
+  - `docs/design/01_fsm.md`
+  - `docs/design/02_ws_protocol.md`
+  - `docs/design/03_data_model.md`
+  - `docs/design/04_tech_stack.md`
+  - `docs/design/05_screen_list.md`
+  - `docs/design/06_source_io_spec.md`
+  - `docs/design/07_constants.md`
+  - `docs/design/08_repo_structure.md`
+  - `docs/design/09_implementation_plan.md`
+  - `packages/shared/src/models/lobby-room-summary.ts`
+  - `packages/shared/src/models/room-state-snapshot.ts`
+  - `apps/worker/src/durable/lobby-directory-object.ts`
+  - `apps/worker/src/durable/room-object.ts`
+  - `apps/worker/src/durable/room-state.ts`
+- Layers: worker, shared, docs
+
+## Invariant Impact
+- INV-01: preserved
+  - Note: Worker routes remain thin; DO remains responsible for room flow.
+- INV-02: changed
+  - Note: Design contract will be aligned from `LOBBY -> READY_CHECK -> ...` to the intended 5-state model where ready is managed inside `LOBBY`.
+- INV-03: changed
+  - Note: Timer semantics will be clarified around lobby ready management and possible removal of unused result timer fields.
+- INV-06: preserved or tightened
+  - Note: Host authority language will be clarified so `FORCE_ADVANCE` remains the forced-finalize path unless `SKIP_HOST_ASSIGN` is intentionally implemented.
+
+## Test Focus
+- `QUALITY.md` section 1 and 2
+- `QUALITY.md` section 3 because FSM/protocol/shared-contract files are touched
+- Targeted shared/worker tests covering lobby visibility/status and force-advance behavior
+- UTF-8 no-BOM / LF-safe diff check
+
+## Rollback Plan
+- Revert this branch as one isolated change set.
+- If shared/worker type cleanup proves unsafe, keep behavior-alignment in docs/governance only and restore the removed fields/types before merge.
+
+## Commit Split Plan
+1. Freeze or retire obsolete planning/governance references and align design docs to the intended current contract.
+2. Apply the smallest shared/worker cleanup needed to match the updated contract and keep tests green.
+
+## Checklist
+- [ ] Design doc alignment confirmed
+- [ ] Impact scope identified
+- [ ] Implementation completed
+- [ ] Tests completed
+- [ ] Regression checks completed
+- [ ] Documentation updates completed


### PR DESCRIPTION
## 目的
- v1 リリース前に room flow の規範文書と governance を現行契約へ揃える
- READY_CHECK を独立 state として扱う旧前提を除去し、START_MATCH / FORCE_ADVANCE / LobbyDirectoryDO の扱いを明確化する

## 変更点
- AGENTS.md / WORKFLOW.md / QUALITY.md / docs/release_preflight_checklist.md を LobbyDirectoryDO と docs/design/01-08 正本前提へ更新
- docs/design の READY_CHECK state、旧 KV ロビー前提、START 表記、RoomSnapshot 命名を現行コード寄りに整列
- docs/design/09_implementation_plan.md を frozen な履歴資料として明示
- shared/worker の lobby status から READY_CHECK を削除し、公開ロビー一覧フィルタを LOBBY のみに整理
- worker hydrate では pre-release 互換として READY_CHECK -> LOBBY を吸収
- esult_deadline は削除せず、Ph1 未使用かつ通常 
ull の予約欄として文書化

## 非変更点
- SKIP_HOST_ASSIGN の有効化はしていない
- esult_deadline の runtime 削除はしていない
- source I/O と rating ロジックは変更していない

## 影響範囲
- Users: 画面/運用/設計の room flow 前提が一致する
- Data: pre-release の旧 READY_CHECK 永続値は restore 時に LOBBY へ吸収する
- Compatibility: リリース前の shared/worker 契約整理
- Cloudflare resources: LobbyDirectoryDO の責務記述と一覧フィルタ契約を整合

## テスト内容
- git diff --check
- 
pm run typecheck は未実行（dependencies 未導入のため 	sc が見つからない）
- 
pm run lint は未実行（dependencies 未導入のため slint が見つからない）
- 
pm run test:worker は未実行（dependencies 未導入のため 	sx が見つからない）
- 
pm run build:client は未実行（dependencies 未導入のため ite が見つからない）

## 回帰確認項目
- LOBBY 内 ready 管理から PICKING -> PLAYING -> RESULT -> CLOSED への遷移前提になっていること
- FORCE_ADVANCE が host の force finalize として記述/実装一致していること
- SKIP_HOST_ASSIGN が v1 では無効として記述/実装一致していること
- 公開ロビー一覧が LOBBY のみ表示前提になっていること

## ロールバック方針
- この PR の 2 コミットを revert して旧文書/型定義へ戻す
- shared/worker cleanup のみ問題があれば 2 コミット目だけ revert して docs 整理を残せる

## docs/design 更新
- あり (