### PR TITLE
feat: feedback submission v1 with non-prod dry run

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -39,11 +39,15 @@ jobs:
           CLOUDFLARE_API_TOKEN_WORKER: ${{ secrets.CLOUDFLARE_API_TOKEN_WORKER }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_WORKERS_SUBDOMAIN: ${{ vars.CLOUDFLARE_WORKERS_SUBDOMAIN }}
+          ISSUE_TOKEN: ${{ secrets.ISSUE_TOKEN }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
           required_vars=(
             CLOUDFLARE_API_TOKEN_WORKER
             CLOUDFLARE_ACCOUNT_ID
             CLOUDFLARE_WORKERS_SUBDOMAIN
+            ISSUE_TOKEN
+            DISCORD_WEBHOOK_URL
           )
 
           for name in "${required_vars[@]}"; do
@@ -55,6 +59,24 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Put Worker secret ISSUE_TOKEN
+        working-directory: ${{ env.WORKER_DIR }}
+        env:
+          CLOUDFLARE_API_TOKEN_WORKER: ${{ secrets.CLOUDFLARE_API_TOKEN_WORKER }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          ISSUE_TOKEN: ${{ secrets.ISSUE_TOKEN }}
+        run: |
+          printf "%s" "${ISSUE_TOKEN}" | CLOUDFLARE_API_TOKEN="${CLOUDFLARE_API_TOKEN_WORKER}" npx wrangler secret put ISSUE_TOKEN
+
+      - name: Put Worker secret DISCORD_WEBHOOK_URL
+        working-directory: ${{ env.WORKER_DIR }}
+        env:
+          CLOUDFLARE_API_TOKEN_WORKER: ${{ secrets.CLOUDFLARE_API_TOKEN_WORKER }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          printf "%s" "${DISCORD_WEBHOOK_URL}" | CLOUDFLARE_API_TOKEN="${CLOUDFLARE_API_TOKEN_WORKER}" npx wrangler secret put DISCORD_WEBHOOK_URL
 
       - name: Deploy Worker with Wrangler
         working-directory: ${{ env.WORKER_DIR }}

--- a/apps/client/src/pages/SettingsPage.tsx
+++ b/apps/client/src/pages/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
-import { ChevronLeft, Database, FolderOpen, Save, Settings as SettingsIcon, User, Volume2, VolumeX } from "lucide-react";
+import { ChevronLeft, Database, FolderOpen, MessageSquare, Save, Settings as SettingsIcon, User, Volume2, VolumeX } from "lucide-react";
 import { pickDirectory, validateSourceDirectory } from "../services/tauri-bridge";
+import { sendFeedback, type FeedbackRequest } from "../services/worker-api-client";
 import { sourceStore } from "../stores/source-store";
 import {
   getActiveSourceDirectory,
@@ -9,6 +10,7 @@ import {
   settingsStore,
   useSettingsStore,
 } from "../stores/settings-store";
+import clientPackageJson from "../../package.json";
 
 interface SettingsPageProps {
   roomJoined: boolean;
@@ -38,14 +40,42 @@ const SOURCE_OPTIONS = [
 const HIDDEN_SOURCE_IDS = new Set<(typeof SOURCE_OPTIONS)[number]["id"]>(["inf_daken_counter"]);
 const VISIBLE_SOURCE_OPTIONS = SOURCE_OPTIONS.filter((option) => !HIDDEN_SOURCE_IDS.has(option.id));
 const VOLUME_PREVIEW_SE_URL = "/se/count_beep.mp3";
+const FEEDBACK_TITLE_MAX_LENGTH = 100;
+const FEEDBACK_SUMMARY_MAX_LENGTH = 2000;
+const FEEDBACK_STEPS_MAX_LENGTH = 2000;
+const FEEDBACK_SUPPLEMENT_MAX_LENGTH = 2000;
+const FEEDBACK_PROBLEM_MAX_LENGTH = 2000;
+const FEEDBACK_PROPOSAL_MAX_LENGTH = 2000;
+const FEEDBACK_CONTENT_MAX_LENGTH = 3000;
+const FEEDBACK_SCREEN = "SettingsScreen";
+const APP_VERSION = typeof clientPackageJson.version === "string" ? clientPackageJson.version : "unknown";
+
+type FeedbackCategory = "bug" | "feature" | "other";
+
+interface FeedbackDraft {
+  category: FeedbackCategory;
+  title: string;
+  summary: string;
+  steps: string;
+  supplement: string;
+  problem: string;
+  proposal: string;
+  content: string;
+}
 
 export function SettingsPage({ roomJoined, onNavigateToLobby }: SettingsPageProps) {
   const draft = useSettingsStore((state) => state.draft);
+  const savedApiBaseUrl = useSettingsStore((state) => state.saved.apiBaseUrl);
   const statusMessage = useSettingsStore((state) => state.statusMessage);
   const _lastSavedAt = useSettingsStore((state) => state.lastSavedAt);
   const previewAudioRef = useRef<HTMLAudioElement | null>(null);
   const [displayNameError, setDisplayNameError] = useState<string | null>(null);
   const [validationMessage, setValidationMessage] = useState<string | null>(null);
+  const [isFeedbackModalOpen, setIsFeedbackModalOpen] = useState(false);
+  const [feedbackDraft, setFeedbackDraft] = useState<FeedbackDraft>(() => createInitialFeedbackDraft());
+  const [feedbackMessage, setFeedbackMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+  const [feedbackValidationError, setFeedbackValidationError] = useState<string | null>(null);
+  const [isFeedbackSubmitting, setIsFeedbackSubmitting] = useState(false);
 
   const activeDirectory = getActiveSourceDirectory(draft);
   const activeOption = getSourceOption(draft.source);
@@ -148,6 +178,29 @@ export function SettingsPage({ roomJoined, onNavigateToLobby }: SettingsPageProp
     }
   }
 
+  async function handleSubmitFeedback(): Promise<void> {
+    const validationError = validateFeedbackDraft(feedbackDraft);
+    if (validationError !== null) {
+      setFeedbackValidationError(validationError);
+      return;
+    }
+
+    setFeedbackValidationError(null);
+    setFeedbackMessage(null);
+    setIsFeedbackSubmitting(true);
+    try {
+      await sendFeedback(savedApiBaseUrl, buildFeedbackRequest(feedbackDraft));
+      setFeedbackDraft(createInitialFeedbackDraft());
+      setIsFeedbackModalOpen(false);
+      setFeedbackMessage({ type: "success", text: "送信しました" });
+    } catch {
+      setFeedbackMessage({ type: "error", text: "送信に失敗しました" });
+      setFeedbackValidationError("送信に失敗しました");
+    } finally {
+      setIsFeedbackSubmitting(false);
+    }
+  }
+
   return (
     <main className="mx-auto flex w-full max-w-6xl flex-col gap-12">
       <header className="mb-2">
@@ -159,10 +212,35 @@ export function SettingsPage({ roomJoined, onNavigateToLobby }: SettingsPageProp
           <ChevronLeft size={18} className="transition-transform group-hover:-translate-x-1" />
           ロビーに戻る
         </button>
-        <h1 className="flex items-center gap-3 text-4xl font-black italic uppercase tracking-tighter text-white">
-          <SettingsIcon className="h-8 w-8 text-cyan-500" />
-          System Settings
-        </h1>
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <h1 className="flex items-center gap-3 text-4xl font-black italic uppercase tracking-tighter text-white">
+            <SettingsIcon className="h-8 w-8 text-cyan-500" />
+            System Settings
+          </h1>
+          <aside className="w-full max-w-xs rounded-2xl border border-cyan-500/20 bg-cyan-500/5 p-4">
+            <p className="text-[10px] font-black uppercase tracking-[0.2em] text-cyan-300">Support</p>
+            <p className="mt-2 text-xs font-semibold leading-relaxed text-gray-300">
+              不具合報告・改善要望・その他の相談を送信できます。
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                setFeedbackValidationError(null);
+                setFeedbackMessage(null);
+                setIsFeedbackModalOpen(true);
+              }}
+              className="mt-4 inline-flex items-center gap-2 rounded-xl border border-cyan-400/40 bg-cyan-500/20 px-4 py-2 text-sm font-black text-cyan-200 transition-all hover:bg-cyan-500/30"
+            >
+              <MessageSquare size={16} />
+              フィードバックを送信
+            </button>
+            {feedbackMessage ? (
+              <p className={`mt-3 text-xs font-bold ${feedbackMessage.type === "success" ? "text-emerald-300" : "text-red-300"}`}>
+                {feedbackMessage.text}
+              </p>
+            ) : null}
+          </aside>
+        </div>
       </header>
 
       <div className="space-y-12">
@@ -319,7 +397,6 @@ export function SettingsPage({ roomJoined, onNavigateToLobby }: SettingsPageProp
         <footer className="space-y-3 pt-4">
           <p className="text-sm text-gray-400">{statusMessage ?? "Ready to save local settings."}</p>
           <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-            
             <button
               type="button"
               onClick={() => {
@@ -333,6 +410,156 @@ export function SettingsPage({ roomJoined, onNavigateToLobby }: SettingsPageProp
           </div>
         </footer>
       </div>
+
+      {isFeedbackModalOpen ? (
+        <div className="fixed inset-0 z-[1200]">
+          <div className="absolute inset-0 bg-black/85 backdrop-blur-[2px]" />
+          <div className="relative flex min-h-full items-center justify-center p-4">
+            <div className="flex max-h-[90vh] w-full max-w-[680px] flex-col overflow-hidden rounded-2xl border border-white/10 bg-[#252526] shadow-[0_25px_70px_rgba(0,0,0,0.8)]">
+              <div className="flex items-center justify-between border-b border-white/5 bg-white/[0.02] px-8 py-6">
+                <h2 className="text-xl font-black text-white">フィードバック送信</h2>
+              </div>
+              <div className="flex flex-col gap-5 overflow-y-auto p-8">
+                <div className="space-y-2">
+                  <label className="text-[10px] font-black uppercase tracking-[0.2em] text-gray-300">種別</label>
+                  <select
+                    value={feedbackDraft.category}
+                    onChange={(event) => {
+                      const nextCategory = event.currentTarget.value as FeedbackCategory;
+                      setFeedbackDraft((current) => ({ ...current, category: nextCategory }));
+                      setFeedbackValidationError(null);
+                    }}
+                    className="w-full rounded-xl border border-white/10 bg-[#1e1e1e] p-3 text-sm font-bold text-white outline-none transition-all focus:border-cyan-500"
+                  >
+                    <option value="bug">不具合報告</option>
+                    <option value="feature">改善要望</option>
+                    <option value="other">その他</option>
+                  </select>
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-[10px] font-black uppercase tracking-[0.2em] text-gray-300">件名</label>
+                  <input
+                    type="text"
+                    value={feedbackDraft.title}
+                    maxLength={FEEDBACK_TITLE_MAX_LENGTH}
+                    onChange={(event) => {
+                      const nextTitle = event.currentTarget.value;
+                      setFeedbackDraft((current) => ({ ...current, title: nextTitle }));
+                      setFeedbackValidationError(null);
+                    }}
+                    className="w-full rounded-xl border border-white/10 bg-[#1e1e1e] p-4 text-sm font-bold text-white outline-none transition-all placeholder:text-gray-600 focus:border-cyan-500"
+                  />
+                </div>
+
+                {feedbackDraft.category === "bug" ? (
+                  <>
+                    <FeedbackTextarea
+                      label="何が起きましたか？"
+                      value={feedbackDraft.summary}
+                      maxLength={FEEDBACK_SUMMARY_MAX_LENGTH}
+                      onChange={(value) => {
+                        setFeedbackDraft((current) => ({ ...current, summary: value }));
+                        setFeedbackValidationError(null);
+                      }}
+                    />
+                    <FeedbackTextarea
+                      label="その前に何をしていましたか？（任意）"
+                      value={feedbackDraft.steps}
+                      maxLength={FEEDBACK_STEPS_MAX_LENGTH}
+                      onChange={(value) => {
+                        setFeedbackDraft((current) => ({ ...current, steps: value }));
+                        setFeedbackValidationError(null);
+                      }}
+                    />
+                    <FeedbackTextarea
+                      label="補足（任意）"
+                      value={feedbackDraft.supplement}
+                      maxLength={FEEDBACK_SUPPLEMENT_MAX_LENGTH}
+                      onChange={(value) => {
+                        setFeedbackDraft((current) => ({ ...current, supplement: value }));
+                        setFeedbackValidationError(null);
+                      }}
+                    />
+                  </>
+                ) : null}
+
+                {feedbackDraft.category === "feature" ? (
+                  <>
+                    <FeedbackTextarea
+                      label="困っていること"
+                      value={feedbackDraft.problem}
+                      maxLength={FEEDBACK_PROBLEM_MAX_LENGTH}
+                      onChange={(value) => {
+                        setFeedbackDraft((current) => ({ ...current, problem: value }));
+                        setFeedbackValidationError(null);
+                      }}
+                    />
+                    <FeedbackTextarea
+                      label="こうしてほしい"
+                      value={feedbackDraft.proposal}
+                      maxLength={FEEDBACK_PROPOSAL_MAX_LENGTH}
+                      onChange={(value) => {
+                        setFeedbackDraft((current) => ({ ...current, proposal: value }));
+                        setFeedbackValidationError(null);
+                      }}
+                    />
+                  </>
+                ) : null}
+
+                {feedbackDraft.category === "other" ? (
+                  <FeedbackTextarea
+                    label="内容"
+                    value={feedbackDraft.content}
+                    maxLength={FEEDBACK_CONTENT_MAX_LENGTH}
+                    onChange={(value) => {
+                      setFeedbackDraft((current) => ({ ...current, content: value }));
+                      setFeedbackValidationError(null);
+                    }}
+                  />
+                ) : null}
+
+                <div className="rounded-xl border border-amber-500/20 bg-amber-500/5 p-4 text-xs leading-relaxed text-amber-100">
+                  <p>送信内容は不具合管理や改善検討に利用されます。</p>
+                  <p>不具合報告・改善要望は公開 Issue として登録される場合があります。</p>
+                  <p>個人情報、join code、表示名、ローカルファイルパスは入力しないでください。</p>
+                </div>
+              </div>
+
+              <div className="shrink-0 border-t border-white/5 bg-[#252526] px-8 py-5">
+                {feedbackValidationError ? <p className="text-sm font-semibold text-red-400">{feedbackValidationError}</p> : null}
+
+                <div className={`flex gap-3 ${feedbackValidationError ? "pt-3" : ""}`}>
+                  <button
+                    type="button"
+                    disabled={isFeedbackSubmitting}
+                    onClick={() => {
+                      setIsFeedbackModalOpen(false);
+                    }}
+                    className="flex-1 rounded-xl bg-white/5 py-4 font-bold text-white transition-all hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    キャンセル
+                  </button>
+                  <button
+                    type="button"
+                    disabled={isFeedbackSubmitting}
+                    onClick={() => {
+                      void handleSubmitFeedback();
+                    }}
+                    className={`flex-1 rounded-xl py-4 font-black transition-all ${
+                      isFeedbackSubmitting
+                        ? "cursor-not-allowed bg-gray-700 text-gray-400"
+                        : "bg-cyan-500 text-black shadow-[0_10px_20px_rgba(6,182,212,0.2)] hover:bg-cyan-400"
+                    }`}
+                  >
+                    {isFeedbackSubmitting ? "送信中..." : "送信"}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </main>
   );
 }
@@ -368,4 +595,155 @@ function validateDisplayName(value: string): string | null {
   }
 
   return null;
+}
+
+function createInitialFeedbackDraft(): FeedbackDraft {
+  return {
+    category: "bug",
+    title: "",
+    summary: "",
+    steps: "",
+    supplement: "",
+    problem: "",
+    proposal: "",
+    content: "",
+  };
+}
+
+function validateFeedbackDraft(draft: FeedbackDraft): string | null {
+  const title = draft.title.trim();
+  if (title.length === 0) {
+    return "件名は必須です。";
+  }
+  if (Array.from(title).length > FEEDBACK_TITLE_MAX_LENGTH) {
+    return "件名は100文字以内で入力してください。";
+  }
+
+  if (draft.category === "bug") {
+    if (draft.summary.trim().length === 0) {
+      return "何が起きましたか？は必須です。";
+    }
+    if (Array.from(draft.summary.trim()).length > FEEDBACK_SUMMARY_MAX_LENGTH) {
+      return "何が起きましたか？は2000文字以内で入力してください。";
+    }
+    if (Array.from(draft.steps.trim()).length > FEEDBACK_STEPS_MAX_LENGTH) {
+      return "その前に何をしていましたか？は2000文字以内で入力してください。";
+    }
+    if (Array.from(draft.supplement.trim()).length > FEEDBACK_SUPPLEMENT_MAX_LENGTH) {
+      return "補足は2000文字以内で入力してください。";
+    }
+    return null;
+  }
+
+  if (draft.category === "feature") {
+    if (draft.problem.trim().length === 0) {
+      return "困っていることは必須です。";
+    }
+    if (draft.proposal.trim().length === 0) {
+      return "こうしてほしいは必須です。";
+    }
+    if (Array.from(draft.problem.trim()).length > FEEDBACK_PROBLEM_MAX_LENGTH) {
+      return "困っていることは2000文字以内で入力してください。";
+    }
+    if (Array.from(draft.proposal.trim()).length > FEEDBACK_PROPOSAL_MAX_LENGTH) {
+      return "こうしてほしいは2000文字以内で入力してください。";
+    }
+    return null;
+  }
+
+  if (draft.content.trim().length === 0) {
+    return "内容は必須です。";
+  }
+  if (Array.from(draft.content.trim()).length > FEEDBACK_CONTENT_MAX_LENGTH) {
+    return "内容は3000文字以内で入力してください。";
+  }
+
+  return null;
+}
+
+function buildFeedbackRequest(draft: FeedbackDraft): FeedbackRequest {
+  const client = {
+    appVersion: APP_VERSION,
+    platform: detectClientPlatform(),
+    screen: FEEDBACK_SCREEN,
+    sentAt: new Date().toISOString(),
+  };
+
+  if (draft.category === "bug") {
+    const steps = draft.steps.trim();
+    const supplement = draft.supplement.trim();
+    return {
+      category: "bug",
+      title: draft.title.trim(),
+      body: {
+        summary: draft.summary.trim(),
+        ...(steps.length > 0 ? { steps } : {}),
+        ...(supplement.length > 0 ? { supplement } : {}),
+      },
+      client,
+    };
+  }
+
+  if (draft.category === "feature") {
+    return {
+      category: "feature",
+      title: draft.title.trim(),
+      body: {
+        problem: draft.problem.trim(),
+        proposal: draft.proposal.trim(),
+      },
+      client,
+    };
+  }
+
+  return {
+    category: "other",
+    title: draft.title.trim(),
+    body: {
+      content: draft.content.trim(),
+    },
+    client,
+  };
+}
+
+function detectClientPlatform(): string {
+  const userAgent = navigator.userAgent.toLowerCase();
+  if (userAgent.includes("windows")) {
+    return "windows";
+  }
+  if (userAgent.includes("mac")) {
+    return "macos";
+  }
+  if (userAgent.includes("linux")) {
+    return "linux";
+  }
+
+  return "unknown";
+}
+
+function FeedbackTextarea({
+  label,
+  value,
+  maxLength,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  maxLength: number;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <label className="text-[10px] font-black uppercase tracking-[0.2em] text-gray-300">{label}</label>
+      <textarea
+        value={value}
+        maxLength={maxLength}
+        rows={4}
+        onChange={(event) => {
+          onChange(event.currentTarget.value);
+        }}
+        className="w-full rounded-xl border border-white/10 bg-[#1e1e1e] p-4 text-sm text-white outline-none transition-all placeholder:text-gray-600 focus:border-cyan-500"
+      />
+    </div>
+  );
 }

--- a/apps/client/src/services/worker-api-client.ts
+++ b/apps/client/src/services/worker-api-client.ts
@@ -14,6 +14,48 @@ export interface ChartSearchResponse {
   next_cursor: string | null;
 }
 
+export type FeedbackCategory = "bug" | "feature" | "other";
+
+export interface FeedbackClientMeta {
+  appVersion: string;
+  platform: string;
+  screen: string;
+  sentAt: string;
+}
+
+export interface FeedbackBugBody {
+  summary: string;
+  steps?: string;
+  supplement?: string;
+}
+
+export interface FeedbackFeatureBody {
+  problem: string;
+  proposal: string;
+}
+
+export interface FeedbackOtherBody {
+  content: string;
+}
+
+export type FeedbackBody = FeedbackBugBody | FeedbackFeatureBody | FeedbackOtherBody;
+
+export interface FeedbackRequest {
+  category: FeedbackCategory;
+  title: string;
+  body: FeedbackBody;
+  client: FeedbackClientMeta;
+}
+
+export interface FeedbackResponse {
+  ok: true;
+  result: {
+    category: FeedbackCategory;
+    destination: "github" | "kv";
+    key?: string;
+  };
+}
+
 interface ApiErrorBody {
   error?: {
     code?: string;
@@ -114,4 +156,12 @@ export async function listCharts(baseUrl: string, query: ChartSearchQuery): Prom
 
   const url = `${normalizedBaseUrl}/api/charts?${searchParams}`;
   return requestJson<ChartSearchResponse>(url, { method: "GET" });
+}
+
+export async function sendFeedback(baseUrl: string, payload: FeedbackRequest): Promise<FeedbackResponse> {
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+  return requestJson<FeedbackResponse>(`${normalizedBaseUrl}/api/feedback`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
 }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,4 +1,5 @@
 import { handleGetCharts } from "./routes/charts";
+import { handlePostFeedback } from "./routes/feedback";
 import { handleGetLobby } from "./routes/lobby";
 import { handlePostRooms, handleRoomWebSocket, matchRoomWebSocketPath } from "./routes/rooms";
 import { LobbyDirectoryDO } from "./durable/lobby-directory-object";
@@ -9,6 +10,7 @@ import { methodNotAllowed, noContent, notFound, withCors } from "./utils/http";
 const CHARTS_ALLOWED_METHODS = ["GET"];
 const ROOMS_ALLOWED_METHODS = ["POST"];
 const LOBBY_ALLOWED_METHODS = ["GET"];
+const FEEDBACK_ALLOWED_METHODS = ["POST"];
 
 export { RoomDurableObject, LobbyDirectoryDO };
 
@@ -52,6 +54,17 @@ export default {
       }
 
       return withCors(methodNotAllowed([...CHARTS_ALLOWED_METHODS, "OPTIONS"]), request, CHARTS_ALLOWED_METHODS);
+    }
+
+    if (url.pathname === "/api/feedback") {
+      if (request.method === "OPTIONS") {
+        return withCors(noContent(), request, FEEDBACK_ALLOWED_METHODS);
+      }
+      if (request.method === "POST") {
+        return withCors(await handlePostFeedback(request, env), request, FEEDBACK_ALLOWED_METHODS);
+      }
+
+      return withCors(methodNotAllowed([...FEEDBACK_ALLOWED_METHODS, "OPTIONS"]), request, FEEDBACK_ALLOWED_METHODS);
     }
 
     return notFound();

--- a/apps/worker/src/routes/feedback.ts
+++ b/apps/worker/src/routes/feedback.ts
@@ -1,0 +1,631 @@
+import type { WorkerEnv } from "../types/env";
+import { parseJsonBody } from "../utils/http";
+import { isRecord } from "../utils/validation";
+
+const FEEDBACK_CATEGORIES = ["bug", "feature", "other"] as const;
+const MAX_TITLE_LENGTH = 100;
+const MAX_SUMMARY_LENGTH = 2000;
+const MAX_STEPS_LENGTH = 2000;
+const MAX_SUPPLEMENT_LENGTH = 2000;
+const MAX_PROBLEM_LENGTH = 2000;
+const MAX_PROPOSAL_LENGTH = 2000;
+const MAX_CONTENT_LENGTH = 3000;
+const MAX_FEEDBACKS_PER_MINUTE = 3;
+const RATE_LIMIT_WINDOW_SECONDS = 70;
+const DEDUPE_WINDOW_SECONDS = 60;
+const DISCORD_CONTENT_LIMIT = 1900;
+const FIELD_BLOCK_PATTERNS: RegExp[] = [
+  /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i,
+  /\bjoin\s*code\b/i,
+  /合言葉/i,
+  /\bdisplay\s*name\b/i,
+  /表示名/i,
+  /[A-Za-z]:\\[^\s]+/,
+  /\/(?:Users|home|var|tmp)\/[^\s]+/,
+];
+
+type FeedbackCategory = (typeof FEEDBACK_CATEGORIES)[number];
+
+interface FeedbackClientMeta {
+  appVersion: string;
+  platform: string;
+  screen: string;
+  sentAt: string;
+}
+
+interface FeedbackBugBody {
+  summary: string;
+  steps: string;
+  supplement: string;
+}
+
+interface FeedbackFeatureBody {
+  problem: string;
+  proposal: string;
+}
+
+interface FeedbackOtherBody {
+  content: string;
+}
+
+type FeedbackBody = FeedbackBugBody | FeedbackFeatureBody | FeedbackOtherBody;
+
+interface FeedbackPayloadBase {
+  title: string;
+  client: FeedbackClientMeta;
+}
+
+interface FeedbackBugPayload extends FeedbackPayloadBase {
+  category: "bug";
+  body: FeedbackBugBody;
+}
+
+interface FeedbackFeaturePayload extends FeedbackPayloadBase {
+  category: "feature";
+  body: FeedbackFeatureBody;
+}
+
+interface FeedbackOtherPayload extends FeedbackPayloadBase {
+  category: "other";
+  body: FeedbackOtherBody;
+}
+
+type FeedbackPayload = FeedbackBugPayload | FeedbackFeaturePayload | FeedbackOtherPayload;
+
+interface FeedbackSuccessResponse {
+  ok: true;
+  result: {
+    category: FeedbackCategory;
+    destination: "github" | "kv";
+    key?: string;
+    dry_run?: boolean;
+  };
+}
+
+interface FeedbackDestinationResult {
+  destination: "github" | "kv";
+  key?: string;
+  issueNumber?: number;
+  issueUrl?: string;
+}
+
+interface FeedbackErrorResponse {
+  ok: false;
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+class FeedbackApiError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "FeedbackApiError";
+  }
+}
+
+function feedbackErrorResponse(error: FeedbackApiError): Response {
+  const payload: FeedbackErrorResponse = {
+    ok: false,
+    error: {
+      code: error.code,
+      message: error.message,
+    },
+  };
+
+  return new Response(JSON.stringify(payload), {
+    status: error.status,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+    },
+  });
+}
+
+function feedbackSuccessResponse(payload: FeedbackSuccessResponse["result"]): Response {
+  const body: FeedbackSuccessResponse = {
+    ok: true,
+    result: payload,
+  };
+
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+    },
+  });
+}
+
+function toFeedbackApiError(error: unknown): FeedbackApiError {
+  if (error instanceof FeedbackApiError) {
+    return error;
+  }
+
+  const message = error instanceof Error ? error.message : "Unknown error.";
+  return new FeedbackApiError(500, "INTERNAL_ERROR", message);
+}
+
+function ensureRecord(value: unknown, fieldName: string): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new FeedbackApiError(400, "VALIDATION_ERROR", `${fieldName} must be an object`);
+  }
+
+  return value;
+}
+
+function sanitizeText(raw: string): string {
+  let sanitized = "";
+  for (const char of raw) {
+    const code = char.charCodeAt(0);
+    const isBlockedControl =
+      (code >= 0x00 && code <= 0x08) ||
+      code === 0x0b ||
+      code === 0x0c ||
+      (code >= 0x0e && code <= 0x1f) ||
+      code === 0x7f;
+    sanitized += isBlockedControl ? " " : char;
+  }
+
+  return sanitized.trim();
+}
+
+function countTextLength(value: string): number {
+  return Array.from(value).length;
+}
+
+function readTextField(
+  source: Record<string, unknown>,
+  key: string,
+  options: { required: boolean; maxLength: number },
+): string {
+  const raw = source[key];
+  if (typeof raw !== "string") {
+    if (options.required) {
+      throw new FeedbackApiError(400, "VALIDATION_ERROR", `${key} is required`);
+    }
+    return "";
+  }
+
+  const value = sanitizeText(raw);
+  if (options.required && value.length === 0) {
+    throw new FeedbackApiError(400, "VALIDATION_ERROR", `${key} is required`);
+  }
+
+  if (countTextLength(value) > options.maxLength) {
+    throw new FeedbackApiError(400, "VALIDATION_ERROR", `${key} is too long`);
+  }
+
+  return value;
+}
+
+function readCategory(input: Record<string, unknown>): FeedbackCategory {
+  const value = input.category;
+  if (typeof value !== "string") {
+    throw new FeedbackApiError(400, "VALIDATION_ERROR", "category is required");
+  }
+
+  if (!FEEDBACK_CATEGORIES.includes(value as FeedbackCategory)) {
+    throw new FeedbackApiError(400, "VALIDATION_ERROR", "category is invalid");
+  }
+
+  return value as FeedbackCategory;
+}
+
+function parseClientMeta(input: Record<string, unknown>): FeedbackClientMeta {
+  const clientRecord = ensureRecord(input.client, "client");
+  const appVersion = readTextField(clientRecord, "appVersion", { required: true, maxLength: 64 });
+  const platform = readTextField(clientRecord, "platform", { required: true, maxLength: 64 });
+  const screen = readTextField(clientRecord, "screen", { required: true, maxLength: 64 });
+  const sentAt = readTextField(clientRecord, "sentAt", { required: true, maxLength: 64 });
+
+  if (Number.isNaN(Date.parse(sentAt))) {
+    throw new FeedbackApiError(400, "VALIDATION_ERROR", "sentAt must be an ISO8601 timestamp");
+  }
+
+  return {
+    appVersion,
+    platform,
+    screen,
+    sentAt,
+  };
+}
+
+function parseBody(category: "bug", rawBody: Record<string, unknown>): FeedbackBugBody;
+function parseBody(category: "feature", rawBody: Record<string, unknown>): FeedbackFeatureBody;
+function parseBody(category: "other", rawBody: Record<string, unknown>): FeedbackOtherBody;
+function parseBody(category: FeedbackCategory, rawBody: Record<string, unknown>): FeedbackBody {
+  if (category === "bug") {
+    return {
+      summary: readTextField(rawBody, "summary", { required: true, maxLength: MAX_SUMMARY_LENGTH }),
+      steps: readTextField(rawBody, "steps", { required: false, maxLength: MAX_STEPS_LENGTH }),
+      supplement: readTextField(rawBody, "supplement", { required: false, maxLength: MAX_SUPPLEMENT_LENGTH }),
+    };
+  }
+
+  if (category === "feature") {
+    return {
+      problem: readTextField(rawBody, "problem", { required: true, maxLength: MAX_PROBLEM_LENGTH }),
+      proposal: readTextField(rawBody, "proposal", { required: true, maxLength: MAX_PROPOSAL_LENGTH }),
+    };
+  }
+
+  return {
+    content: readTextField(rawBody, "content", { required: true, maxLength: MAX_CONTENT_LENGTH }),
+  };
+}
+
+function collectTextFields(payload: FeedbackPayload): string[] {
+  const textFields: string[] = [
+    payload.title,
+    payload.client.appVersion,
+    payload.client.platform,
+    payload.client.screen,
+  ];
+
+  if (payload.category === "bug") {
+    textFields.push(payload.body.summary, payload.body.steps, payload.body.supplement);
+  } else if (payload.category === "feature") {
+    textFields.push(payload.body.problem, payload.body.proposal);
+  } else {
+    textFields.push(payload.body.content);
+  }
+
+  return textFields;
+}
+
+function enforceSensitiveTextGuard(payload: FeedbackPayload): void {
+  const joined = collectTextFields(payload).join("\n");
+  for (const pattern of FIELD_BLOCK_PATTERNS) {
+    if (pattern.test(joined)) {
+      throw new FeedbackApiError(
+        400,
+        "VALIDATION_ERROR",
+        "入力内容に公開不適切な情報が含まれている可能性があります",
+      );
+    }
+  }
+}
+
+async function parseFeedbackRequest(request: Request): Promise<FeedbackPayload> {
+  let body: unknown;
+  try {
+    body = await parseJsonBody(request);
+  } catch (error) {
+    throw new FeedbackApiError(400, "VALIDATION_ERROR", error instanceof Error ? error.message : "Invalid request body");
+  }
+
+  const input = ensureRecord(body, "request");
+  const category = readCategory(input);
+  const title = readTextField(input, "title", { required: true, maxLength: MAX_TITLE_LENGTH });
+  const rawBody = ensureRecord(input.body, "body");
+  const client = parseClientMeta(input);
+  let payload: FeedbackPayload;
+  if (category === "bug") {
+    payload = {
+      category,
+      title,
+      body: parseBody("bug", rawBody),
+      client,
+    };
+  } else if (category === "feature") {
+    payload = {
+      category,
+      title,
+      body: parseBody("feature", rawBody),
+      client,
+    };
+  } else {
+    payload = {
+      category,
+      title,
+      body: parseBody("other", rawBody),
+      client,
+    };
+  }
+
+  enforceSensitiveTextGuard(payload);
+  return payload;
+}
+
+function parseCounter(value: string | null): number {
+  if (value === null) {
+    return 0;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return 0;
+  }
+
+  return parsed;
+}
+
+function hexFromBytes(input: Uint8Array): string {
+  return Array.from(input)
+    .map((value) => value.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function randomHex(length: number): string {
+  const bytes = new Uint8Array(Math.ceil(length / 2));
+  crypto.getRandomValues(bytes);
+  return hexFromBytes(bytes).slice(0, length);
+}
+
+async function hashFeedbackPayload(payload: FeedbackPayload): Promise<string> {
+  const text = JSON.stringify({
+    category: payload.category,
+    title: payload.title,
+    body: payload.body,
+  });
+  const hashBuffer = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+  return hexFromBytes(new Uint8Array(hashBuffer)).slice(0, 16);
+}
+
+function trimConfig(value: string | undefined): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function isProductionEnv(env: WorkerEnv): boolean {
+  return trimConfig(env.APP_ENV).toLowerCase() === "production";
+}
+
+async function enforceRateLimit(request: Request, env: WorkerEnv, payloadHash: string): Promise<void> {
+  const ipAddress = request.headers.get("cf-connecting-ip")?.trim() || "unknown";
+  const minuteBucket = Math.floor(Date.now() / 60_000);
+  const rateKey = `feedback_rate:${ipAddress}:${minuteBucket}`;
+  const dedupeKey = `feedback_dedupe:${ipAddress}:${payloadHash}`;
+
+  const currentCount = parseCounter(await env.FEEDBACK_KV.get(rateKey, "text"));
+  if (currentCount >= MAX_FEEDBACKS_PER_MINUTE) {
+    throw new FeedbackApiError(429, "RATE_LIMITED", "送信間隔を空けてください");
+  }
+
+  const duplicated = await env.FEEDBACK_KV.get(dedupeKey, "text");
+  if (duplicated !== null) {
+    throw new FeedbackApiError(429, "RATE_LIMITED", "同じ内容の連続送信はできません");
+  }
+
+  await env.FEEDBACK_KV.put(rateKey, String(currentCount + 1), { expirationTtl: RATE_LIMIT_WINDOW_SECONDS });
+  await env.FEEDBACK_KV.put(dedupeKey, "1", { expirationTtl: DEDUPE_WINDOW_SECONDS });
+}
+
+function buildGitHubIssueTitle(payload: FeedbackPayload): string {
+  if (payload.category === "bug") {
+    return `[Bug] ${payload.title}`;
+  }
+  return `[Feature] ${payload.title}`;
+}
+
+function buildBugIssueBody(payload: FeedbackPayload, appEnv: string): string {
+  if (payload.category !== "bug") {
+    throw new Error("bug payload required");
+  }
+
+  const steps = payload.body.steps.length > 0 ? payload.body.steps : "Not provided";
+  const supplement = payload.body.supplement.length > 0 ? payload.body.supplement : "Not provided";
+  return [
+    "## Category",
+    "Bug",
+    "",
+    "## What Happened",
+    payload.body.summary,
+    "",
+    "## What Were You Doing Before It Happened",
+    steps,
+    "",
+    "## Additional Notes",
+    supplement,
+    "",
+    "## Environment",
+    `- app_version: ${payload.client.appVersion}`,
+    `- platform: ${payload.client.platform}`,
+    `- screen: ${payload.client.screen}`,
+    `- sent_at: ${payload.client.sentAt}`,
+    `- app_env: ${appEnv}`,
+  ].join("\n");
+}
+
+function buildFeatureIssueBody(payload: FeedbackPayload, appEnv: string): string {
+  if (payload.category !== "feature") {
+    throw new Error("feature payload required");
+  }
+
+  return [
+    "## Category",
+    "Feature Request",
+    "",
+    "## Problem",
+    payload.body.problem,
+    "",
+    "## Proposal",
+    payload.body.proposal,
+    "",
+    "## Environment",
+    `- app_version: ${payload.client.appVersion}`,
+    `- platform: ${payload.client.platform}`,
+    `- screen: ${payload.client.screen}`,
+    `- sent_at: ${payload.client.sentAt}`,
+    `- app_env: ${appEnv}`,
+  ].join("\n");
+}
+
+async function createGitHubIssue(payload: FeedbackPayload, env: WorkerEnv): Promise<FeedbackDestinationResult> {
+  const owner = trimConfig(env.REPO_OWNER_GITHUB);
+  const repo = trimConfig(env.REPO_NAME_GITHUB);
+  const token = trimConfig(env.ISSUE_TOKEN);
+  if (owner.length === 0 || repo.length === 0 || token.length === 0) {
+    throw new FeedbackApiError(500, "CONFIG_ERROR", "GitHub issue destination is not configured");
+  }
+  if (payload.category !== "bug" && payload.category !== "feature") {
+    throw new FeedbackApiError(500, "INTERNAL_ERROR", "Invalid issue category");
+  }
+
+  const issueBody = payload.category === "bug"
+    ? buildBugIssueBody(payload, trimConfig(env.APP_ENV))
+    : buildFeatureIssueBody(payload, trimConfig(env.APP_ENV));
+  const labels = payload.category === "bug" ? ["from-app", "bug"] : ["from-app", "enhancement"];
+  const response = await fetch(`https://api.github.com/repos/${owner}/${repo}/issues`, {
+    method: "POST",
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json; charset=utf-8",
+      "user-agent": "infinitas-feedback-worker",
+    },
+    body: JSON.stringify({
+      title: buildGitHubIssueTitle(payload),
+      body: issueBody,
+      labels,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new FeedbackApiError(502, "DESTINATION_ERROR", "GitHub Issue の作成に失敗しました");
+  }
+
+  const responseBody = (await response.json()) as {
+    number?: number;
+    html_url?: string;
+  };
+  if (typeof responseBody.number !== "number" || typeof responseBody.html_url !== "string") {
+    throw new FeedbackApiError(502, "DESTINATION_ERROR", "GitHub Issue のレスポンスが不正です");
+  }
+
+  return {
+    destination: "github",
+    issueNumber: responseBody.number,
+    issueUrl: responseBody.html_url,
+  };
+}
+
+async function saveToKv(payload: FeedbackPayload, env: WorkerEnv): Promise<FeedbackDestinationResult> {
+  if (payload.category !== "other") {
+    throw new FeedbackApiError(500, "INTERNAL_ERROR", "Invalid KV category");
+  }
+
+  const timestamp = Math.floor(Date.now() / 1000);
+  const key = `feedback:${timestamp}:${randomHex(6)}`;
+  const value = {
+    id: key,
+    category: payload.category,
+    title: payload.title,
+    body: payload.body,
+    client: payload.client,
+    appEnv: trimConfig(env.APP_ENV),
+    status: "new",
+  };
+
+  try {
+    await env.FEEDBACK_KV.put(key, JSON.stringify(value));
+  } catch {
+    throw new FeedbackApiError(502, "DESTINATION_ERROR", "フィードバック保存に失敗しました");
+  }
+
+  return {
+    destination: "kv",
+    key,
+  };
+}
+
+async function saveFeedback(payload: FeedbackPayload, env: WorkerEnv): Promise<FeedbackDestinationResult> {
+  if (payload.category === "bug" || payload.category === "feature") {
+    return createGitHubIssue(payload, env);
+  }
+
+  return saveToKv(payload, env);
+}
+
+function clipText(input: string, maxLength: number): string {
+  return Array.from(input).slice(0, maxLength).join("");
+}
+
+function buildDiscordContent(payload: FeedbackPayload, env: WorkerEnv, destination: FeedbackDestinationResult): string {
+  const appEnv = trimConfig(env.APP_ENV) || "unknown";
+  const header = `[${payload.category.toUpperCase()}][${appEnv}] ${payload.title}`;
+  const details = [
+    `appVersion: ${payload.client.appVersion}`,
+    `platform: ${payload.client.platform}`,
+    `screen: ${payload.client.screen}`,
+    `sentAt: ${payload.client.sentAt}`,
+  ];
+
+  if (payload.category === "bug") {
+    details.push(`issue: ${destination.issueNumber ? `#${destination.issueNumber}` : destination.issueUrl ?? "-"}`);
+    details.push(`summary: ${clipText(payload.body.summary, 200)}`);
+  } else if (payload.category === "feature") {
+    details.push(`issue: ${destination.issueNumber ? `#${destination.issueNumber}` : destination.issueUrl ?? "-"}`);
+    details.push(`problem: ${clipText(payload.body.problem, 200)}`);
+  } else {
+    details.push(`kv: ${destination.key ?? "-"}`);
+    details.push(`content: ${clipText(payload.body.content, 200)}`);
+  }
+
+  return clipText([header, ...details].join("\n"), DISCORD_CONTENT_LIMIT);
+}
+
+async function notifyDiscord(payload: FeedbackPayload, env: WorkerEnv, destination: FeedbackDestinationResult): Promise<void> {
+  const webhookUrl = trimConfig(env.DISCORD_WEBHOOK_URL);
+  if (webhookUrl.length === 0) {
+    return;
+  }
+
+  const content = buildDiscordContent(payload, env, destination);
+  try {
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify({ content }),
+    });
+    if (!response.ok) {
+      console.warn(`feedback discord notify failed: status=${response.status}`);
+    }
+  } catch (error) {
+    console.warn(`feedback discord notify failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+export async function handlePostFeedback(request: Request, env: WorkerEnv): Promise<Response> {
+  try {
+    const payload = await parseFeedbackRequest(request);
+    const payloadHash = await hashFeedbackPayload(payload);
+    await enforceRateLimit(request, env, payloadHash);
+
+    if (!isProductionEnv(env)) {
+      const intendedDestination: "github" | "kv" = payload.category === "other" ? "kv" : "github";
+      console.info(
+        JSON.stringify({
+          event: "feedback_dry_run",
+          app_env: trimConfig(env.APP_ENV) || "unknown",
+          category: payload.category,
+          destination: intendedDestination,
+          title: payload.title,
+          client: payload.client,
+          received_at: new Date().toISOString(),
+        }),
+      );
+
+      return feedbackSuccessResponse({
+        category: payload.category,
+        destination: intendedDestination,
+        dry_run: true,
+      });
+    }
+
+    const destination = await saveFeedback(payload, env);
+    await notifyDiscord(payload, env, destination);
+
+    return feedbackSuccessResponse({
+      category: payload.category,
+      destination: destination.destination,
+      ...(destination.key ? { key: destination.key } : {}),
+    });
+  } catch (error) {
+    return feedbackErrorResponse(toFeedbackApiError(error));
+  }
+}

--- a/apps/worker/src/routes/feedback.ts
+++ b/apps/worker/src/routes/feedback.ts
@@ -580,7 +580,10 @@ async function notifyDiscord(payload: FeedbackPayload, env: WorkerEnv, destinati
       headers: {
         "content-type": "application/json; charset=utf-8",
       },
-      body: JSON.stringify({ content }),
+      body: JSON.stringify({
+        content,
+        allowed_mentions: { parse: [] },
+      }),
     });
     if (!response.ok) {
       console.warn(`feedback discord notify failed: status=${response.status}`);

--- a/apps/worker/src/types/env.ts
+++ b/apps/worker/src/types/env.ts
@@ -2,6 +2,15 @@ export interface DurableObjectIdLike {
   toString(): string;
 }
 
+export interface KVNamespacePutOptions {
+  expirationTtl?: number;
+}
+
+export interface WorkerKVNamespace {
+  get(key: string, type: "text"): Promise<string | null>;
+  put(key: string, value: string, options?: KVNamespacePutOptions): Promise<void>;
+}
+
 export interface DurableObjectStubLike {
   fetch(request: Request): Promise<Response>;
 }
@@ -19,4 +28,10 @@ export interface LobbyDirectoryDurableObjectNamespace {
 export interface WorkerEnv {
   ROOM_DO: RoomDurableObjectNamespace;
   LOBBY_DIRECTORY_DO: LobbyDirectoryDurableObjectNamespace;
+  FEEDBACK_KV: WorkerKVNamespace;
+  REPO_OWNER_GITHUB: string;
+  REPO_NAME_GITHUB: string;
+  APP_ENV: string;
+  ISSUE_TOKEN: string;
+  DISCORD_WEBHOOK_URL: string;
 }

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -2,6 +2,16 @@ name = "infinitas-arena"
 main = "src/index.ts"
 compatibility_date = "2025-01-01"
 
+[vars]
+REPO_OWNER_GITHUB = "tts1374"
+REPO_NAME_GITHUB = "infinitas_arena"
+APP_ENV = "production"
+
+[[kv_namespaces]]
+binding = "FEEDBACK_KV"
+id = "a03343c6198440b096eeb37bfacd1260"
+preview_id = "9367beac3a0a474aad9af13b46395feb"
+
 [[durable_objects.bindings]]
 name = "ROOM_DO"
 class_name = "RoomDurableObject"

--- a/tasks/codex-feedback-v1.md
+++ b/tasks/codex-feedback-v1.md
@@ -1,0 +1,59 @@
+# Feedback Send Feature v1 (Plan Mode)
+
+## 目的
+- 設定画面上部右側の補助カードからフィードバック送信フォームを開けるようにする。
+- `POST /api/feedback` を実装し、`bug/feature` は GitHub Issue、`other` は KV に保存する。
+- 全件で Discord webhook 通知を行い、deploy workflow で Worker secret 注入を追加する。
+
+## 非目的
+- エラー時専用導線の追加
+- 添付機能（ログ/画像）・返信機能・管理画面
+- D1 保存・高度な重複判定・FAQ/既知不具合候補表示
+- 目的外 UI 改善や広範なリファクタ
+
+## 変更点
+- client: Settings 上部右側に補助アクションカードと送信フォームを追加
+- client: 種別別入力、最小バリデーション、送信中多重送信防止、成功/失敗メッセージ
+- client: Worker への `POST /api/feedback` 呼び出し追加（client 情報自動付与）
+- worker: `/api/feedback` ルート実装（検証/サニタイズ/文字数上限/簡易レート制限）
+- worker: `bug/feature` は GitHub Issue 作成、`other` は KV 保存
+- worker: 保存成功後 Discord 通知（失敗は非致命、ログに記録）
+- infra: worker env/binding 反映、deploy workflow に secret put 手順追加
+
+## 影響範囲
+- ユーザー: 設定画面にフィードバック送信導線とフォームを追加
+- データ: `other` は `FEEDBACK_KV` に `feedback:{timestamp}:{random}` で保存
+- 互換性: 既存 API/WS 契約には影響しない（新規 HTTP エンドポイント追加）
+- Cloudflare: Worker vars/secrets/binding と GitHub Actions deploy フローに影響
+
+## 対象ファイル / レイヤ
+- client: `apps/client/src/pages/SettingsPage.tsx`（必要に応じて related service/type）
+- worker: `apps/worker/src/index.ts`, `apps/worker/src/routes/*`, `apps/worker/src/types/*`, `apps/worker/src/utils/*`
+- worker config: `apps/worker/wrangler.toml`
+- CI: `.github/workflows/deploy-worker.yml`
+
+## テスト観点
+- UI: 種別切替で必須入力が変わる、送信中ボタン無効化、成功/失敗表示
+- API: 必須・上限チェック、種別分岐、失敗時レスポンス形式
+- 保存: `other` の KV key/value 形式、`bug/feature` の Issue title/label/body
+- 通知: 保存成功後のみ実行、通知失敗が API 成功を阻害しない
+- rate limit: 1分3回制限、同一 payload 短時間連投抑止
+- deploy: secret put 実行後に deploy
+
+## ロールバック方針
+- フロント導線を戻すことで UI 影響を即時撤回可能
+- Worker ルートを無効化/巻き戻しで送信機能を停止可能
+- deploy workflow の secret put 手順のみ個別差し戻し可能
+
+## コミット分割計画
+1. client UI + 送信クライアント実装
+2. worker `/api/feedback` 実装（検証・保存分岐・通知・レート制限）
+3. worker config + deploy workflow secret 注入 + 必要テスト
+
+## 実行チェックリスト
+- [ ] 設計確認（既存 worker route 規約・settings 画面構造）
+- [ ] 影響範囲特定（client / worker / CI）
+- [ ] 実装
+- [ ] テスト
+- [ ] 回帰確認
+- [ ] ドキュメント更新（必要最小限）


### PR DESCRIPTION
## 目的
設定画面からフィードバック送信を可能にし、保存先分岐と通知を実装する。

## 変更点
- 設定画面右上に補助カードと送信モーダルを追加
- bug/feature/other の入力と送信処理を追加
- bug入力を自然文ベースへ簡略化
- Worker に POST /api/feedback を追加
- bug/feature は GitHub Issue、other は KV 保存
- bug Issue テンプレを UI と整合する形式へ変更
- 保存成功後 Discord 通知（通知失敗は非致命）
- 非production環境は dry-run（外部送信せずログ出力）
- deploy workflow に wrangler secret put を追加

## 検証
- npm run typecheck
- npm run lint