### PR TITLE
Add server-authoritative match_id for stats and harden deploy-worker trigger

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -2,12 +2,6 @@ name: Deploy infinitas-arena Worker
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - v1
-    paths:
-      - "apps/worker/**"
-      - ".github/workflows/deploy-worker.yml"
 
 permissions:
   contents: read

--- a/apps/client/src/dev/visual-scenarios.ts
+++ b/apps/client/src/dev/visual-scenarios.ts
@@ -365,6 +365,7 @@ function createResultReady(args: {
 }): ResultReadyPayload {
   return {
     summary: {
+      match_id: `${args.mode.toLowerCase()}-visual-match`,
       mode: args.mode,
       win_metric: "SCORE",
       total_rounds: args.totalRounds,

--- a/apps/client/src/features/stats/models.ts
+++ b/apps/client/src/features/stats/models.ts
@@ -58,6 +58,7 @@ export interface SessionRound {
 
 export interface RoomStatsSession {
   room_id: string;
+  match_id: string;
   settings: RoomSettings;
   players: RoomPlayerSnapshot[];
   rounds: SessionRound[];

--- a/apps/client/src/features/stats/stats.test.ts
+++ b/apps/client/src/features/stats/stats.test.ts
@@ -91,6 +91,7 @@ function makeRound(
 
 function makeSession(input: {
   roomId: string;
+  matchId?: string;
   battleType: StatsBattleType;
   playMode: PlayStyle;
   playerIds: string[];
@@ -100,6 +101,7 @@ function makeSession(input: {
 }): RoomStatsSession {
   return {
     room_id: input.roomId,
+    match_id: input.matchId ?? input.roomId,
     settings: {
       visibility: input.battleType === "PRIVATE" ? "PRIVATE" : "PUBLIC",
       join_code: null,
@@ -173,6 +175,7 @@ function makeResultReady(input: {
 
   return {
     summary: {
+      match_id: input.session.match_id,
       mode: input.session.settings.mode,
       win_metric: input.session.settings.win_metric,
       total_rounds: input.totalRounds ?? input.session.rounds.length,
@@ -599,6 +602,137 @@ runCase("DO-provided unrated decision blocks local rating updates", () => {
   assert.equal(archive.matches[0]?.invalid_reason, "mismatch_observed_key");
   assert.equal(archive.matches[0]?.rating_after, null);
   assert.equal(getCurrentRating(archive, "BPL", "SP"), null);
+});
+
+runCase("server-authoritative match_id separates rematches and fallback keeps room_id", () => {
+  let archive = createEmptyStatsArchive();
+  const roomId = "same-room";
+  const transitionSession = makeSession({
+    roomId: "transition-room",
+    battleType: "BPL",
+    playMode: "SP",
+    playerIds: [MY_PLAYER_ID, "opponent"],
+    mode: "BPL",
+    rounds: [
+      makeRound(0, "SP", [
+        makeResult({ playerId: MY_PLAYER_ID, metricValue: 2200, submittedAt: iso(2), bp: 10 }),
+        makeResult({ playerId: "opponent", metricValue: 2000, submittedAt: iso(3), bp: 14 }),
+      ]),
+      makeRound(1, "SP", [
+        makeResult({ playerId: MY_PLAYER_ID, metricValue: 2100, submittedAt: iso(4), bp: 11 }),
+        makeResult({ playerId: "opponent", metricValue: 2050, submittedAt: iso(5), bp: 12 }),
+      ]),
+    ],
+  });
+  const withProvisionalIds = reduceArchiveWithSession(archive, {
+    session: transitionSession,
+    myPlayerId: MY_PLAYER_ID,
+    processedAt: iso(6),
+  });
+  const withAuthoritativeIds = reduceArchiveWithSession(withProvisionalIds, {
+    session: {
+      ...transitionSession,
+      match_id: "transition-match-1",
+    },
+    myPlayerId: MY_PLAYER_ID,
+    processedAt: iso(7),
+  });
+  assert.equal(withAuthoritativeIds.match_games.some((entry) => entry.match_id === "transition-room"), false);
+  assert.equal(withAuthoritativeIds.play_results.some((entry) => entry.source_match_id === "transition-room"), false);
+  assert.equal(withAuthoritativeIds.match_games.filter((entry) => entry.match_id === "transition-match-1").length, 2);
+  assert.equal(
+    withAuthoritativeIds.play_results.filter((entry) => entry.source_match_id === "transition-match-1").length,
+    2,
+  );
+  archive = withAuthoritativeIds;
+
+  const firstSession = makeSession({
+    roomId,
+    matchId: "match-alpha",
+    battleType: "ARENA",
+    playMode: "SP",
+    playerIds: [MY_PLAYER_ID, "opponent"],
+    mode: "ARENA",
+    rounds: [
+      makeRound(0, "SP", [
+        makeResult({ playerId: MY_PLAYER_ID, metricValue: 2100, submittedAt: iso(6), bp: 11 }),
+        makeResult({ playerId: "opponent", metricValue: 2000, submittedAt: iso(7), bp: 15 }),
+      ]),
+      makeRound(1, "SP", [
+        makeResult({ playerId: MY_PLAYER_ID, metricValue: 2050, submittedAt: iso(8), bp: 12 }),
+        makeResult({ playerId: "opponent", metricValue: 1900, submittedAt: iso(9), bp: 16 }),
+      ]),
+    ],
+  });
+  archive = recordClosedMatch(
+    archive,
+    firstSession,
+    makeResultReady({
+      session: firstSession,
+      isRated: true,
+      ratedBlockReason: null,
+      winnerPlayerIds: [MY_PLAYER_ID],
+    }),
+  );
+
+  const secondSession = makeSession({
+    roomId,
+    matchId: "match-beta",
+    battleType: "ARENA",
+    playMode: "SP",
+    playerIds: [MY_PLAYER_ID, "opponent"],
+    mode: "ARENA",
+    rounds: [
+      makeRound(0, "SP", [
+        makeResult({ playerId: MY_PLAYER_ID, metricValue: 1800, submittedAt: iso(16), bp: 20 }),
+        makeResult({ playerId: "opponent", metricValue: 1900, submittedAt: iso(17), bp: 18 }),
+      ]),
+    ],
+  });
+  archive = recordClosedMatch(
+    archive,
+    secondSession,
+    makeResultReady({
+      session: secondSession,
+      isRated: true,
+      ratedBlockReason: null,
+      winnerPlayerIds: ["opponent"],
+    }),
+  );
+
+  assert.equal(archive.matches.some((entry) => entry.match_id === "match-alpha"), true);
+  assert.equal(archive.matches.some((entry) => entry.match_id === "match-beta"), true);
+  assert.equal(archive.match_games.filter((entry) => entry.match_id === "match-alpha").length, 2);
+  assert.equal(archive.match_games.filter((entry) => entry.match_id === "match-beta").length, 1);
+  assert.equal(archive.play_results.filter((entry) => entry.source_match_id === "match-alpha").length, 2);
+  assert.equal(archive.play_results.filter((entry) => entry.source_match_id === "match-beta").length, 1);
+
+  const fallbackSession = makeSession({
+    roomId: "legacy-room",
+    battleType: "BPL",
+    playMode: "SP",
+    playerIds: [MY_PLAYER_ID, "opponent"],
+    mode: "BPL",
+    rounds: [
+      makeRound(0, "SP", [
+        makeResult({ playerId: MY_PLAYER_ID, metricValue: 2000, submittedAt: iso(30), bp: 10 }),
+        makeResult({ playerId: "opponent", metricValue: 1900, submittedAt: iso(31), bp: 13 }),
+      ]),
+      makeRound(1, "SP", [
+        makeResult({ playerId: MY_PLAYER_ID, metricValue: 2050, submittedAt: iso(32), bp: 9 }),
+        makeResult({ playerId: "opponent", metricValue: 1800, submittedAt: iso(33), bp: 16 }),
+      ]),
+      makeRound(2, "SP", [
+        makeResult({ playerId: MY_PLAYER_ID, metricValue: 2100, submittedAt: iso(34), bp: 8 }),
+        makeResult({ playerId: "opponent", metricValue: 1700, submittedAt: iso(35), bp: 19 }),
+      ]),
+    ],
+  });
+  archive = recordClosedMatch(archive, fallbackSession, null);
+
+  assert.equal(archive.matches.some((entry) => entry.match_id === "legacy-room"), true);
+  assert.equal(archive.match_games.some((entry) => entry.match_id === "legacy-room"), true);
+  assert.equal(archive.play_results.some((entry) => entry.source_match_id === "legacy-room"), true);
 });
 
 runCase("chart rankings require three matches and stay separated by chart id, rule, and mode", () => {

--- a/apps/client/src/features/stats/stats.ts
+++ b/apps/client/src/features/stats/stats.ts
@@ -373,14 +373,37 @@ function resolveMatchRatingDecision(input: {
   };
 }
 
+function resolveSessionMatchId(input: {
+  previousSession: RoomStatsSession | null;
+  snapshot: RoomStateSnapshot;
+  resultReady: ResultReadyPayload | null;
+}): string {
+  const summaryRecord = input.resultReady === null ? null : asRecord(input.resultReady.summary);
+  const resultReadyMatchId = asString(summaryRecord?.match_id);
+  if (resultReadyMatchId !== null) {
+    return resultReadyMatchId;
+  }
+
+  if (input.previousSession !== null && input.previousSession.room_id === input.snapshot.room_id) {
+    return input.previousSession.match_id;
+  }
+
+  return input.snapshot.room_id;
+}
+
 export function captureRoomStatsSession(
   previousSession: RoomStatsSession | null,
   snapshot: RoomStateSnapshot,
   resultReady: ResultReadyPayload | null,
 ): RoomStatsSession {
+  const sessionMatchId = resolveSessionMatchId({
+    previousSession,
+    snapshot,
+    resultReady,
+  });
   const frozenRoundByIndex = new Map(snapshot.frozen_rounds.map((round) => [round.round_index, round]));
   const roundsByIndex = new Map(
-    previousSession?.room_id === snapshot.room_id
+    previousSession?.room_id === snapshot.room_id && previousSession.match_id === sessionMatchId
       ? previousSession.rounds.map((round) => [round.round_index, round])
       : [],
   );
@@ -422,6 +445,7 @@ export function captureRoomStatsSession(
 
   return {
     room_id: snapshot.room_id,
+    match_id: sessionMatchId,
     settings: snapshot.settings,
     players: snapshot.players,
     rounds: Array.from(roundsByIndex.values()).sort((left, right) => left.round_index - right.round_index),
@@ -568,7 +592,7 @@ function derivePlayResult(
   }
 
   return {
-    play_result_id: `${session.room_id}:${round.round_index}:${myPlayerId}`,
+    play_result_id: `${session.match_id}:${round.round_index}:${myPlayerId}`,
     played_at: myResult.submitted_at,
     battle_type: getBattleType(session.settings),
     play_mode: session.settings.play_style,
@@ -578,7 +602,7 @@ function derivePlayResult(
     chart_level: round.display.level,
     my_ex_score: metrics.exScore,
     my_bp: metrics.bp,
-    source_match_id: session.room_id,
+    source_match_id: session.match_id,
   };
 }
 
@@ -634,8 +658,8 @@ function deriveMatchGame(
   }
 
   return {
-    match_game_id: `${session.room_id}:${round.round_index}`,
-    match_id: session.room_id,
+    match_game_id: `${session.match_id}:${round.round_index}`,
+    match_id: session.match_id,
     played_at: round.round_started_at ?? confirmedAt,
     game_index: round.round_index,
     chart_id: buildChartId(round.expected_key),
@@ -848,7 +872,7 @@ function deriveArenaMatchRecord(
   });
 
   return {
-    match_id: session.room_id,
+    match_id: session.match_id,
     started_at: startedAt,
     ended_at:
       snapshot.closed_at ??
@@ -909,7 +933,7 @@ function deriveBplMatchRecord(
   });
 
   return {
-    match_id: session.room_id,
+    match_id: session.match_id,
     started_at: startedAt,
     ended_at: snapshot.closed_at ?? sortByTimeAscending(matchGames).at(-1)?.result_confirmed_at ?? startedAt,
     battle_type: getBattleType(session.settings),
@@ -945,14 +969,38 @@ export function reduceArchiveWithSession(
     return archive;
   }
 
-  const nextPlayResults = input.session.rounds
-    .map((round) => derivePlayResult(input.session as RoomStatsSession, round, input.myPlayerId))
+  const session = input.session;
+  const nextPlayResults = session.rounds
+    .map((round) => derivePlayResult(session, round, input.myPlayerId))
     .filter((entry): entry is PlayResult => entry !== null);
-  const nextMatchGames = input.session.rounds
-    .map((round) => deriveMatchGame(input.session as RoomStatsSession, round, input.myPlayerId))
+  const nextMatchGames = session.rounds
+    .map((round) => deriveMatchGame(session, round, input.myPlayerId))
     .filter((entry): entry is MatchGame => entry !== null);
-  const playResults = upsertPlayResults(archive.play_results, nextPlayResults);
-  const matchGames = upsertMatchGames(archive.match_games, nextMatchGames);
+  const hasAuthoritativeMatchId = session.match_id !== session.room_id;
+  const provisionalPlayResultIdPrefix = `${session.room_id}:`;
+  const provisionalPlayResultIdSuffix = `:${input.myPlayerId}`;
+  const provisionalMatchGameIdPrefix = `${session.room_id}:`;
+  const basePlayResults = hasAuthoritativeMatchId
+    ? archive.play_results.filter(
+        (entry) =>
+          !(
+            entry.source_match_id === session.room_id &&
+            entry.play_result_id.startsWith(provisionalPlayResultIdPrefix) &&
+            entry.play_result_id.endsWith(provisionalPlayResultIdSuffix)
+          ),
+      )
+    : archive.play_results;
+  const baseMatchGames = hasAuthoritativeMatchId
+    ? archive.match_games.filter(
+        (entry) =>
+          !(
+            entry.match_id === session.room_id &&
+            entry.match_game_id.startsWith(provisionalMatchGameIdPrefix)
+          ),
+      )
+    : archive.match_games;
+  const playResults = upsertPlayResults(basePlayResults, nextPlayResults);
+  const matchGames = upsertMatchGames(baseMatchGames, nextMatchGames);
 
   if (playResults === archive.play_results && matchGames === archive.match_games) {
     return archive;
@@ -983,7 +1031,7 @@ export function reduceArchiveWithClosedMatch(
   const session = input.session;
 
   const matchGames = archive.match_games
-    .filter((entry) => entry.match_id === session.room_id)
+    .filter((entry) => entry.match_id === session.match_id)
     .sort((left, right) => left.game_index - right.game_index);
   const nextMatch =
     session.settings.mode === "ARENA"

--- a/apps/worker/src/durable/room-state.test.mjs
+++ b/apps/worker/src/durable/room-state.test.mjs
@@ -175,6 +175,8 @@ function submitCurrentRoundResult(state, playerId, roundIndex, metricValue, nowA
 function getResultSummary(state) {
   const payload = state.getResultReadyPayload();
   assert.ok(payload, "result ready payload should exist");
+  assert.equal(typeof payload.summary.match_id, "string");
+  assert.ok(payload.summary.match_id.length > 0);
   return payload.summary;
 }
 
@@ -580,4 +582,47 @@ test("MATCH_TTL expires in RESULT and closes room", () => {
   assert.ok(transition);
   assert.equal(state.getRoomState(), "CLOSED");
   assert.equal(state.toSnapshot().close_reason, "MATCH_TTL_EXPIRED");
+});
+
+test("RESULT_READY summary uses server-authoritative match_id and rematch rotates it", () => {
+  const state = createState();
+  prepareMatch(state);
+
+  playCurrentRound(state, 0, 2200, 2100, "2026-03-08T00:02");
+  playCurrentRound(state, 1, 2300, 2000, "2026-03-08T00:03");
+
+  const firstSummary = getResultSummary(state);
+  assert.notEqual(firstSummary.match_id, "room-1");
+
+  assert.deepEqual(state.returnToLobby("host", new Date("2026-03-08T00:04:00.000Z")), { ok: true });
+  assert.equal(state.setPlayerReady("host", true).ok, true);
+  assert.equal(state.setPlayerReady("guest", true).ok, true);
+  assert.deepEqual(state.startMatch("host", new Date("2026-03-08T00:05:00.000Z")), { ok: true });
+  assert.equal(state.submitPick("host", "chart-1", new Date("2026-03-08T00:05:10.000Z")).ok, true);
+  assert.equal(state.submitPick("guest", "chart-2", new Date("2026-03-08T00:05:11.000Z")).ok, true);
+
+  playCurrentRound(state, 0, 2400, 2300, "2026-03-08T00:06");
+  playCurrentRound(state, 1, 2500, 2400, "2026-03-08T00:07");
+
+  const secondSummary = getResultSummary(state);
+  assert.notEqual(secondSummary.match_id, firstSummary.match_id);
+});
+
+test("hydrate legacy RESULT_READY payload without match_id falls back to room_id", () => {
+  const state = createState();
+  prepareMatch(state);
+
+  playCurrentRound(state, 0, 2200, 2100, "2026-03-08T00:02");
+  playCurrentRound(state, 1, 2300, 2000, "2026-03-08T00:03");
+
+  const record = state.toPersistenceRecord();
+  const legacyRecord = JSON.parse(JSON.stringify(record));
+  delete legacyRecord.current_match_id;
+  delete legacyRecord.result_ready_payload.summary.match_id;
+
+  const restored = new RoomLobbyState(createChartMaster());
+  restored.hydrate(legacyRecord);
+
+  const restoredSummary = getResultSummary(restored);
+  assert.equal(restoredSummary.match_id, "room-1");
 });

--- a/apps/worker/src/durable/room-state.ts
+++ b/apps/worker/src/durable/room-state.ts
@@ -235,6 +235,7 @@ export interface RoomStatePersistenceRecord {
   frozen_rounds: FrozenRound[];
   current_round: CurrentRoundSnapshot | null;
   match_player_ids: string[];
+  current_match_id?: string | null;
   match_song_unlock_filter?: MatchSongUnlockFilter | null;
   result_ready_payload: ResultReadyPayload | null;
   result_key_mismatch_detected?: boolean;
@@ -284,6 +285,37 @@ function parseRequiredDate(value: string): Date {
   }
 
   return parsed;
+}
+
+function generateMatchId(): string {
+  return crypto.randomUUID();
+}
+
+function extractResultReadySummaryMatchId(payload: ResultReadyPayload | null): string | null {
+  if (payload === null) {
+    return null;
+  }
+
+  const summaryRecord = payload.summary as unknown as Record<string, unknown>;
+  const matchId = summaryRecord.match_id;
+  return typeof matchId === "string" && matchId.length > 0 ? matchId : null;
+}
+
+function ensureResultReadyPayloadMatchId(
+  payload: ResultReadyPayload | null,
+  fallbackMatchId: string,
+): ResultReadyPayload | null {
+  if (payload === null) {
+    return null;
+  }
+
+  return {
+    ...payload,
+    summary: {
+      ...payload.summary,
+      match_id: extractResultReadySummaryMatchId(payload) ?? fallbackMatchId,
+    },
+  };
 }
 
 function computeMatchDeadline(createdAt: Date): Date {
@@ -492,6 +524,7 @@ export class RoomLobbyState {
   private frozenRounds: FrozenRound[] = [];
   private currentRound: CurrentRoundSnapshot | null = null;
   private matchPlayerIds: string[] = [];
+  private currentMatchId: string | null = null;
   private matchSongUnlockFilter: MatchSongUnlockFilter | null = null;
   private resultReadyPayload: ResultReadyPayload | null = null;
   private resultKeyMismatchDetected = false;
@@ -713,6 +746,7 @@ export class RoomLobbyState {
     this.closedAt = null;
     this.closeReason = null;
     this.matchPlayerIds = this.getPlayersInJoinOrder().map((player) => player.player_id);
+    this.currentMatchId = generateMatchId();
     const matchPlayers = this.matchPlayerIds
       .map((matchPlayerId) => this.players.get(matchPlayerId))
       .filter((player): player is InternalPlayer => player !== undefined);
@@ -1343,9 +1377,13 @@ export class RoomLobbyState {
               confirmed: this.currentRound.confirmed.map((entry) => ({ ...entry })),
             },
       match_player_ids: [...this.matchPlayerIds],
+      current_match_id: this.currentMatchId,
       match_song_unlock_filter:
         this.matchSongUnlockFilter === null ? null : cloneMatchSongUnlockFilter(this.matchSongUnlockFilter),
-      result_ready_payload: this.resultReadyPayload,
+      result_ready_payload: ensureResultReadyPayloadMatchId(
+        this.resultReadyPayload,
+        this.currentMatchId ?? this.roomId,
+      ),
       result_key_mismatch_detected: this.resultKeyMismatchDetected,
       force_advanced_round_indices: Array.from(this.forceAdvancedRoundIndices).sort((left, right) => left - right),
     };
@@ -1418,11 +1456,22 @@ export class RoomLobbyState {
             confirmed: record.current_round.confirmed.map((entry) => ({ ...entry })),
           };
     this.matchPlayerIds = [...record.match_player_ids];
+    const persistedCurrentMatchId =
+      typeof record.current_match_id === "string" && record.current_match_id.length > 0
+        ? record.current_match_id
+        : null;
+    this.currentMatchId = persistedCurrentMatchId ?? extractResultReadySummaryMatchId(record.result_ready_payload);
     this.matchSongUnlockFilter =
       record.match_song_unlock_filter === undefined || record.match_song_unlock_filter === null
         ? null
         : cloneMatchSongUnlockFilter(record.match_song_unlock_filter);
-    this.resultReadyPayload = record.result_ready_payload;
+    this.resultReadyPayload = ensureResultReadyPayloadMatchId(
+      record.result_ready_payload,
+      this.currentMatchId ?? this.roomId,
+    );
+    if (this.currentMatchId === null) {
+      this.currentMatchId = extractResultReadySummaryMatchId(this.resultReadyPayload);
+    }
     this.resultKeyMismatchDetected = record.result_key_mismatch_detected === true;
     this.forceAdvancedRoundIndices.clear();
     for (const roundIndex of record.force_advanced_round_indices ?? []) {
@@ -1631,6 +1680,7 @@ export class RoomLobbyState {
     this.frozenRounds = [];
     this.currentRound = null;
     this.matchPlayerIds = [];
+    this.currentMatchId = null;
     this.matchSongUnlockFilter = null;
     this.resultReadyPayload = null;
     this.resultKeyMismatchDetected = false;
@@ -1948,6 +1998,7 @@ export class RoomLobbyState {
   }
 
   private buildResultReadyPayload(): ResultReadyPayload {
+    const matchId = this.currentMatchId ?? this.roomId;
     const perPlayerRounds = new Map<string, Array<Record<string, unknown>>>();
     for (const playerId of this.matchPlayerIds) {
       perPlayerRounds.set(playerId, []);
@@ -2085,6 +2136,7 @@ export class RoomLobbyState {
 
       return {
         summary: {
+          match_id: matchId,
           mode: this.settings.mode,
           win_metric: this.settings.win_metric,
           total_rounds: this.frozenRounds.length,
@@ -2166,6 +2218,7 @@ export class RoomLobbyState {
 
     return {
       summary: {
+        match_id: matchId,
         mode: this.settings.mode,
         win_metric: this.settings.win_metric,
         total_rounds: this.frozenRounds.length,

--- a/docs/design/02_ws_protocol.md
+++ b/docs/design/02_ws_protocol.md
@@ -114,10 +114,11 @@
 
 ### 4.5 RESULT
 - `RESULT_READY`
-  - payload: `{ summary: { mode, win_metric, total_rounds, completed_rounds, winner_player_ids, is_draw, is_rated, rated_block_reason, rating_before, rating_after, rating_delta }, per_round: object, per_player: object }`
+  - payload: `{ summary: { match_id, mode, win_metric, total_rounds, completed_rounds, winner_player_ids, is_draw, is_rated, rated_block_reason, rating_before, rating_after, rating_delta }, per_round: object, per_player: object }`
   - 備考: `per_round.rounds[].results[]` には `status / metric_value / reason / submitted_at / submitted_by / source_meta?` を含めてもよい
   - 備考: `rated_block_reason` は最低限 `missing_submission | mismatch_observed_key | incomplete_match | skip_occurred | timeout_occurred | force_advanced | result_conflict` を扱う
   - 備考: v1 では `RESULT_READY.summary.is_rated` がレート適用可否の権威情報
+  - 備考: v1 では `RESULT_READY.summary.match_id` を統計識別子の正本とし、欠落時のみ `room_id` fallback を許容
   - 備考: 通常フローでは `PLAYING -> RESULT` 遷移時に配信し、`RESULT -> LOBBY` 復帰まで保持して表示する
 
 ### 4.6 同期/エラー

--- a/docs/design/03_data_model.md
+++ b/docs/design/03_data_model.md
@@ -303,6 +303,7 @@ type LobbyRoomSummary = {
     - `chart_id`
     - `my_ex_score`
     - `my_bp`
+    - `source_match_id`
   - `personal_bests`
     - `chart_id`
     - `play_mode`
@@ -311,6 +312,7 @@ type LobbyRoomSummary = {
     - `best_played_at`
     - `source_play_result_id`
 - 集計ルール:
+  - 統計識別子の基準は `RESULT_READY.summary.match_id`（server-authoritative）とし、欠落時のみ `room_id` fallback を使用する
   - レート系列は `ARENA_SP` / `ARENA_DP` / `BPL_SP` / `BPL_DP` を分離する
   - レート更新は `matches` を基準にマッチ単位で行う
   - ARENA は `match_games` を集約して最終順位を決め、pairwise 擬似対戦で `matches.rating_delta` を算出する

--- a/packages/shared/src/ws/server.ts
+++ b/packages/shared/src/ws/server.ts
@@ -92,6 +92,7 @@ export type RatedBlockReason =
   | "result_conflict";
 
 export interface ResultReadySummary {
+  match_id: string;
   mode: "ARENA" | "BPL";
   win_metric: "SCORE" | "MISSCOUNT";
   total_rounds: number;


### PR DESCRIPTION
## 目的
- `RESULT -> LOBBY -> START_MATCH` の再戦時に、同一 `room_id` による統計上書きを防止する
- 予期せぬ本番反映を防ぐため、`deploy-worker` workflow の自動実行トリガーを無効化する

## 変更点
- shared: `RESULT_READY.summary.match_id` を追加（加算互換）
- worker:
  - `START_MATCH` ごとに server-authoritative な `match_id` を生成
  - `RESULT_READY.summary.match_id` に常時設定
  - 永続レコードに `current_match_id`（optional）を追加
  - hydrate 時に legacy payload (`summary.match_id` 欠落) を `room_id` fallback で補完
- client(stats):
  - 統計識別子を `match_id` 優先へ変更（fallback は `room_id` 維持）
  - `match_id` 確定前に `room_id` で作られた暫定エントリを確定時に置換して混線防止
- docs:
  - `docs/design/02_ws_protocol.md` に `RESULT_READY.summary.match_id` を反映
  - `docs/design/03_data_model.md` に統計識別子基準と `source_match_id` を明記
- CI:
  - `.github/workflows/deploy-worker.yml` から `push` トリガーを削除し、`workflow_dispatch` のみへ

## 非変更点
- Room FSM の遷移仕様そのもの（`RESULT -> LOBBY` の意味）は変更なし
- `room_id` の生成規則や公開API契約は変更なし
- 監視ソースI/O仕様（inf-notebook / daken）は変更なし

## 影響範囲
- ユーザー: 新クライアントでは再戦が別マッチとして保存される
- 互換性: `match_id` 欠落時は `room_id` fallback を維持
- Cloudflare: DO永続化に optional フィールド追加（後方互換）
- 運用: Worker本番デプロイは手動実行のみ

## テスト
- `npm run typecheck`
- `npm run lint`
- `npm run test:worker`
- `npm run test:client-stats`
- `npm run build:client`
- `npx wrangler deploy --dry-run` (apps/worker)

## 回帰確認観点
- 同一 `room_id` の2連戦で `matches` が2件になること
- `match_games` / `play_results` が `match_id` 単位で分離されること
- `match_id` 欠落の legacy データ hydrate で `room_id` fallback が効くこと