### PR TITLE
Fix stats persistence around rematch/leave and prevent empty match rows

### DIFF
--- a/apps/client/src/features/stats/stats.test.ts
+++ b/apps/client/src/features/stats/stats.test.ts
@@ -24,6 +24,7 @@ import {
   type StatsBattleType,
 } from "./models";
 import {
+  captureRoomStatsSession,
   getChartRankings,
   getCurrentRating,
   getDetailedMatchHistory,
@@ -733,6 +734,135 @@ runCase("server-authoritative match_id separates rematches and fallback keeps ro
   assert.equal(archive.matches.some((entry) => entry.match_id === "legacy-room"), true);
   assert.equal(archive.match_games.some((entry) => entry.match_id === "legacy-room"), true);
   assert.equal(archive.play_results.some((entry) => entry.source_match_id === "legacy-room"), true);
+});
+
+runCase("match_id fallback resets to room_id after returning to LOBBY", () => {
+  const roomId = "same-room";
+  const previousSession = makeSession({
+    roomId,
+    matchId: "match-alpha",
+    battleType: "ARENA",
+    playMode: "SP",
+    playerIds: [MY_PLAYER_ID, "opponent"],
+    mode: "ARENA",
+    rounds: [
+      makeRound(0, "SP", [
+        makeResult({ playerId: MY_PLAYER_ID, metricValue: 2200, submittedAt: iso(40), bp: 9 }),
+        makeResult({ playerId: "opponent", metricValue: 2100, submittedAt: iso(41), bp: 12 }),
+      ]),
+    ],
+  });
+  const staleResultReady = makeResultReady({
+    session: previousSession,
+    isRated: true,
+    ratedBlockReason: null,
+    winnerPlayerIds: [MY_PLAYER_ID],
+  });
+  const lobbySnapshot: RoomStateSnapshot = {
+    room_id: roomId,
+    room_state: "LOBBY",
+    settings: previousSession.settings,
+    host_player_id: previousSession.players[0]?.player_id ?? MY_PLAYER_ID,
+    players: previousSession.players,
+    picks: [],
+    frozen_rounds: [],
+    current_round: null,
+    timers: {
+      ready_check_deadline: null,
+      picking_deadline: null,
+      match_deadline: null,
+      result_deadline: null,
+    },
+    result_ready: false,
+    created_at: iso(42),
+    closed_at: null,
+    close_reason: null,
+  };
+
+  const nextSession = captureRoomStatsSession(previousSession, lobbySnapshot, staleResultReady);
+
+  assert.equal(nextSession.match_id, roomId);
+  assert.equal(nextSession.rounds.length, 0);
+});
+
+runCase("closed match without confirmed games does not create an empty match record", () => {
+  const session = makeSession({
+    roomId: "incomplete-close",
+    battleType: "BPL",
+    playMode: "SP",
+    playerIds: [MY_PLAYER_ID, "opponent"],
+    mode: "BPL",
+    rounds: [makeRound(0, "SP", [])],
+  });
+  const archive = recordClosedMatch(createEmptyStatsArchive(), session, null);
+
+  assert.equal(archive.match_games.length, 0);
+  assert.equal(archive.matches.some((entry) => entry.match_id === session.match_id), false);
+});
+
+runCase("authoritative match_id promotion keeps rounds and rewrites provisional ids", () => {
+  const roomId = "promotion-room";
+  const provisionalSession = makeSession({
+    roomId,
+    battleType: "BPL",
+    playMode: "SP",
+    playerIds: [MY_PLAYER_ID, "opponent"],
+    mode: "BPL",
+    rounds: [
+      makeRound(0, "SP", [
+        makeResult({ playerId: MY_PLAYER_ID, metricValue: 2050, submittedAt: iso(43), bp: 11 }),
+        makeResult({ playerId: "opponent", metricValue: 1950, submittedAt: iso(44), bp: 14 }),
+      ]),
+      makeRound(1, "SP", [
+        makeResult({ playerId: MY_PLAYER_ID, metricValue: 2100, submittedAt: iso(45), bp: 10 }),
+        makeResult({ playerId: "opponent", metricValue: 2000, submittedAt: iso(46), bp: 13 }),
+      ]),
+    ],
+  });
+  const withProvisionalIds = reduceArchiveWithSession(createEmptyStatsArchive(), {
+    session: provisionalSession,
+    myPlayerId: MY_PLAYER_ID,
+    processedAt: iso(47),
+  });
+  assert.equal(withProvisionalIds.match_games.filter((entry) => entry.match_id === roomId).length, 2);
+
+  const baseResultReady = makeResultReady({
+    session: provisionalSession,
+    isRated: true,
+    ratedBlockReason: null,
+    winnerPlayerIds: [MY_PLAYER_ID],
+  });
+  const authoritativeMatchId = "promotion-match-1";
+  const authoritativeResultReady: ResultReadyPayload = {
+    ...baseResultReady,
+    summary: {
+      ...baseResultReady.summary,
+      match_id: authoritativeMatchId,
+    },
+  };
+  const promotedSession = captureRoomStatsSession(
+    provisionalSession,
+    makeSnapshot(provisionalSession),
+    authoritativeResultReady,
+  );
+  assert.equal(promotedSession.match_id, authoritativeMatchId);
+  assert.equal(promotedSession.rounds.length, provisionalSession.rounds.length);
+
+  const withAuthoritativeIds = reduceArchiveWithSession(withProvisionalIds, {
+    session: promotedSession,
+    myPlayerId: MY_PLAYER_ID,
+    processedAt: iso(48),
+  });
+  assert.equal(withAuthoritativeIds.match_games.some((entry) => entry.match_id === roomId), false);
+  assert.equal(withAuthoritativeIds.play_results.some((entry) => entry.source_match_id === roomId), false);
+  assert.equal(
+    withAuthoritativeIds.match_games.filter((entry) => entry.match_id === authoritativeMatchId).length,
+    2,
+  );
+  assert.equal(
+    withAuthoritativeIds.play_results.filter((entry) => entry.source_match_id === authoritativeMatchId).length,
+    2,
+  );
 });
 
 runCase("chart rankings require three matches and stay separated by chart id, rule, and mode", () => {

--- a/apps/client/src/features/stats/stats.ts
+++ b/apps/client/src/features/stats/stats.ts
@@ -378,6 +378,10 @@ function resolveSessionMatchId(input: {
   snapshot: RoomStateSnapshot;
   resultReady: ResultReadyPayload | null;
 }): string {
+  if (input.snapshot.room_state === "LOBBY") {
+    return input.snapshot.room_id;
+  }
+
   const summaryRecord = input.resultReady === null ? null : asRecord(input.resultReady.summary);
   const resultReadyMatchId = asString(summaryRecord?.match_id);
   if (resultReadyMatchId !== null) {
@@ -401,11 +405,14 @@ export function captureRoomStatsSession(
     snapshot,
     resultReady,
   });
+  const canReusePreviousRounds =
+    snapshot.room_state !== "LOBBY" &&
+    previousSession?.room_id === snapshot.room_id &&
+    (previousSession.match_id === sessionMatchId ||
+      (previousSession.match_id === snapshot.room_id && sessionMatchId !== snapshot.room_id));
   const frozenRoundByIndex = new Map(snapshot.frozen_rounds.map((round) => [round.round_index, round]));
   const roundsByIndex = new Map(
-    previousSession?.room_id === snapshot.room_id && previousSession.match_id === sessionMatchId
-      ? previousSession.rounds.map((round) => [round.round_index, round])
-      : [],
+    canReusePreviousRounds ? previousSession.rounds.map((round) => [round.round_index, round]) : [],
   );
 
   if (snapshot.current_round !== null) {
@@ -980,7 +987,9 @@ export function reduceArchiveWithSession(
   const provisionalPlayResultIdPrefix = `${session.room_id}:`;
   const provisionalPlayResultIdSuffix = `:${input.myPlayerId}`;
   const provisionalMatchGameIdPrefix = `${session.room_id}:`;
-  const basePlayResults = hasAuthoritativeMatchId
+  const shouldReplaceProvisionalPlayResults = hasAuthoritativeMatchId && nextPlayResults.length > 0;
+  const shouldReplaceProvisionalMatchGames = hasAuthoritativeMatchId && nextMatchGames.length > 0;
+  const basePlayResults = shouldReplaceProvisionalPlayResults
     ? archive.play_results.filter(
         (entry) =>
           !(
@@ -990,7 +999,7 @@ export function reduceArchiveWithSession(
           ),
       )
     : archive.play_results;
-  const baseMatchGames = hasAuthoritativeMatchId
+  const baseMatchGames = shouldReplaceProvisionalMatchGames
     ? archive.match_games.filter(
         (entry) =>
           !(
@@ -1033,6 +1042,9 @@ export function reduceArchiveWithClosedMatch(
   const matchGames = archive.match_games
     .filter((entry) => entry.match_id === session.match_id)
     .sort((left, right) => left.game_index - right.game_index);
+  if (matchGames.length === 0) {
+    return archive;
+  }
   const nextMatch =
     session.settings.mode === "ARENA"
       ? deriveArenaMatchRecord(session, input.snapshot, input.resultReady, input.myPlayerId)

--- a/apps/client/src/services/stats-archive.ts
+++ b/apps/client/src/services/stats-archive.ts
@@ -58,15 +58,56 @@ function syncSession(snapshot: RoomStateSnapshot | null): void {
 function syncFromRoomStore(): void {
   const snapshot = roomStore.getState().snapshot;
   const resultReady = roomStore.getState().resultReady;
-  syncSession(snapshot);
+  const previousSession = currentSession;
 
   if (snapshot === null) {
+    currentSession = null;
     lastClosedRoomKey = null;
     return;
   }
 
   const myPlayerId = settingsStore.getState().saved.playerId;
   const processedAt = new Date().toISOString();
+  const shouldFinalizeOnLobbyRemake =
+    snapshot.room_state === "LOBBY" &&
+    resultReady === null &&
+    previousSession !== null &&
+    previousSession.room_id === snapshot.room_id &&
+    previousSession.rounds.length > 0;
+
+  if (shouldFinalizeOnLobbyRemake) {
+    const roundSignature = previousSession.rounds
+      .map((round) => `${round.round_index}:${round.round_started_at ?? ""}`)
+      .join("|");
+    const closedRoomKey = `${snapshot.room_id}:lobby:${roundSignature}`;
+
+    if (closedRoomKey !== lastClosedRoomKey) {
+      const afterSessionFlushFromLobby = reduceArchiveWithSession(internalStore.getState().archive, {
+        session: previousSession,
+        myPlayerId,
+        processedAt,
+      });
+      setArchiveIfChanged(afterSessionFlushFromLobby);
+
+      lastClosedRoomKey = closedRoomKey;
+      const afterMatchCloseFromLobby = reduceArchiveWithClosedMatch(afterSessionFlushFromLobby, {
+        session: previousSession,
+        snapshot: {
+          ...snapshot,
+          room_state: "CLOSED",
+          close_reason: "ALL_ROUNDS_COMPLETED",
+          closed_at: snapshot.closed_at ?? processedAt,
+        },
+        resultReady: null,
+        myPlayerId,
+        processedAt,
+      });
+      setArchiveIfChanged(afterMatchCloseFromLobby);
+      currentSession = null;
+    }
+  }
+
+  syncSession(snapshot);
   const afterSessionFlush = reduceArchiveWithSession(internalStore.getState().archive, {
     session: currentSession,
     myPlayerId,

--- a/apps/client/src/services/stats-archive.ts
+++ b/apps/client/src/services/stats-archive.ts
@@ -80,6 +80,18 @@ function syncFromRoomStore(): void {
       .map((round) => `${round.round_index}:${round.round_started_at ?? ""}`)
       .join("|");
     const closedRoomKey = `${snapshot.room_id}:lobby:${roundSignature}`;
+    const plannedFrozenRounds =
+      snapshot.frozen_rounds.length > 0
+        ? snapshot.frozen_rounds
+        : [...previousSession.rounds]
+            .sort((left, right) => left.round_index - right.round_index)
+            .map((round) => ({
+              round_index: round.round_index,
+              expected_key: round.expected_key,
+              display: round.display,
+              started_at: round.round_started_at,
+              soft_ttl_seconds: 300,
+            }));
 
     if (closedRoomKey !== lastClosedRoomKey) {
       const afterSessionFlushFromLobby = reduceArchiveWithSession(internalStore.getState().archive, {
@@ -97,6 +109,7 @@ function syncFromRoomStore(): void {
           room_state: "CLOSED",
           close_reason: "ALL_ROUNDS_COMPLETED",
           closed_at: snapshot.closed_at ?? processedAt,
+          frozen_rounds: plannedFrozenRounds,
         },
         resultReady: null,
         myPlayerId,


### PR DESCRIPTION
## 目的
- RESULT後の REMAKE ROOM -> HOST LEAVE ROOM で直前試合が統計に残らない問題を解消する
- データ未確定時に空の統計行（-- / -- / 0）が保存される問題を防ぐ
- authoritative match_id 昇格時に統計が消える回帰を防ぐ

## 変更点
- stats-archive.ts
  - LOBBY再遷移時に前セッションを1回だけ補完確定する分岐を追加
- stats.ts
  - LOBBY遷移時は match_id を oom_id にリセット
  - authoritative match_id 昇格時に provisional rounds を引き継げるよう修正
  - provisional IDの置換は authoritative 側の実データ生成時のみ実施
  - match_games が 0 件のときは MatchRecord を作成しないガードを追加
- stats.test.ts
  - LOBBY復帰で match_id がリセットされる回帰テスト
  - 空matchが作成されない回帰テスト
  - authoritative match_id 昇格時のデータ保持/置換回帰テスト

## 非変更点
- WS schema / DO FSM / source I/O 仕様の変更なし
- 既存の保存先スキーマ変更なし

## 影響範囲
- Client統計集計ロジック（pps/client/src/features/stats/*, pps/client/src/services/stats-archive.ts）のみ

## テスト
- 
pm run test:client-stats
- 
pm run typecheck:client
- 
pm run lint
- 
pm run build:client

## 回帰確認観点
- 通常進行のRESULTで統計が残る
- REMAKE ROOM -> HOST LEAVE ROOM 後も直前試合が残る
- 空統計行（-- / -- / 0）が新規作成されない
- authoritative match_id 昇格時に既存統計が消えない