### PR TITLE
feat: add daken_counter_v3 monitoring source (Issue #77)

### DIFF
--- a/apps/client/src/app/App.tsx
+++ b/apps/client/src/app/App.tsx
@@ -111,6 +111,19 @@ export function App() {
     void sourceStore.start(savedSettings, { force: false });
   }, [mockScenarioRequested, savedSettings]);
 
+  useEffect(() => {
+    if (mockScenarioRequested) {
+      return;
+    }
+
+    sourceStore.syncRoomSnapshot(roomSnapshot);
+  }, [
+    mockScenarioRequested,
+    roomSnapshot,
+    savedSettings.source,
+    savedSettings.dakenCounterV3Port,
+  ]);
+
   function navigate(view: AppView): void {
     startTransition(() => {
       setActiveView(view);

--- a/apps/client/src/dev/visual-scenarios.ts
+++ b/apps/client/src/dev/visual-scenarios.ts
@@ -63,6 +63,7 @@ const ARENA_PLAYER_3_ID = "mock-arena-player-3";
 const ARENA_PLAYER_4_ID = "mock-arena-player-4";
 
 const BASE_SETTINGS: Omit<ClientSettings, "playerId" | "displayName" | "source" | "apiBaseUrl"> = {
+  dakenCounterV3Port: 8767,
   sourcePaths: {
     dakenTodayUpdateXml: "",
     notebookExportRecentJson: "",

--- a/apps/client/src/pages/SettingsPage.tsx
+++ b/apps/client/src/pages/SettingsPage.tsx
@@ -1,13 +1,16 @@
 import { useEffect, useRef, useState } from "react";
 import { ChevronLeft, Database, FolderOpen, MessageSquare, Save, Package, CheckSquare, Square, Check, Settings as SettingsIcon, User, Volume2, VolumeX } from "lucide-react";
 import { pickDirectory, validateSourceDirectory } from "../services/tauri-bridge";
-import type { SongPack } from "@infinitas/shared";
+import type { SongPack, SourceType } from "@infinitas/shared";
 import { listSongPacks, sendFeedback, type FeedbackRequest } from "../services/worker-api-client";
 import { sourceStore } from "../stores/source-store";
 import {
   getActiveSourceDirectory,
   getVoicePlaybackVolume,
+  isValidPortNumber,
   isVoicePlaybackEnabled,
+  SOURCE_PORT_MAX,
+  SOURCE_PORT_MIN,
   settingsStore,
   useSettingsStore,
 } from "../stores/settings-store";
@@ -20,21 +23,32 @@ interface SettingsPageProps {
 
 const DJ_NAME_PATTERN = /^[a-zA-Z0-9.\-*&!?#$]*$/;
 const DJ_NAME_MAX_LENGTH = 6;
+const DAKEN_COUNTER_V3_CONNECTION_WARNING =
+  "打鍵カウンタv3 に接続できませんでした。ポート設定と起動状態を確認してください。";
 
 const SOURCE_OPTIONS = [
   {
     id: "inf_daken_counter" as const,
     name: "打鍵カウンタ",
     description: "today_update.xml を監視",
-    label: "Daken Counter Directory",
-    placeholder: "C:\\Games\\beatmania IIDX INFINITAS\\data",
+    usesDirectory: true,
+    directoryLabel: "Daken Counter Directory",
+    directoryPlaceholder: "C:\\Games\\beatmania IIDX INFINITAS\\data",
   },
   {
     id: "inf-notebook" as const,
     name: "リザルト手帳",
     description: "summary.json を監視",
-    label: "Result Notebook Directory",
-    placeholder: "C:\\Users\\you\\Documents\\inf-notebook",
+    usesDirectory: true,
+    directoryLabel: "Result Notebook Directory",
+    directoryPlaceholder: "C:\\Users\\you\\Documents\\inf-notebook",
+  },
+  {
+    id: "daken_counter_v3" as const,
+    name: "打鍵カウンタv3",
+    description: "ローカルWebSocket (today_updates) を監視",
+    usesDirectory: false,
+    portLabel: "Daken Counter v3 WebSocket Port",
   },
 ];
 
@@ -52,7 +66,7 @@ const FEEDBACK_SCREEN = "SettingsScreen";
 const APP_VERSION = typeof clientPackageJson.version === "string" ? clientPackageJson.version : "unknown";
 
 type FeedbackCategory = "bug" | "feature" | "other";
-type SettingsErrorField = "display_name" | "source_directory";
+type SettingsErrorField = "display_name" | "source_directory" | "source_port";
 
 interface FeedbackDraft {
   category: FeedbackCategory;
@@ -73,6 +87,7 @@ export function SettingsPage({ roomJoined, onNavigateToLobby }: SettingsPageProp
   const previewAudioRef = useRef<HTMLAudioElement | null>(null);
   const displayNameInputRef = useRef<HTMLInputElement | null>(null);
   const sourceDirectoryInputRef = useRef<HTMLInputElement | null>(null);
+  const sourcePortInputRef = useRef<HTMLInputElement | null>(null);
   const [displayNameError, setDisplayNameError] = useState<string | null>(null);
   const [validationMessage, setValidationMessage] = useState<string | null>(null);
   const [focusedErrorField, setFocusedErrorField] = useState<SettingsErrorField | null>(null);
@@ -85,8 +100,8 @@ export function SettingsPage({ roomJoined, onNavigateToLobby }: SettingsPageProp
   const [songPackDialogMessage, setSongPackDialogMessage] = useState<string | null>(null);
   const [isSongPackLoading, setIsSongPackLoading] = useState(false);
 
-  const activeDirectory = getActiveSourceDirectory(draft);
   const activeOption = getSourceOption(draft.source);
+  const activeDirectory = activeOption.usesDirectory ? getActiveSourceDirectory(draft) : "";
 
   const togglePack = (packId: number) => {
     const currentOwnedPackIds = draft.ownedPackIds;
@@ -187,6 +202,10 @@ export function SettingsPage({ roomJoined, onNavigateToLobby }: SettingsPageProp
   }
 
   async function handleBrowseDirectory(): Promise<void> {
+    if (!activeOption.usesDirectory) {
+      return;
+    }
+
     try {
       const selectedDirectory = await pickDirectory();
       if (selectedDirectory !== null) {
@@ -210,6 +229,18 @@ export function SettingsPage({ roomJoined, onNavigateToLobby }: SettingsPageProp
     }
 
     setDisplayNameError(null);
+
+    if (draft.source === "daken_counter_v3") {
+      if (!isValidPortNumber(draft.dakenCounterV3Port)) {
+        setValidationMessage(`WebSocketポートは ${SOURCE_PORT_MIN} - ${SOURCE_PORT_MAX} の整数で入力してください。`);
+        focusErrorField("source_port");
+        return;
+      }
+
+      settingsStore.save();
+      await sourceStore.start(settingsStore.getState().saved, { force: false });
+      return;
+    }
 
     if (activeDirectory.trim().length === 0) {
       setValidationMessage("先に監視元フォルダを指定してください。");
@@ -239,7 +270,15 @@ export function SettingsPage({ roomJoined, onNavigateToLobby }: SettingsPageProp
   }
 
   function focusErrorField(field: SettingsErrorField): void {
-    const target = field === "display_name" ? displayNameInputRef.current : sourceDirectoryInputRef.current;
+    let target: HTMLInputElement | null = null;
+    if (field === "display_name") {
+      target = displayNameInputRef.current;
+    } else if (field === "source_directory") {
+      target = sourceDirectoryInputRef.current;
+    } else {
+      target = sourcePortInputRef.current;
+    }
+
     if (target === null) {
       return;
     }
@@ -390,45 +429,81 @@ export function SettingsPage({ roomJoined, onNavigateToLobby }: SettingsPageProp
 
           <div className="space-y-3">
             <label className="text-[10px] font-black uppercase italic tracking-wider text-gray-500">
-              {activeOption.label}
+              {activeOption.usesDirectory ? activeOption.directoryLabel : activeOption.portLabel}
             </label>
-            <div className="flex max-w-3xl flex-col gap-3 md:flex-row">
-              <input
-                ref={sourceDirectoryInputRef}
-                type="text"
-                value={activeDirectory}
-                disabled={roomJoined}
-                onChange={(event) => {
-                  settingsStore.updateSourceDirectory(draft.source, event.currentTarget.value);
-                  if (focusedErrorField === "source_directory") {
-                    setFocusedErrorField(null);
-                  }
-                  setValidationMessage(null);
-                }}
-                aria-invalid={validationMessage !== null}
-                placeholder={activeOption.placeholder}
-                className={`flex-1 scroll-mt-20 rounded-xl border bg-[#151515] px-4 py-3 text-sm font-mono text-gray-300 outline-none placeholder:text-gray-600 disabled:cursor-not-allowed disabled:opacity-70 ${
-                  validationMessage
-                    ? focusedErrorField === "source_directory"
-                      ? "border-red-500 ring-2 ring-red-500/30"
-                      : "border-red-500"
-                    : "border-white/5 focus:border-cyan-500"
-                }`}
-              />
-              <button
-                type="button"
-                disabled={roomJoined}
-                onClick={() => {
-                  void handleBrowseDirectory();
-                }}
-                className="flex items-center justify-center gap-2 rounded-xl border border-white/10 bg-[#2d2d30] px-6 py-3 text-sm font-bold text-white transition-all active:scale-95 hover:bg-[#353538] disabled:cursor-not-allowed disabled:opacity-70"
-              >
-                <FolderOpen size={18} />
-                参照
-              </button>
-            </div>
+            {activeOption.usesDirectory ? (
+              <div className="flex max-w-3xl flex-col gap-3 md:flex-row">
+                <input
+                  ref={sourceDirectoryInputRef}
+                  type="text"
+                  value={activeDirectory}
+                  disabled={roomJoined}
+                  onChange={(event) => {
+                    settingsStore.updateSourceDirectory(draft.source, event.currentTarget.value);
+                    if (focusedErrorField === "source_directory") {
+                      setFocusedErrorField(null);
+                    }
+                    setValidationMessage(null);
+                  }}
+                  aria-invalid={validationMessage !== null}
+                  placeholder={activeOption.directoryPlaceholder}
+                  className={`flex-1 scroll-mt-20 rounded-xl border bg-[#151515] px-4 py-3 text-sm font-mono text-gray-300 outline-none placeholder:text-gray-600 disabled:cursor-not-allowed disabled:opacity-70 ${
+                    validationMessage
+                      ? focusedErrorField === "source_directory"
+                        ? "border-red-500 ring-2 ring-red-500/30"
+                        : "border-red-500"
+                      : "border-white/5 focus:border-cyan-500"
+                  }`}
+                />
+                <button
+                  type="button"
+                  disabled={roomJoined}
+                  onClick={() => {
+                    void handleBrowseDirectory();
+                  }}
+                  className="flex items-center justify-center gap-2 rounded-xl border border-white/10 bg-[#2d2d30] px-6 py-3 text-sm font-bold text-white transition-all active:scale-95 hover:bg-[#353538] disabled:cursor-not-allowed disabled:opacity-70"
+                >
+                  <FolderOpen size={18} />
+                  参照
+                </button>
+              </div>
+            ) : (
+              <div className="max-w-md">
+                <input
+                  ref={sourcePortInputRef}
+                  type="number"
+                  inputMode="numeric"
+                  min={SOURCE_PORT_MIN}
+                  max={SOURCE_PORT_MAX}
+                  step={1}
+                  value={draft.dakenCounterV3Port}
+                  disabled={roomJoined}
+                  onChange={(event) => {
+                    const parsed = Number.isFinite(event.currentTarget.valueAsNumber)
+                      ? Math.trunc(event.currentTarget.valueAsNumber)
+                      : 0;
+                    settingsStore.update("dakenCounterV3Port", parsed);
+                    if (focusedErrorField === "source_port") {
+                      setFocusedErrorField(null);
+                    }
+                    setValidationMessage(null);
+                  }}
+                  aria-invalid={validationMessage !== null}
+                  placeholder="8767"
+                  className={`w-full scroll-mt-20 rounded-xl border bg-[#151515] px-4 py-3 text-sm font-mono text-gray-300 outline-none placeholder:text-gray-600 disabled:cursor-not-allowed disabled:opacity-70 ${
+                    validationMessage
+                      ? focusedErrorField === "source_port"
+                        ? "border-red-500 ring-2 ring-red-500/30"
+                        : "border-red-500"
+                      : "border-white/5 focus:border-cyan-500"
+                  }`}
+                />
+              </div>
+            )}
             <p className="text-xs text-gray-500">
-              {draft.source === "inf_daken_counter"
+              {draft.source === "daken_counter_v3"
+                ? `LOBBY入場時に ws://localhost:${draft.dakenCounterV3Port} へ接続します。PLAYING開始時に接続確認し、失敗時は「${DAKEN_COUNTER_V3_CONNECTION_WARNING}」を表示します。`
+                : draft.source === "inf_daken_counter"
                 ? "選択したフォルダ配下の today_update.xml を自動で監視します。"
                 : "選択したフォルダ配下の records/summary.json を監視し、export/recent.json から score/misscount を補完します。"}
             </p>
@@ -802,7 +877,7 @@ export function SettingsPage({ roomJoined, onNavigateToLobby }: SettingsPageProp
   );
 }
 
-function getSourceOption(source: "inf_daken_counter" | "inf-notebook") {
+function getSourceOption(source: SourceType) {
   return SOURCE_OPTIONS.find((option) => option.id === source) ?? SOURCE_OPTIONS[0]!;
 }
 

--- a/apps/client/src/runtime/runtime-config.ts
+++ b/apps/client/src/runtime/runtime-config.ts
@@ -11,6 +11,7 @@ export interface RuntimeSettingsDefaults {
   playerId: string | undefined;
   displayName: string | undefined;
   source: SourceType | undefined;
+  dakenCounterV3Port: number | undefined;
   sourcePaths: RuntimeSourcePathDefaults;
 }
 
@@ -59,6 +60,16 @@ function readNumberParam(name: string, fallback: number): number {
   return Number.isFinite(value) ? value : fallback;
 }
 
+function readOptionalIntegerParam(name: string): number | undefined {
+  const raw = readSearchParam(name);
+  if (raw === undefined) {
+    return undefined;
+  }
+
+  const value = Number(raw);
+  return Number.isFinite(value) ? Math.trunc(value) : undefined;
+}
+
 function normalizeInstanceId(value: string | undefined): string | null {
   if (value === undefined) {
     return null;
@@ -83,6 +94,9 @@ const apiBaseUrlFromEnv = import.meta.env.VITE_WORKER_API_BASE_URL?.trim();
 const apiBaseUrl =
   apiBaseUrlFromEnv && apiBaseUrlFromEnv.length > 0 ? apiBaseUrlFromEnv : readSearchParam("api");
 const source = parseSourceType(readSearchParam("source"));
+const dakenCounterV3Port =
+  readOptionalIntegerParam("dakenCounterV3Port") ??
+  readOptionalIntegerParam("dakenPort");
 const updaterTarget =
   readSearchParam("updateTarget") ?? import.meta.env.VITE_UPDATER_TARGET?.trim() ?? "windows-x86_64";
 const updaterTimeoutEnvRaw = import.meta.env.VITE_UPDATER_CHECK_TIMEOUT_MS?.trim();
@@ -110,6 +124,7 @@ export const runtimeConfig: RuntimeConfig = {
     playerId,
     displayName,
     source,
+    dakenCounterV3Port,
     sourcePaths: {
       dakenTodayUpdateXml: readSearchParam("dakenPath"),
       notebookExportRecentJson: readSearchParam("notebookPath"),

--- a/apps/client/src/services/source-submission.ts
+++ b/apps/client/src/services/source-submission.ts
@@ -291,7 +291,10 @@ function buildDebugObservation(
 
   return {
     timestamp: template.source_meta?.timestamp ?? "",
-    playStyle: template.source === "inf_daken_counter" ? expectedKey.play_style : null,
+    playStyle:
+      template.source === "inf_daken_counter" || template.source === "daken_counter_v3"
+        ? expectedKey.play_style
+        : null,
     difficulty: expectedKey.difficulty,
     title: template.source_meta?.title ?? expectedKey.title_search_key,
     titleSearchKey: expectedKey.title_search_key,
@@ -420,6 +423,7 @@ export function submitParsedSourceChange(
       score: matchedObservation.score,
       misscount: matchedObservation.misscount,
       file_path: parsedChange.filePath,
+      ...(matchedObservation.sourceMetaExtras ?? {}),
     },
   });
   if (!sent) {

--- a/apps/client/src/services/tauri-bridge.ts
+++ b/apps/client/src/services/tauri-bridge.ts
@@ -22,6 +22,7 @@ export interface ParsedSourceObservationPayload {
   titleSearchKey: string;
   score: number;
   misscount: number;
+  sourceMetaExtras?: Record<string, string | number | boolean | null>;
 }
 
 export type ParsedSourceUnresolvedCaseKind =

--- a/apps/client/src/stores/settings-store.ts
+++ b/apps/client/src/stores/settings-store.ts
@@ -6,6 +6,10 @@ import { createExternalStore, useExternalStore } from "./create-store";
 const SETTINGS_STORAGE_KEY = "infinitas.client.settings.v1";
 const DEFAULT_API_BASE_URL = "http://127.0.0.1:8787";
 const DEFAULT_VOICE_VOLUME = 80;
+export const SOURCE_PORT_MIN = 1;
+export const SOURCE_PORT_MAX = 65535;
+export const DAKEN_COUNTER_V3_DEFAULT_PORT = 8767;
+const FALLBACK_SOURCE: SourceType = "inf-notebook";
 
 export interface SourcePaths {
   dakenTodayUpdateXml: string;
@@ -23,6 +27,7 @@ export interface ClientSettings {
   playerId: string;
   displayName: string;
   source: SourceType;
+  dakenCounterV3Port: number;
   sourcePaths: SourcePaths;
   sourceDirectories: SourceDirectories;
   voiceEnabled: boolean;
@@ -45,6 +50,7 @@ interface PartialClientSettings {
   playerId?: string;
   displayName?: string;
   source?: string;
+  dakenCounterV3Port?: number;
   sourcePaths?: Partial<SourcePaths>;
   sourceDirectories?: Partial<SourceDirectories>;
   voiceEnabled?: boolean;
@@ -71,7 +77,29 @@ function createDefaultSourceDirectories(): SourceDirectories {
 }
 
 function normalizeSource(value: string | undefined): SourceType {
-  return SOURCE_TYPES.includes(value as SourceType) ? (value as SourceType) : SOURCE_TYPES[0];
+  if (!SOURCE_TYPES.includes(value as SourceType)) {
+    return FALLBACK_SOURCE;
+  }
+
+  const normalized = value as SourceType;
+  return normalized === "inf_daken_counter" ? FALLBACK_SOURCE : normalized;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+export function isValidPortNumber(value: number): boolean {
+  return Number.isInteger(value) && value >= SOURCE_PORT_MIN && value <= SOURCE_PORT_MAX;
+}
+
+export function normalizeDakenCounterV3Port(value: unknown): number {
+  if (!isFiniteNumber(value)) {
+    return DAKEN_COUNTER_V3_DEFAULT_PORT;
+  }
+
+  const normalized = Math.trunc(value);
+  return isValidPortNumber(normalized) ? normalized : DAKEN_COUNTER_V3_DEFAULT_PORT;
 }
 
 function normalizeBaseUrl(value: string | undefined): string {
@@ -235,6 +263,7 @@ function createDefaultSettings(): ClientSettings {
     playerId: runtimeConfig.settingsDefaults.playerId?.trim() || crypto.randomUUID(),
     displayName: runtimeConfig.settingsDefaults.displayName?.trim() ?? "",
     source: normalizeSource(runtimeConfig.settingsDefaults.source),
+    dakenCounterV3Port: normalizeDakenCounterV3Port(runtimeConfig.settingsDefaults.dakenCounterV3Port),
     sourcePaths,
     sourceDirectories,
     voiceEnabled: true,
@@ -277,6 +306,7 @@ function normalizeSettings(rawSettings: PartialClientSettings | null): ClientSet
     playerId: rawSettings?.playerId?.trim() || defaults.playerId,
     displayName: rawSettings?.displayName?.trim() ?? defaults.displayName,
     source: normalizeSource(rawSettings?.source ?? defaults.source),
+    dakenCounterV3Port: normalizeDakenCounterV3Port(rawSettings?.dakenCounterV3Port ?? defaults.dakenCounterV3Port),
     sourcePaths,
     sourceDirectories,
     ...voiceSettings,
@@ -295,15 +325,29 @@ function syncVoiceDraft(draft: ClientSettings): ClientSettings {
 }
 
 export function getActiveSourceDirectory(settings: Pick<ClientSettings, "source" | "sourceDirectories">): string {
-  return settings.source === "inf_daken_counter"
-    ? settings.sourceDirectories.dakenDirectory
-    : settings.sourceDirectories.notebookDirectory;
+  if (settings.source === "inf_daken_counter") {
+    return settings.sourceDirectories.dakenDirectory;
+  }
+
+  if (settings.source === "inf-notebook") {
+    return settings.sourceDirectories.notebookDirectory;
+  }
+
+  return "";
 }
 
 export function isRoomEntryReady(
-  settings: Pick<ClientSettings, "displayName" | "source" | "sourceDirectories">,
+  settings: Pick<ClientSettings, "displayName" | "source" | "sourceDirectories" | "dakenCounterV3Port">,
 ): boolean {
-  return settings.displayName.trim().length > 0 && getActiveSourceDirectory(settings).trim().length > 0;
+  if (settings.displayName.trim().length === 0) {
+    return false;
+  }
+
+  if (settings.source === "daken_counter_v3") {
+    return isValidPortNumber(settings.dakenCounterV3Port);
+  }
+
+  return getActiveSourceDirectory(settings).trim().length > 0;
 }
 
 export function isVoicePlaybackEnabled(
@@ -360,6 +404,13 @@ export const settingsStore = {
   },
   updateSourceDirectory(source: SourceType, directory: string): void {
     internalStore.setState((state) => {
+      if (source === "daken_counter_v3") {
+        return {
+          ...state,
+          statusMessage: null,
+        };
+      }
+
       const sourceDirectories =
         source === "inf_daken_counter"
           ? {

--- a/apps/client/src/stores/source-store.ts
+++ b/apps/client/src/stores/source-store.ts
@@ -111,7 +111,7 @@ let dakenCounterV3ReconnectTimer: number | null = null;
 let dakenCounterV3MonitoringEnabled = false;
 let dakenCounterV3LastRoomState: RoomStateSnapshot["room_state"] | null = null;
 let dakenCounterV3HasSnapshotBaseline = false;
-let dakenCounterV3SnapshotFingerprints = new Set<string>();
+let dakenCounterV3SnapshotFingerprintCounts = new Map<string, number>();
 const dakenCounterV3ProcessedFingerprints = new Set<string>();
 const dakenCounterV3ProcessedFingerprintQueue: string[] = [];
 
@@ -301,7 +301,15 @@ function resetDakenCounterV3SnapshotTracking(): void {
   dakenCounterV3MonitoringEnabled = false;
   dakenCounterV3LastRoomState = null;
   dakenCounterV3HasSnapshotBaseline = false;
-  dakenCounterV3SnapshotFingerprints = new Set<string>();
+  dakenCounterV3SnapshotFingerprintCounts = new Map<string, number>();
+  dakenCounterV3ProcessedFingerprints.clear();
+  dakenCounterV3ProcessedFingerprintQueue.splice(0, dakenCounterV3ProcessedFingerprintQueue.length);
+}
+
+function resetDakenCounterV3MatchTracking(): void {
+  dakenCounterV3MonitoringEnabled = false;
+  dakenCounterV3HasSnapshotBaseline = false;
+  dakenCounterV3SnapshotFingerprintCounts = new Map<string, number>();
   dakenCounterV3ProcessedFingerprints.clear();
   dakenCounterV3ProcessedFingerprintQueue.splice(0, dakenCounterV3ProcessedFingerprintQueue.length);
 }
@@ -434,7 +442,7 @@ function parseDakenCounterV3Item(
 
 function parseDakenCounterV3Message(rawMessage: string): {
   entries: DakenCounterV3ObservationEntry[];
-  fingerprintSet: Set<string>;
+  fingerprintCounts: Map<string, number>;
 } | null {
   let parsedMessage: unknown;
   try {
@@ -474,8 +482,61 @@ function parseDakenCounterV3Message(rawMessage: string): {
 
   return {
     entries,
-    fingerprintSet: new Set(entries.map((entry) => entry.fingerprint)),
+    fingerprintCounts: buildDakenCounterV3FingerprintCounts(entries),
   };
+}
+
+function buildDakenCounterV3FingerprintCounts(
+  entries: DakenCounterV3ObservationEntry[],
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const entry of entries) {
+    counts.set(entry.fingerprint, (counts.get(entry.fingerprint) ?? 0) + 1);
+  }
+
+  return counts;
+}
+
+function diffDakenCounterV3SnapshotEntries(
+  previousCounts: Map<string, number>,
+  currentCounts: Map<string, number>,
+  currentEntries: DakenCounterV3ObservationEntry[],
+): DakenCounterV3ObservationEntry[] {
+  const remaining = new Map<string, number>();
+  for (const [fingerprint, currentCount] of currentCounts) {
+    const previousCount = previousCounts.get(fingerprint) ?? 0;
+    if (currentCount > previousCount) {
+      remaining.set(fingerprint, currentCount - previousCount);
+    }
+  }
+
+  if (remaining.size === 0) {
+    return [];
+  }
+
+  const deltaEntries: DakenCounterV3ObservationEntry[] = [];
+  for (const entry of currentEntries) {
+    const rest = remaining.get(entry.fingerprint) ?? 0;
+    if (rest <= 0) {
+      continue;
+    }
+
+    deltaEntries.push(entry);
+    if (rest === 1) {
+      remaining.delete(entry.fingerprint);
+    } else {
+      remaining.set(entry.fingerprint, rest - 1);
+    }
+  }
+
+  return deltaEntries;
+}
+
+function isRetryableDakenCounterV3SubmitFailure(message: string): boolean {
+  return (
+    message === "A connected PLAYING room is required before injecting source data." ||
+    message === "Failed to send RESULT_SUBMIT for the injected payload."
+  );
 }
 
 function shouldKeepDakenCounterV3Connection(snapshot: RoomStateSnapshot | null): boolean {
@@ -528,14 +589,19 @@ function handleDakenCounterV3SocketMessage(rawMessage: string): void {
     return;
   }
 
+  const previousCounts = dakenCounterV3SnapshotFingerprintCounts;
   const deltaEntries = dakenCounterV3HasSnapshotBaseline
-    ? parsedSnapshot.entries.filter(
-        (entry) => !dakenCounterV3SnapshotFingerprints.has(entry.fingerprint),
+    ? diffDakenCounterV3SnapshotEntries(
+        previousCounts,
+        parsedSnapshot.fingerprintCounts,
+        parsedSnapshot.entries,
       )
     : [];
 
-  dakenCounterV3SnapshotFingerprints = parsedSnapshot.fingerprintSet;
-  dakenCounterV3HasSnapshotBaseline = true;
+  if (!dakenCounterV3HasSnapshotBaseline) {
+    dakenCounterV3SnapshotFingerprintCounts = parsedSnapshot.fingerprintCounts;
+    dakenCounterV3HasSnapshotBaseline = true;
+  }
 
   const roomSnapshot = roomStore.getState().snapshot;
   if (
@@ -543,6 +609,7 @@ function handleDakenCounterV3SocketMessage(rawMessage: string): void {
     roomSnapshot.room_state !== "PLAYING" ||
     !dakenCounterV3MonitoringEnabled
   ) {
+    dakenCounterV3SnapshotFingerprintCounts = parsedSnapshot.fingerprintCounts;
     return;
   }
 
@@ -550,24 +617,40 @@ function handleDakenCounterV3SocketMessage(rawMessage: string): void {
     (entry) => !dakenCounterV3ProcessedFingerprints.has(entry.fingerprint),
   );
   if (uniqueEntries.length === 0) {
+    dakenCounterV3SnapshotFingerprintCounts = parsedSnapshot.fingerprintCounts;
     return;
   }
 
+  let hasRetryableFailure = false;
   for (const entry of uniqueEntries) {
-    rememberProcessedFingerprint(entry.fingerprint);
+    const parsedChange: ParsedSourceChangePayload = {
+      source: DAKEN_COUNTER_V3_SOURCE,
+      filePath: buildDakenCounterV3Endpoint(currentDakenCounterV3Port()),
+      fileSizeBytes: 0,
+      observations: [entry.observation],
+      unresolvedCases: [],
+    };
+
+    const outcome = submitParsedSourceChange(parsedChange, DAKEN_COUNTER_V3_ORIGIN_LABEL);
+    if (outcome.ok) {
+      rememberProcessedFingerprint(entry.fingerprint);
+      continue;
+    }
+
+    if (outcome.pendingUnresolvedAlias !== undefined) {
+      continue;
+    }
+
+    if (isRetryableDakenCounterV3SubmitFailure(outcome.message)) {
+      hasRetryableFailure = true;
+      continue;
+    }
+
+    roomStore.noteLocalEvent(`Source auto-submit skipped: ${outcome.message}`);
   }
 
-  const parsedChange: ParsedSourceChangePayload = {
-    source: DAKEN_COUNTER_V3_SOURCE,
-    filePath: buildDakenCounterV3Endpoint(currentDakenCounterV3Port()),
-    fileSizeBytes: 0,
-    observations: uniqueEntries.map((entry) => entry.observation),
-    unresolvedCases: [],
-  };
-
-  const outcome = submitParsedSourceChange(parsedChange, DAKEN_COUNTER_V3_ORIGIN_LABEL);
-  if (!outcome.ok && outcome.pendingUnresolvedAlias === undefined) {
-    roomStore.noteLocalEvent(`Source auto-submit skipped: ${outcome.message}`);
+  if (!hasRetryableFailure) {
+    dakenCounterV3SnapshotFingerprintCounts = parsedSnapshot.fingerprintCounts;
   }
 }
 
@@ -689,6 +772,8 @@ function syncDakenCounterV3RoomLifecycle(snapshot: RoomStateSnapshot | null): vo
   }
 
   if (currentState === "LOBBY" && previousState !== "LOBBY") {
+    // Clear per-match dedupe state so rematches can submit identical result tuples.
+    resetDakenCounterV3MatchTracking();
     connectDakenCounterV3Socket(snapshot);
   }
 

--- a/apps/client/src/stores/source-store.ts
+++ b/apps/client/src/stores/source-store.ts
@@ -1,9 +1,10 @@
-import type { SourceType } from "@infinitas/shared";
+import type { RoomStateSnapshot, SourceType } from "@infinitas/shared";
 import {
   getSourceWatcherState,
   isTauriRuntime,
   listenToSourceWatcherEvents,
   type ParsedSourceChangePayload,
+  type ParsedSourceObservationPayload,
   type ParsedSourceUnresolvedCasePayload,
   startSourceWatcher,
   stopSourceWatcher,
@@ -20,7 +21,7 @@ import {
 } from "../services/source-submission";
 import { roomStore } from "./room-store";
 import { createExternalStore, useExternalStore } from "./create-store";
-import { type ClientSettings, type SourcePaths } from "./settings-store";
+import { isValidPortNumber, type ClientSettings, type SourcePaths } from "./settings-store";
 
 export interface SourceWatcherState {
   status: SourceWatcherStatus;
@@ -103,6 +104,24 @@ let attachedListener: (() => void) | null = null;
 let attachPromise: Promise<void> | null = null;
 let appliedConfigKey: string | null = null;
 let unresolvedDialogSequence = 0;
+let latestSettings: Pick<ClientSettings, "source" | "sourcePaths" | "dakenCounterV3Port"> | null = null;
+let dakenCounterV3Socket: WebSocket | null = null;
+let dakenCounterV3SocketPort: number | null = null;
+let dakenCounterV3ReconnectTimer: number | null = null;
+let dakenCounterV3MonitoringEnabled = false;
+let dakenCounterV3LastRoomState: RoomStateSnapshot["room_state"] | null = null;
+let dakenCounterV3HasSnapshotBaseline = false;
+let dakenCounterV3SnapshotFingerprints = new Set<string>();
+const dakenCounterV3ProcessedFingerprints = new Set<string>();
+const dakenCounterV3ProcessedFingerprintQueue: string[] = [];
+
+const DAKEN_COUNTER_V3_SOURCE: SourceType = "daken_counter_v3";
+const DAKEN_COUNTER_V3_ORIGIN_LABEL = "打鍵カウンタv3";
+const DAKEN_COUNTER_V3_DEFAULT_PORT = 8767;
+const DAKEN_COUNTER_V3_WARNING_MESSAGE =
+  "打鍵カウンタv3 に接続できませんでした。ポート設定と起動状態を確認してください。";
+const DAKEN_COUNTER_V3_HISTORY_LIMIT = 512;
+const DAKEN_COUNTER_V3_RECONNECT_DELAY_MS = 2000;
 
 const initialState: SourceStoreState = {
   watcherState: {
@@ -120,10 +139,11 @@ const initialState: SourceStoreState = {
 
 const internalStore = createExternalStore<SourceStoreState>(initialState);
 
-function createConfigKey(settings: Pick<ClientSettings, "source" | "sourcePaths">): string {
+function createConfigKey(settings: Pick<ClientSettings, "source" | "sourcePaths" | "dakenCounterV3Port">): string {
   return JSON.stringify({
     source: settings.source,
     sourcePaths: settings.sourcePaths,
+    dakenCounterV3Port: settings.dakenCounterV3Port,
   });
 }
 
@@ -153,6 +173,544 @@ function mapWatcherEvent(payload: SourceWatcherEventPayload): SourceWatcherEvent
     occurredAt: new Date(payload.occurredAtMs).toISOString(),
     parserOutput: payload.parserOutput,
   };
+}
+
+interface DakenCounterV3ObservationEntry {
+  fingerprint: string;
+  observation: ParsedSourceObservationPayload;
+}
+
+const DAKEN_COUNTER_V3_DIFFICULTY_MAP: Record<
+  string,
+  { playStyle: "SP" | "DP"; difficulty: ParsedSourceObservationPayload["difficulty"] }
+> = {
+  SPB: { playStyle: "SP", difficulty: "BEGINNER" },
+  SPN: { playStyle: "SP", difficulty: "NORMAL" },
+  SPH: { playStyle: "SP", difficulty: "HYPER" },
+  SPA: { playStyle: "SP", difficulty: "ANOTHER" },
+  SPL: { playStyle: "SP", difficulty: "LEGGENDARIA" },
+  DPB: { playStyle: "DP", difficulty: "BEGINNER" },
+  DPN: { playStyle: "DP", difficulty: "NORMAL" },
+  DPH: { playStyle: "DP", difficulty: "HYPER" },
+  DPA: { playStyle: "DP", difficulty: "ANOTHER" },
+  DPL: { playStyle: "DP", difficulty: "LEGGENDARIA" },
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function normalizeText(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeTitle(value: unknown): string | null {
+  const rawTitle = normalizeText(value);
+  if (rawTitle.length === 0) {
+    return null;
+  }
+
+  const normalized = rawTitle
+    .normalize("NFKC")
+    .replace(/\u3000/g, " ")
+    .split(/\s+/)
+    .filter((token) => token.length > 0)
+    .join(" ")
+    .replace(/ \(/g, "(")
+    .toLowerCase();
+
+  return normalized.length > 0 ? normalized : null;
+}
+
+function parseNonNegativeInteger(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const normalized = Math.trunc(value);
+    return normalized >= 0 ? normalized : null;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!/^\d+$/.test(trimmed)) {
+      return null;
+    }
+
+    const parsed = Number.parseInt(trimmed, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+function parseOptionalString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function parseDifficultyCode(rawDifficulty: unknown): {
+  code: string;
+  playStyle: "SP" | "DP";
+  difficulty: ParsedSourceObservationPayload["difficulty"];
+} | null {
+  const normalized = normalizeText(rawDifficulty).normalize("NFKC").toUpperCase();
+  if (normalized.length === 0) {
+    return null;
+  }
+
+  const mapped = DAKEN_COUNTER_V3_DIFFICULTY_MAP[normalized];
+  if (!mapped) {
+    return null;
+  }
+
+  return {
+    code: normalized,
+    playStyle: mapped.playStyle,
+    difficulty: mapped.difficulty,
+  };
+}
+
+function fingerprintHash(input: string): string {
+  let hash = 2166136261;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+function rememberProcessedFingerprint(fingerprint: string): void {
+  if (dakenCounterV3ProcessedFingerprints.has(fingerprint)) {
+    return;
+  }
+
+  dakenCounterV3ProcessedFingerprints.add(fingerprint);
+  dakenCounterV3ProcessedFingerprintQueue.push(fingerprint);
+  while (dakenCounterV3ProcessedFingerprintQueue.length > DAKEN_COUNTER_V3_HISTORY_LIMIT) {
+    const oldest = dakenCounterV3ProcessedFingerprintQueue.shift();
+    if (oldest !== undefined) {
+      dakenCounterV3ProcessedFingerprints.delete(oldest);
+    }
+  }
+}
+
+function resetDakenCounterV3SnapshotTracking(): void {
+  dakenCounterV3MonitoringEnabled = false;
+  dakenCounterV3LastRoomState = null;
+  dakenCounterV3HasSnapshotBaseline = false;
+  dakenCounterV3SnapshotFingerprints = new Set<string>();
+  dakenCounterV3ProcessedFingerprints.clear();
+  dakenCounterV3ProcessedFingerprintQueue.splice(0, dakenCounterV3ProcessedFingerprintQueue.length);
+}
+
+function clearDakenCounterV3ReconnectTimer(): void {
+  if (dakenCounterV3ReconnectTimer !== null) {
+    window.clearTimeout(dakenCounterV3ReconnectTimer);
+    dakenCounterV3ReconnectTimer = null;
+  }
+}
+
+function buildDakenCounterV3Endpoint(port: number): string {
+  return `ws://localhost:${port}`;
+}
+
+function currentDakenCounterV3Port(): number {
+  const configuredPort = latestSettings?.dakenCounterV3Port ?? DAKEN_COUNTER_V3_DEFAULT_PORT;
+  return isValidPortNumber(configuredPort) ? configuredPort : DAKEN_COUNTER_V3_DEFAULT_PORT;
+}
+
+function isDakenCounterV3SocketOpen(): boolean {
+  return dakenCounterV3Socket !== null && dakenCounterV3Socket.readyState === WebSocket.OPEN;
+}
+
+function updateDakenCounterV3WatcherState(
+  status: SourceWatcherStatus,
+  detail: string,
+  watchedPaths: string[] = [],
+): void {
+  internalStore.setState((state) => ({
+    ...state,
+    watcherState: {
+      ...state.watcherState,
+      status,
+      source: DAKEN_COUNTER_V3_SOURCE,
+      watchedPaths,
+      detail,
+      lastEventAt: new Date().toISOString(),
+    },
+  }));
+}
+
+function parseDakenCounterV3Item(
+  rawItem: unknown,
+  index: number,
+): DakenCounterV3ObservationEntry | null {
+  if (!isRecord(rawItem)) {
+    console.warn(`${DAKEN_COUNTER_V3_ORIGIN_LABEL}: discarded item[${index}] because it is not an object.`);
+    return null;
+  }
+
+  const battle = parseNonNegativeInteger(rawItem.battle);
+  if (battle === 1) {
+    console.info(`${DAKEN_COUNTER_V3_ORIGIN_LABEL}: discarded item[${index}] because battle == 1.`);
+    return null;
+  }
+
+  const title = normalizeText(rawItem.title);
+  const titleSearchKey = normalizeTitle(rawItem.title);
+  if (title.length === 0 || titleSearchKey === null) {
+    console.warn(`${DAKEN_COUNTER_V3_ORIGIN_LABEL}: discarded item[${index}] because title is empty.`);
+    return null;
+  }
+
+  const parsedDifficulty = parseDifficultyCode(rawItem.difficulty);
+  if (parsedDifficulty === null) {
+    console.warn(
+      `${DAKEN_COUNTER_V3_ORIGIN_LABEL}: discarded item[${index}] because difficulty is unknown.`,
+      rawItem.difficulty,
+    );
+    return null;
+  }
+
+  const score = parseNonNegativeInteger(rawItem.score);
+  if (score === null) {
+    console.warn(`${DAKEN_COUNTER_V3_ORIGIN_LABEL}: discarded item[${index}] because score is invalid.`);
+    return null;
+  }
+
+  const rawBp = parseNonNegativeInteger(rawItem.bp);
+  const rawPreScore = parseNonNegativeInteger(rawItem.pre_score);
+  const rawPreBp = parseNonNegativeInteger(rawItem.pre_bp);
+  const bp = rawBp ?? 9999;
+  const preBp = rawPreBp ?? 9999;
+  const bestScore = rawPreScore === null ? score : Math.max(score, rawPreScore);
+  const bestBp = Math.min(bp, preBp);
+
+  const lamp = parseOptionalString(rawItem.lamp);
+  const preLamp = parseOptionalString(rawItem.pre_lamp);
+  const opt = parseOptionalString(rawItem.opt);
+  const playSpeed = parseOptionalString(rawItem.playspeed);
+  const notes = parseNonNegativeInteger(rawItem.notes);
+
+  const fingerprintSeed = [
+    titleSearchKey,
+    parsedDifficulty.code,
+    score,
+    bp,
+    rawPreScore ?? "",
+    preBp,
+    lamp ?? "",
+    opt ?? "",
+    playSpeed ?? "",
+  ].join("|");
+
+  return {
+    fingerprint: fingerprintHash(fingerprintSeed),
+    observation: {
+      timestamp: new Date().toISOString(),
+      playStyle: parsedDifficulty.playStyle,
+      difficulty: parsedDifficulty.difficulty,
+      title,
+      titleSearchKey,
+      score,
+      misscount: bp,
+      sourceMetaExtras: {
+        best_score: bestScore,
+        best_bp: bestBp,
+        pre_score: rawPreScore ?? score,
+        pre_bp: preBp,
+        lamp,
+        pre_lamp: preLamp,
+        opt,
+        playspeed: playSpeed,
+        notes,
+      },
+    },
+  };
+}
+
+function parseDakenCounterV3Message(rawMessage: string): {
+  entries: DakenCounterV3ObservationEntry[];
+  fingerprintSet: Set<string>;
+} | null {
+  let parsedMessage: unknown;
+  try {
+    parsedMessage = JSON.parse(rawMessage);
+  } catch (error) {
+    console.warn(`${DAKEN_COUNTER_V3_ORIGIN_LABEL}: discarded malformed JSON message.`, error);
+    return null;
+  }
+
+  if (!isRecord(parsedMessage)) {
+    console.warn(`${DAKEN_COUNTER_V3_ORIGIN_LABEL}: discarded message because payload is not an object.`);
+    return null;
+  }
+
+  if (parsedMessage.type !== "today_updates") {
+    console.info(
+      `${DAKEN_COUNTER_V3_ORIGIN_LABEL}: ignored message because type is not today_updates.`,
+      parsedMessage.type,
+    );
+    return null;
+  }
+
+  if (!isRecord(parsedMessage.data) || !Array.isArray(parsedMessage.data.items)) {
+    console.warn(
+      `${DAKEN_COUNTER_V3_ORIGIN_LABEL}: discarded today_updates because data.items is not an array.`,
+    );
+    return null;
+  }
+
+  const entries: DakenCounterV3ObservationEntry[] = [];
+  for (let index = 0; index < parsedMessage.data.items.length; index += 1) {
+    const nextEntry = parseDakenCounterV3Item(parsedMessage.data.items[index], index);
+    if (nextEntry !== null) {
+      entries.push(nextEntry);
+    }
+  }
+
+  return {
+    entries,
+    fingerprintSet: new Set(entries.map((entry) => entry.fingerprint)),
+  };
+}
+
+function shouldKeepDakenCounterV3Connection(snapshot: RoomStateSnapshot | null): boolean {
+  return (
+    latestSettings?.source === DAKEN_COUNTER_V3_SOURCE &&
+    snapshot !== null &&
+    snapshot.room_state !== "CLOSED"
+  );
+}
+
+function disconnectDakenCounterV3Socket(options: { resetTracking: boolean }): void {
+  clearDakenCounterV3ReconnectTimer();
+
+  const activeSocket = dakenCounterV3Socket;
+  dakenCounterV3Socket = null;
+  dakenCounterV3SocketPort = null;
+  if (activeSocket !== null) {
+    activeSocket.onopen = null;
+    activeSocket.onmessage = null;
+    activeSocket.onerror = null;
+    activeSocket.onclose = null;
+
+    if (
+      activeSocket.readyState === WebSocket.CONNECTING ||
+      activeSocket.readyState === WebSocket.OPEN
+    ) {
+      activeSocket.close();
+    }
+  }
+
+  if (options.resetTracking) {
+    resetDakenCounterV3SnapshotTracking();
+  }
+}
+
+function scheduleDakenCounterV3Reconnect(snapshot: RoomStateSnapshot | null): void {
+  if (!shouldKeepDakenCounterV3Connection(snapshot) || dakenCounterV3ReconnectTimer !== null) {
+    return;
+  }
+
+  dakenCounterV3ReconnectTimer = window.setTimeout(() => {
+    dakenCounterV3ReconnectTimer = null;
+    connectDakenCounterV3Socket(roomStore.getState().snapshot);
+  }, DAKEN_COUNTER_V3_RECONNECT_DELAY_MS);
+}
+
+function handleDakenCounterV3SocketMessage(rawMessage: string): void {
+  const parsedSnapshot = parseDakenCounterV3Message(rawMessage);
+  if (parsedSnapshot === null) {
+    return;
+  }
+
+  const deltaEntries = dakenCounterV3HasSnapshotBaseline
+    ? parsedSnapshot.entries.filter(
+        (entry) => !dakenCounterV3SnapshotFingerprints.has(entry.fingerprint),
+      )
+    : [];
+
+  dakenCounterV3SnapshotFingerprints = parsedSnapshot.fingerprintSet;
+  dakenCounterV3HasSnapshotBaseline = true;
+
+  const roomSnapshot = roomStore.getState().snapshot;
+  if (
+    roomSnapshot === null ||
+    roomSnapshot.room_state !== "PLAYING" ||
+    !dakenCounterV3MonitoringEnabled
+  ) {
+    return;
+  }
+
+  const uniqueEntries = deltaEntries.filter(
+    (entry) => !dakenCounterV3ProcessedFingerprints.has(entry.fingerprint),
+  );
+  if (uniqueEntries.length === 0) {
+    return;
+  }
+
+  for (const entry of uniqueEntries) {
+    rememberProcessedFingerprint(entry.fingerprint);
+  }
+
+  const parsedChange: ParsedSourceChangePayload = {
+    source: DAKEN_COUNTER_V3_SOURCE,
+    filePath: buildDakenCounterV3Endpoint(currentDakenCounterV3Port()),
+    fileSizeBytes: 0,
+    observations: uniqueEntries.map((entry) => entry.observation),
+    unresolvedCases: [],
+  };
+
+  const outcome = submitParsedSourceChange(parsedChange, DAKEN_COUNTER_V3_ORIGIN_LABEL);
+  if (!outcome.ok && outcome.pendingUnresolvedAlias === undefined) {
+    roomStore.noteLocalEvent(`Source auto-submit skipped: ${outcome.message}`);
+  }
+}
+
+function connectDakenCounterV3Socket(snapshot: RoomStateSnapshot | null): void {
+  if (!shouldKeepDakenCounterV3Connection(snapshot)) {
+    disconnectDakenCounterV3Socket({ resetTracking: false });
+    return;
+  }
+
+  const port = currentDakenCounterV3Port();
+  if (!isValidPortNumber(port)) {
+    updateDakenCounterV3WatcherState(
+      "ERROR",
+      `${DAKEN_COUNTER_V3_ORIGIN_LABEL}: invalid port ${String(port)}.`,
+    );
+    return;
+  }
+
+  if (
+    dakenCounterV3Socket !== null &&
+    dakenCounterV3SocketPort === port &&
+    (dakenCounterV3Socket.readyState === WebSocket.CONNECTING ||
+      dakenCounterV3Socket.readyState === WebSocket.OPEN)
+  ) {
+    return;
+  }
+
+  disconnectDakenCounterV3Socket({ resetTracking: false });
+
+  const endpoint = buildDakenCounterV3Endpoint(port);
+  try {
+    const socket = new WebSocket(endpoint);
+    dakenCounterV3Socket = socket;
+    dakenCounterV3SocketPort = port;
+    updateDakenCounterV3WatcherState("IDLE", `${DAKEN_COUNTER_V3_ORIGIN_LABEL}: connecting...`, [endpoint]);
+
+    socket.onopen = () => {
+      if (dakenCounterV3Socket !== socket) {
+        return;
+      }
+      updateDakenCounterV3WatcherState("RUNNING", `${DAKEN_COUNTER_V3_ORIGIN_LABEL}: connected.`, [endpoint]);
+      console.info(`${DAKEN_COUNTER_V3_ORIGIN_LABEL}: connected to ${endpoint}.`);
+    };
+
+    socket.onmessage = (event) => {
+      if (dakenCounterV3Socket !== socket) {
+        return;
+      }
+
+      if (typeof event.data !== "string") {
+        console.warn(`${DAKEN_COUNTER_V3_ORIGIN_LABEL}: discarded non-text WebSocket payload.`);
+        return;
+      }
+
+      handleDakenCounterV3SocketMessage(event.data);
+    };
+
+    socket.onerror = (event) => {
+      if (dakenCounterV3Socket !== socket) {
+        return;
+      }
+      console.error(`${DAKEN_COUNTER_V3_ORIGIN_LABEL}: WebSocket error.`, event);
+    };
+
+    socket.onclose = (event) => {
+      if (dakenCounterV3Socket !== socket) {
+        return;
+      }
+
+      dakenCounterV3Socket = null;
+      dakenCounterV3SocketPort = null;
+      const reason = event.reason.trim().length > 0 ? event.reason : `code=${event.code}`;
+      console.warn(`${DAKEN_COUNTER_V3_ORIGIN_LABEL}: connection closed (${reason}).`);
+
+      const latestSnapshot = roomStore.getState().snapshot;
+      if (shouldKeepDakenCounterV3Connection(latestSnapshot)) {
+        updateDakenCounterV3WatcherState(
+          "ERROR",
+          `${DAKEN_COUNTER_V3_ORIGIN_LABEL}: connection closed (${reason}). retrying...`,
+          [endpoint],
+        );
+        scheduleDakenCounterV3Reconnect(latestSnapshot);
+        return;
+      }
+
+      updateDakenCounterV3WatcherState(
+        "STOPPED",
+        `${DAKEN_COUNTER_V3_ORIGIN_LABEL}: disconnected.`,
+      );
+    };
+  } catch (error) {
+    updateDakenCounterV3WatcherState(
+      "ERROR",
+      error instanceof Error ? error.message : `${DAKEN_COUNTER_V3_ORIGIN_LABEL}: failed to connect.`,
+      [endpoint],
+    );
+    console.error(`${DAKEN_COUNTER_V3_ORIGIN_LABEL}: failed to open WebSocket.`, error);
+    scheduleDakenCounterV3Reconnect(snapshot);
+  }
+}
+
+function syncDakenCounterV3RoomLifecycle(snapshot: RoomStateSnapshot | null): void {
+  const previousState = dakenCounterV3LastRoomState;
+  const currentState = snapshot?.room_state ?? null;
+  dakenCounterV3LastRoomState = currentState;
+
+  if (latestSettings?.source !== DAKEN_COUNTER_V3_SOURCE) {
+    disconnectDakenCounterV3Socket({ resetTracking: true });
+    return;
+  }
+
+  if (!shouldKeepDakenCounterV3Connection(snapshot)) {
+    disconnectDakenCounterV3Socket({ resetTracking: true });
+    updateDakenCounterV3WatcherState(
+      "IDLE",
+      `${DAKEN_COUNTER_V3_ORIGIN_LABEL}: join a room to start monitoring.`,
+    );
+    return;
+  }
+
+  if (currentState === "LOBBY" && previousState !== "LOBBY") {
+    connectDakenCounterV3Socket(snapshot);
+  }
+
+  if (currentState !== "PLAYING") {
+    dakenCounterV3MonitoringEnabled = false;
+    return;
+  }
+
+  if (previousState === "PLAYING") {
+    return;
+  }
+
+  if (!isDakenCounterV3SocketOpen()) {
+    dakenCounterV3MonitoringEnabled = false;
+    roomStore.reportSourceUnavailable(DAKEN_COUNTER_V3_WARNING_MESSAGE);
+    console.warn(
+      `${DAKEN_COUNTER_V3_ORIGIN_LABEL}: monitoring is disabled because the connection was unavailable at PLAYING start.`,
+    );
+    return;
+  }
+
+  dakenCounterV3MonitoringEnabled = true;
 }
 
 function nextUnresolvedDialogId(): string {
@@ -470,6 +1028,8 @@ export const sourceStore = {
     attachedListener?.();
     attachedListener = null;
     attachPromise = null;
+    latestSettings = null;
+    disconnectDakenCounterV3Socket({ resetTracking: true });
     internalStore.setState((state) => ({
       ...state,
       runtimeReady: false,
@@ -478,10 +1038,39 @@ export const sourceStore = {
     }));
   },
   async start(
-    settings: Pick<ClientSettings, "source" | "sourcePaths">,
+    settings: Pick<ClientSettings, "source" | "sourcePaths" | "dakenCounterV3Port">,
     options: StartOptions = {},
   ): Promise<void> {
     await ensureAttached();
+
+    latestSettings = settings;
+
+    if (settings.source === DAKEN_COUNTER_V3_SOURCE) {
+      appliedConfigKey = createConfigKey(settings);
+      if (isTauriRuntime()) {
+        const currentWatcherState = internalStore.getState().watcherState;
+        if (
+          currentWatcherState.source !== null &&
+          currentWatcherState.source !== DAKEN_COUNTER_V3_SOURCE &&
+          currentWatcherState.status !== "IDLE"
+        ) {
+          try {
+            const stoppedPayload = await stopSourceWatcher();
+            internalStore.setState((state) => ({
+              ...state,
+              watcherState: mapWatcherState(stoppedPayload),
+            }));
+          } catch {
+            // noop: legacy watcher may already be inactive
+          }
+        }
+      }
+
+      syncDakenCounterV3RoomLifecycle(roomStore.getState().snapshot);
+      return;
+    }
+
+    disconnectDakenCounterV3Socket({ resetTracking: true });
 
     if (!isTauriRuntime()) {
       return;
@@ -553,6 +1142,8 @@ export const sourceStore = {
     }
   },
   async stop(): Promise<void> {
+    latestSettings = null;
+    disconnectDakenCounterV3Socket({ resetTracking: true });
     await ensureAttached();
 
     if (!isTauriRuntime()) {
@@ -577,6 +1168,9 @@ export const sourceStore = {
         },
       }));
     }
+  },
+  syncRoomSnapshot(snapshot: RoomStateSnapshot | null): void {
+    syncDakenCounterV3RoomLifecycle(snapshot);
   },
 };
 

--- a/docs/design/02_ws_protocol.md
+++ b/docs/design/02_ws_protocol.md
@@ -40,7 +40,7 @@
 
 ### 3.1 ルーム
 - `ROOM_JOIN`
-  - payload: `{ join_code?: string, display_name: string, source: "inf_daken_counter"|"inf-notebook", client_version?: string, client_capabilities?: object }`
+  - payload: `{ join_code?: string, display_name: string, source: "inf_daken_counter"|"inf-notebook"|"daken_counter_v3", client_version?: string, client_capabilities?: object }`
   - 備考: WS接続直後に必ず送る（DOがJOIN完了するまでstate配信しない）
 - `ROOM_LEAVE`
   - payload: `{}`
@@ -158,7 +158,7 @@
   "settings": { "...": "..." },
   "host_player_id": "string",
   "players": [
-    { "player_id": "string", "display_name": "string", "source": "inf_daken_counter|inf-notebook", "connected": true, "ready": false }
+    { "player_id": "string", "display_name": "string", "source": "inf_daken_counter|inf-notebook|daken_counter_v3", "connected": true, "ready": false }
   ],
   "picks": [
     { "player_id": "string", "pick_chart_key": "string", "accepted_at": "ISO8601" }

--- a/docs/design/03_data_model.md
+++ b/docs/design/03_data_model.md
@@ -41,7 +41,7 @@
 ### 2.3 Player
 - `player_id: string`
 - `display_name: string`
-- `source: inf_daken_counter|inf-notebook`（端末設定）
+- `source: inf_daken_counter|inf-notebook|daken_counter_v3`（端末設定）
 - `connected: bool`
 - `ready: bool`
 - `joined_at: datetime`

--- a/docs/design/06_source_io_spec.md
+++ b/docs/design/06_source_io_spec.md
@@ -7,12 +7,15 @@ Ph1で対応するローカル監視ソースについて、
 Ph1では以下を前提とする。
 
 - 対応ソースは 2種類
-  - `inf_daken_counter`
   - `inf-notebook`
+  - `daken_counter_v3`
+  - `inf_daken_counter` は legacy（設定UIでは非表示）
 - **1端末1ソース固定**
 - ソースは事前設定で選択
 - ルーム参加中は変更不可
-- 監視方式は **file watcher**
+- 監視方式はソースごとに固定
+  - `inf-notebook`: **file watcher**
+  - `daken_counter_v3`: **local WebSocket** (`ws://localhost:{port}`)
 - 監視異常時は `SOURCE_UNAVAILABLE` を表示し、TECHスキップ誘導とする
 
 ---
@@ -238,7 +241,7 @@ score/misscount = export/recent.json (timestamp一致)
 
 ---
 
-## 3. ソース: inf_daken_counter（打鍵カウンタ）
+## 3. ソース: inf_daken_counter（legacy / 非推奨）
 
 ## 3.1 使用ファイル
 必須:
@@ -338,11 +341,30 @@ Ph1では以下を採用する。
 
 ---
 
+## 3.7 ソース: daken_counter_v3（Ph1 v1）
+
+入力:
+- local WebSocket `ws://localhost:{port}`（default `8767`）
+
+受信:
+- `type == "today_updates"` のみ処理対象
+- `data.items[]` は一覧スナップショットとして扱い、前回受信との差分のみ新規候補にする
+
+採用:
+- LOBBY では採用しない（直近スナップショットのみ保持）
+- PLAYING 開始時に接続確認し、接続不可なら `SOURCE_UNAVAILABLE` として監視開始しない
+- PLAYING 中のみ差分判定を有効化し、重複履歴を保持して再処理を防ぐ
+- `difficulty` は 3.4 の変換表を厳格適用する
+- `battle == 1` は v1 非対応として破棄する
+
+---
+
 ## 4. ソース設定UIとの対応
 
 ## 4.1 設定値
-- `inf_daken_counter`
 - `inf-notebook`
+- `daken_counter_v3`
+- `inf_daken_counter` は legacy 非推奨（既存設定が残っていても利用しない）
 
 ## 4.2 制約
 - 1端末1ソース固定
@@ -355,6 +377,9 @@ Ph1では以下を採用する。
 ### inf-notebook
 - `records/summary.json`
 - `export/recent.json`
+
+### daken_counter_v3
+- `ws://localhost:{port}`（default: `8767`）
 
 ---
 

--- a/docs/design/07_constants.md
+++ b/docs/design/07_constants.md
@@ -109,7 +109,8 @@ Ph1で固定するタイマー値、制約値、表示/運用上の定数を整�
 ## 5. ソース監視定数
 
 ## 5.1 source options
-- `SOURCE_OPTIONS = ["inf_daken_counter", "inf-notebook"]`
+- `SOURCE_OPTIONS = ["inf_daken_counter", "inf-notebook", "daken_counter_v3"]`
+- 設定UIでの選択対象は `inf-notebook` / `daken_counter_v3`（`inf_daken_counter` はlegacy非表示）
 
 ## 5.2 source制約
 - `SOURCE_FIXED_PER_DEVICE = true`

--- a/packages/shared/src/enums/source.ts
+++ b/packages/shared/src/enums/source.ts
@@ -1,3 +1,3 @@
-export const SOURCE_TYPES = ["inf_daken_counter", "inf-notebook"] as const;
+export const SOURCE_TYPES = ["inf_daken_counter", "inf-notebook", "daken_counter_v3"] as const;
 
 export type SourceType = (typeof SOURCE_TYPES)[number];

--- a/tasks/issue-77-daken-counter-v3.md
+++ b/tasks/issue-77-daken-counter-v3.md
@@ -1,0 +1,51 @@
+# issue-77-daken-counter-v3
+
+## Purpose
+- 監視対象に `打鍵カウンタv3`（`daken_counter_v3`）を追加し、`today_updates` スナップショットを既存の結果取り込み共通経路へ合流させる。
+
+## Non-goals
+- 旧打鍵カウンタ互換対応は行わない。
+- Worker/DO 側プロトコルや保存経路の新設は行わない。
+- 目的外のUI改修や広域リファクタは行わない。
+
+## Changes
+- `SourceType` と設定モデルに `daken_counter_v3` とポート設定（既定 `8767`）を追加し、設定UIで選択/入力できるようにする。
+- LOBBY入場でローカルWebSocket接続、PLAYING開始時に接続確認、離脱時切断のライフサイクルを追加する。
+- `today_updates` 受信データを厳格パースし、LOBBYでは採用せず、PLAYING中のみスナップショット差分を既存共通経路に投入する。
+- 差分/重複防止（履歴上限付き）・`difficulty` 未知値破棄・`battle == 1` 破棄・JSON不正耐性を追加する。
+
+## Impact
+- Users: 設定画面で新監視対象とポート設定が利用可能になる。
+- Data: ローカル設定に監視ソース種別とポートが追加される。
+- Compatibility: 旧打鍵カウンタ設定は利用対象外として扱う。
+- Cloudflare: なし（clientローカル実装のみ）。
+
+## Target Files / Layers
+- Files:
+  - `packages/shared/src/enums/source.ts`
+  - `apps/client/src/stores/settings-store.ts`
+  - `apps/client/src/pages/SettingsPage.tsx`
+  - `apps/client/src/stores/source-store.ts`
+  - `apps/client/src/services/source-submission.ts`
+  - 必要に応じて `apps/client/src/services/*` / `apps/client/src/stores/*` の局所ファイル
+- Layers: client / shared
+
+## Test Focus
+- 技術的検証: client build, lint, 変更箇所ユニットテスト（可能な範囲）
+- 監視ソース検証: LOBBY非採用、PLAYING差分採用、接続失敗時警告、無効メッセージ破棄、重複防止
+- 差分検証: 目的ファイル限定、不要整形なし、UTF-8 no BOM / LF維持
+
+## Rollback Plan
+- `daken_counter_v3` の選択肢追加と受信処理差分を単純revertし、既存 `inf-notebook` / `inf_daken_counter` のみへ戻す。
+
+## Commit Split Plan
+1. shared/client 設定モデルと設定UIに `daken_counter_v3` + ポート設定を追加
+2. WebSocket受信/差分取り込みロジックを既存共通経路へ統合し、検証コードを追加
+
+## Checklist
+- [x] Design doc alignment confirmed (if required)
+- [x] Impact scope identified
+- [x] Implementation completed
+- [x] Tests completed
+- [x] Regression checks completed
+- [x] Documentation updates completed (if required)


### PR DESCRIPTION
- [x] WORKFLOW.md を確認した
- [x] QUALITY.md を満たしている

## 目的
Issue #77: 監視対象に `打鍵カウンタv3`（`daken_counter_v3`）を追加し、`today_updates` の受信結果を既存の共通結果取り込み経路へ流す。

## 変更点
- shared/client の source 定義に `daken_counter_v3` を追加。
- 設定UIに `打鍵カウンタv3` を追加し、選択時のみ WebSocket ポート入力（default 8767）を表示。
- 旧 `inf_daken_counter` は設定UIから非表示化し、残存設定は `inf-notebook` にフォールバック。
- `sourceStore` に `daken_counter_v3` 用ローカルWS接続を追加。
  - LOBBY入場時接続
  - LOBBY中はスナップショット保持のみ（採用なし）
  - PLAYING開始時に接続確認（失敗時は警告）
  - 退出時切断
- `today_updates` の差分判定・重複防止を実装（履歴上限あり）。
- `difficulty` 厳格解釈、未知difficulty/空title/`battle==1`/不正JSON/不正payloadの破棄ログを追加。
- DTOは既存 `submitParsedSourceChange` 共通経路に合流（専用保存経路は未追加）。
- `bp`/`pre_bp` 欠損時は 9999 補完、best値を算出して source_meta に保持。
- 規範設計docs（source列挙/監視仕様）を実装に合わせて更新。
- Plan Mode artifact: `tasks/issue-77-daken-counter-v3.md` を追加。

## 非変更点
- Worker/DO のFSM・WS schema・保存経路の新設はなし。
- 旧打鍵カウンタ互換の復活対応はなし。

## 影響範囲
- Users: 設定画面で `打鍵カウンタv3` とポート設定が利用可能。
- Data: ローカル設定に `dakenCounterV3Port` を追加。
- Compatibility: 旧 `inf_daken_counter` 設定は利用対象外として扱う。
- Cloudflare: 変更なし（client / shared中心）。

## テスト
- `npm run typecheck`
- `npm run lint`
- `npm run build:client`
- `npm run test:worker`
- `npm run test:client-stats`

## 回帰確認項目
- `daken_counter_v3` 選択時のみポート入力表示
- LOBBY接続 / PLAYING開始時接続確認 / 退出切断
- LOBBY中は非採用、PLAYING中のみ差分採用
- 不正payload/未知difficulty/`battle==1` の破棄ログ
- 既存 `inf-notebook` 経路に影響がないこと

## ロールバック方針
- `daken_counter_v3` 追加差分をrevertし、既存監視ソースのみへ戻す。

## docs/design 更新
- あり（`02_ws_protocol.md`, `03_data_model.md`, `06_source_io_spec.md`, `07_constants.md`）