### PR TITLE
feat: add Reflux latest.json/tracker.tsv source integration (#95)

### DIFF
--- a/apps/client/src-tauri/src/commands/source_directory_validation.rs
+++ b/apps/client/src-tauri/src/commands/source_directory_validation.rs
@@ -33,6 +33,10 @@ pub fn validate_source_directory(
             join_path(base_directory, &["export", "recent.json"]),
             join_path(base_directory, &["records", "summary.json"]),
         ],
+        SourceType::Reflux => vec![
+            join_path(base_directory, &["latest.json"]),
+            join_path(base_directory, &["tracker.tsv"]),
+        ],
     };
 
     let missing_paths = required_paths

--- a/apps/client/src-tauri/src/models/source_watcher.rs
+++ b/apps/client/src-tauri/src/models/source_watcher.rs
@@ -1,4 +1,7 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub const SOURCE_WATCHER_EVENT_NAME: &str = "source-watcher://event";
@@ -9,6 +12,8 @@ pub enum SourceType {
     InfDakenCounter,
     #[serde(rename = "inf-notebook")]
     InfNotebook,
+    #[serde(rename = "reflux")]
+    Reflux,
 }
 
 impl SourceType {
@@ -16,6 +21,7 @@ impl SourceType {
         match self {
             Self::InfDakenCounter => "inf_daken_counter",
             Self::InfNotebook => "inf-notebook",
+            Self::Reflux => "reflux",
         }
     }
 }
@@ -26,6 +32,8 @@ pub struct SourcePathsConfig {
     pub daken_today_update_xml: String,
     pub notebook_export_recent_json: String,
     pub notebook_records_recent_json: String,
+    pub reflux_latest_json: String,
+    pub reflux_tracker_tsv: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -78,11 +86,14 @@ pub struct ParsedSourceObservation {
     pub title_search_key: String,
     pub score: u32,
     pub misscount: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_meta_extras: Option<HashMap<String, Value>>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ParsedSourceUnresolvedCaseKind {
+    UnresolvedAlias,
     ResolvedPartial,
     AmbiguousRecent,
 }

--- a/apps/client/src-tauri/src/parsers/daken.rs
+++ b/apps/client/src-tauri/src/parsers/daken.rs
@@ -133,6 +133,7 @@ fn parse_daken_item(raw_item: &str) -> Result<ParsedDakenItem, String> {
             title_search_key: title,
             score,
             misscount,
+            source_meta_extras: None,
         },
     })
 }

--- a/apps/client/src-tauri/src/parsers/mod.rs
+++ b/apps/client/src-tauri/src/parsers/mod.rs
@@ -1,5 +1,6 @@
 mod daken;
 mod notebook;
+mod reflux;
 
 use std::path::PathBuf;
 
@@ -20,5 +21,6 @@ pub fn create_parser(
     match source {
         SourceType::InfNotebook => Box::new(notebook::NotebookParser::new(source_paths)),
         SourceType::InfDakenCounter => Box::new(daken::DakenParser::new(source_paths)),
+        SourceType::Reflux => Box::new(reflux::RefluxParser::new(source_paths)),
     }
 }

--- a/apps/client/src-tauri/src/parsers/notebook.rs
+++ b/apps/client/src-tauri/src/parsers/notebook.rs
@@ -621,6 +621,7 @@ fn resolution_result_to_observation(
         title_search_key: title_search_key.clone(),
         score: recent.score,
         misscount: recent.misscount,
+        source_meta_extras: None,
     })
 }
 

--- a/apps/client/src-tauri/src/parsers/reflux.rs
+++ b/apps/client/src-tauri/src/parsers/reflux.rs
@@ -358,7 +358,14 @@ fn parse_latest_record(raw_json: &str) -> Result<LatestRecord, String> {
     } else {
         title.as_str()
     };
-    let secondary_fingerprint = format!("{title_for_fingerprint}::{diff}::{score}::{bad}::{poor}");
+    let timestamp_for_fingerprint = if timestamp.trim().is_empty() {
+        "-"
+    } else {
+        timestamp.as_str()
+    };
+    let secondary_fingerprint = format!(
+        "{timestamp_for_fingerprint}::{title_for_fingerprint}::{diff}::{score}::{bad}::{poor}"
+    );
 
     Ok(LatestRecord {
         timestamp,
@@ -460,6 +467,21 @@ fn map_diff_to_chart(diff: &str) -> Option<(&'static str, &'static str)> {
         "DPH" => Some(("DP", "HYPER")),
         "DPA" => Some(("DP", "ANOTHER")),
         "DPL" => Some(("DP", "LEGGENDARIA")),
+        _ => None,
+    }
+}
+
+fn normalize_chart_difficulty(raw_difficulty: &str) -> Option<&'static str> {
+    let normalized = raw_difficulty
+        .trim()
+        .to_ascii_uppercase()
+        .replace([' ', '-', '_'], "");
+    match normalized.as_str() {
+        "B" | "BEGINNER" | "SPB" | "DPB" => Some("BEGINNER"),
+        "N" | "NORMAL" | "NOVICE" | "SPN" | "DPN" => Some("NORMAL"),
+        "H" | "HYPER" | "SPH" | "DPH" => Some("HYPER"),
+        "A" | "ANOTHER" | "SPA" | "DPA" => Some("ANOTHER"),
+        "L" | "LEGGENDARIA" | "SPL" | "DPL" => Some("LEGGENDARIA"),
         _ => None,
     }
 }
@@ -567,7 +589,7 @@ fn load_alias_catalog() -> AliasCatalog {
         let Some(play_style) = normalize_play_style(chart.play_style.as_str()) else {
             continue;
         };
-        let Some((_, difficulty)) = map_diff_to_chart(chart.difficulty.as_str()) else {
+        let Some(difficulty) = normalize_chart_difficulty(chart.difficulty.as_str()) else {
             continue;
         };
         let title_search_key = chart.title_search_key.trim();
@@ -974,6 +996,52 @@ mod tests {
     }
 
     #[test]
+    fn reflux_parser_allows_same_tuple_when_timestamp_changes() {
+        let temp_dir = create_temp_dir("reflux-dedupe-timestamp");
+        let latest_path = temp_dir.join("latest.json");
+        let tracker_path = temp_dir.join("tracker.tsv");
+
+        write_file(
+            &tracker_path,
+            "title\tDPL Lamp\tDPL EX Score\tDPL Miss Count\n",
+        );
+        write_file(
+            &latest_path,
+            r#"{"timestamp":"20260320-100000","title":"Song A","title2":"Song A Alt","diff":"DPL","exscore":"2000","bad":"5","poor":"6","assist":"OFF","lamp":"AC","playtype":"DP","gaugepercent":"88"}"#,
+        );
+
+        let mut parser = RefluxParser::new_with_catalog(
+            &SourcePathsConfig {
+                reflux_latest_json: latest_path.to_string_lossy().into_owned(),
+                reflux_tracker_tsv: tracker_path.to_string_lossy().into_owned(),
+                ..SourcePathsConfig::default()
+            },
+            build_catalog(&[("Song A", "Song A", "DP", "LEGGENDARIA")]),
+        );
+
+        let first = parser
+            .parse(&ParserInput {
+                changed_path: latest_path.clone(),
+            })
+            .expect("first parse should succeed");
+        assert!(first.is_some());
+
+        write_file(
+            &latest_path,
+            r#"{"timestamp":"20260320-100500","title":"Song A","title2":"Song A Alt","diff":"DPL","exscore":"2000","bad":"5","poor":"6","assist":"OFF","lamp":"AC","playtype":"DP","gaugepercent":"99"}"#,
+        );
+
+        let second = parser
+            .parse(&ParserInput {
+                changed_path: latest_path.clone(),
+            })
+            .expect("second parse should succeed");
+        assert!(second.is_some());
+
+        let _ = fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
     fn parse_tracker_cache_prefers_higher_score_then_lower_bp() {
         let catalog = build_catalog(&[("Song A", "Song A", "DP", "LEGGENDARIA")]);
         let cache = parse_tracker_cache(
@@ -997,6 +1065,14 @@ mod tests {
                 misscount: Some(20),
             })
         );
+    }
+
+    #[test]
+    fn normalize_chart_difficulty_accepts_master_labels() {
+        assert_eq!(super::normalize_chart_difficulty("ANOTHER"), Some("ANOTHER"));
+        assert_eq!(super::normalize_chart_difficulty("hyper"), Some("HYPER"));
+        assert_eq!(super::normalize_chart_difficulty("spn"), Some("NORMAL"));
+        assert_eq!(super::normalize_chart_difficulty("dpl"), Some("LEGGENDARIA"));
     }
 
     fn assert_source_meta_extras(

--- a/apps/client/src-tauri/src/parsers/reflux.rs
+++ b/apps/client/src-tauri/src/parsers/reflux.rs
@@ -1,0 +1,1074 @@
+use std::{
+    collections::{HashMap, HashSet},
+    env, fs,
+    hash::{DefaultHasher, Hash, Hasher},
+    path::{Path, PathBuf},
+    thread,
+    time::Duration,
+};
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::{
+    models::{
+        ParsedSourceChange, ParsedSourceObservation, ParsedSourceUnresolvedCase,
+        ParsedSourceUnresolvedCaseKind, SourcePathsConfig, SourceType,
+    },
+    parsers::{ParserInput, SourceParser},
+};
+
+const LATEST_DEBOUNCE_MS: u64 = 120;
+const LATEST_PARSE_RETRY_COUNT: usize = 2;
+const LATEST_PARSE_RETRY_DELAY_MS: u64 = 80;
+
+const DIFF_CODES: [&str; 10] = [
+    "SPB", "SPN", "SPH", "SPA", "SPL", "DPB", "DPN", "DPH", "DPA", "DPL",
+];
+
+#[derive(Clone, Debug, Deserialize)]
+struct WorkerChartMasterSnapshot {
+    #[serde(default)]
+    charts: Vec<WorkerChartMasterChart>,
+    #[serde(default)]
+    aliases: HashMap<String, String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct WorkerChartMasterChart {
+    play_style: String,
+    difficulty: String,
+    title: String,
+    title_search_key: String,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct ChartIndexKey {
+    play_style: String,
+    difficulty: String,
+    title_search_key: String,
+}
+
+#[derive(Clone, Debug, Default)]
+struct AliasCatalog {
+    alias_to_title_search_keys: HashMap<String, Vec<String>>,
+    chart_index: HashSet<ChartIndexKey>,
+}
+
+impl AliasCatalog {
+    fn has_alias_exact(&self, raw_alias: &str) -> bool {
+        let alias = raw_alias.trim();
+        !alias.is_empty() && self.alias_to_title_search_keys.contains_key(alias)
+    }
+
+    fn resolve_chart_candidates_exact(
+        &self,
+        raw_alias: &str,
+        play_style: &str,
+        difficulty: &str,
+    ) -> Vec<String> {
+        let alias = raw_alias.trim();
+        if alias.is_empty() {
+            return Vec::new();
+        }
+
+        let Some(title_search_keys) = self.alias_to_title_search_keys.get(alias) else {
+            return Vec::new();
+        };
+
+        title_search_keys
+            .iter()
+            .filter(|title_search_key| {
+                self.chart_index.contains(&ChartIndexKey {
+                    play_style: play_style.to_string(),
+                    difficulty: difficulty.to_string(),
+                    title_search_key: (*title_search_key).clone(),
+                })
+            })
+            .cloned()
+            .collect()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct TrackerBestEntry {
+    score: u32,
+    misscount: Option<u32>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct TrackerCache {
+    best_by_chart: HashMap<ChartIndexKey, TrackerBestEntry>,
+}
+
+#[derive(Clone, Debug)]
+struct LatestRecord {
+    timestamp: String,
+    title: String,
+    title2: String,
+    play_style: String,
+    difficulty: String,
+    score: u32,
+    misscount: u32,
+    secondary_fingerprint: String,
+}
+
+#[derive(Clone, Debug)]
+struct TitleResolutionAttempt {
+    has_alias: bool,
+    candidates: Vec<String>,
+}
+
+pub struct RefluxParser {
+    latest_path: PathBuf,
+    latest_path_key: String,
+    tracker_path: PathBuf,
+    tracker_path_key: String,
+    alias_catalog: AliasCatalog,
+    tracker_cache: TrackerCache,
+    last_content_hash: Option<u64>,
+    last_secondary_fingerprint: Option<String>,
+}
+
+impl RefluxParser {
+    pub fn new(source_paths: &SourcePathsConfig) -> Self {
+        Self::new_internal(source_paths, load_alias_catalog())
+    }
+
+    #[cfg(test)]
+    fn new_with_catalog(source_paths: &SourcePathsConfig, alias_catalog: AliasCatalog) -> Self {
+        Self::new_internal(source_paths, alias_catalog)
+    }
+
+    fn new_internal(source_paths: &SourcePathsConfig, alias_catalog: AliasCatalog) -> Self {
+        let latest_path = PathBuf::from(source_paths.reflux_latest_json.trim());
+        let tracker_path = PathBuf::from(source_paths.reflux_tracker_tsv.trim());
+        let tracker_cache =
+            load_tracker_cache(&tracker_path, &alias_catalog).unwrap_or_else(|error| {
+                eprintln!(
+                    "reflux: tracker.tsv initial load failed ({}): {error}",
+                    tracker_path.to_string_lossy()
+                );
+                TrackerCache::default()
+            });
+
+        Self {
+            latest_path_key: path_key(&latest_path),
+            latest_path,
+            tracker_path_key: path_key(&tracker_path),
+            tracker_path,
+            alias_catalog,
+            tracker_cache,
+            last_content_hash: None,
+            last_secondary_fingerprint: None,
+        }
+    }
+
+    fn reload_tracker_cache(&mut self) {
+        match load_tracker_cache(&self.tracker_path, &self.alias_catalog) {
+            Ok(cache) => {
+                self.tracker_cache = cache;
+            }
+            Err(error) => {
+                eprintln!(
+                    "reflux: tracker.tsv reload failed ({}): {error}",
+                    self.tracker_path.to_string_lossy()
+                );
+                self.tracker_cache = TrackerCache::default();
+            }
+        }
+    }
+}
+
+impl SourceParser for RefluxParser {
+    fn parse(&mut self, input: &ParserInput) -> Result<Option<ParsedSourceChange>, String> {
+        let metadata = fs::metadata(&input.changed_path)
+            .map_err(|error| format!("Failed to read {:?}: {error}", input.changed_path))?;
+        let changed_path_key = path_key(&input.changed_path);
+
+        if changed_path_key == self.tracker_path_key {
+            self.reload_tracker_cache();
+            return Ok(None);
+        }
+
+        if changed_path_key != self.latest_path_key {
+            return Ok(None);
+        }
+
+        thread::sleep(Duration::from_millis(LATEST_DEBOUNCE_MS));
+        let Some((raw_json, latest)) = read_latest_with_retry(&self.latest_path)? else {
+            return Ok(None);
+        };
+
+        let content_hash = hash_text(&raw_json);
+        if self.last_content_hash == Some(content_hash) {
+            return Ok(None);
+        }
+        if self.last_secondary_fingerprint.as_deref() == Some(latest.secondary_fingerprint.as_str())
+        {
+            self.last_content_hash = Some(content_hash);
+            return Ok(None);
+        }
+        self.last_content_hash = Some(content_hash);
+        self.last_secondary_fingerprint = Some(latest.secondary_fingerprint.clone());
+
+        let resolution = resolve_title_search_key(&latest, &self.alias_catalog);
+        match resolution {
+            Ok(title_search_key) => {
+                let chart_key = ChartIndexKey {
+                    play_style: latest.play_style.clone(),
+                    difficulty: latest.difficulty.clone(),
+                    title_search_key: title_search_key.clone(),
+                };
+                let best = self.tracker_cache.best_by_chart.get(&chart_key);
+
+                let mut source_meta_extras = HashMap::new();
+                source_meta_extras.insert(
+                    "best_score".to_string(),
+                    best.map(|entry| Value::from(entry.score))
+                        .unwrap_or(Value::Null),
+                );
+                source_meta_extras.insert(
+                    "best_misscount".to_string(),
+                    best.and_then(|entry| entry.misscount)
+                        .map(Value::from)
+                        .unwrap_or(Value::Null),
+                );
+                source_meta_extras.insert("current_score".to_string(), Value::from(latest.score));
+                source_meta_extras.insert(
+                    "current_misscount".to_string(),
+                    Value::from(latest.misscount),
+                );
+
+                Ok(Some(ParsedSourceChange {
+                    source: SourceType::Reflux,
+                    file_path: self.latest_path.to_string_lossy().into_owned(),
+                    file_size_bytes: metadata.len(),
+                    observations: vec![ParsedSourceObservation {
+                        timestamp: latest.timestamp,
+                        play_style: Some(latest.play_style),
+                        difficulty: latest.difficulty,
+                        title: latest.title,
+                        title_search_key,
+                        score: latest.score,
+                        misscount: latest.misscount,
+                        source_meta_extras: Some(source_meta_extras),
+                    }],
+                    unresolved_cases: Vec::new(),
+                }))
+            }
+            Err((unresolved_title, candidate_count)) => Ok(Some(ParsedSourceChange {
+                source: SourceType::Reflux,
+                file_path: self.latest_path.to_string_lossy().into_owned(),
+                file_size_bytes: metadata.len(),
+                observations: Vec::new(),
+                unresolved_cases: vec![ParsedSourceUnresolvedCase {
+                    kind: ParsedSourceUnresolvedCaseKind::UnresolvedAlias,
+                    timestamp: latest.timestamp,
+                    play_style: latest.play_style,
+                    difficulty: latest.difficulty,
+                    title: unresolved_title,
+                    title_search_key: None,
+                    score: Some(latest.score),
+                    misscount: Some(latest.misscount),
+                    recent_candidate_count: Some(candidate_count),
+                }],
+            })),
+        }
+    }
+}
+
+fn read_latest_with_retry(path: &Path) -> Result<Option<(String, LatestRecord)>, String> {
+    if !path.exists() {
+        return Err(format!(
+            "Failed to read {}: file does not exist.",
+            path.to_string_lossy()
+        ));
+    }
+
+    for attempt in 0..=LATEST_PARSE_RETRY_COUNT {
+        let raw_json = fs::read_to_string(path)
+            .map_err(|error| format!("Failed to read {}: {error}", path.to_string_lossy()))?;
+        match parse_latest_record(&raw_json) {
+            Ok(parsed) => return Ok(Some((raw_json, parsed))),
+            Err(error) => {
+                if attempt < LATEST_PARSE_RETRY_COUNT {
+                    thread::sleep(Duration::from_millis(LATEST_PARSE_RETRY_DELAY_MS));
+                    continue;
+                }
+                eprintln!(
+                    "reflux: ignored latest.json update because it is not readable yet ({}): {error}",
+                    path.to_string_lossy()
+                );
+                return Ok(None);
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+fn parse_latest_record(raw_json: &str) -> Result<LatestRecord, String> {
+    let root: Value = serde_json::from_str(raw_json)
+        .map_err(|error| format!("Failed to parse latest.json payload: {error}"))?;
+    let object = root
+        .as_object()
+        .ok_or_else(|| "latest.json root is not a JSON object.".to_string())?;
+
+    let title = read_optional_text(object, "title");
+    let title2 = read_optional_text(object, "title2");
+    if title.is_empty() && title2.is_empty() {
+        return Err("latest.json is missing both title and title2.".to_string());
+    }
+
+    let diff = read_required_text(object, "diff")?;
+    let (play_style, difficulty) = map_diff_to_chart(diff.as_str())
+        .ok_or_else(|| format!("latest.json contains unsupported diff: {diff}"))?;
+
+    let score = parse_required_u32(object, "exscore")?;
+    let bad = parse_required_u32(object, "bad")?;
+    let poor = parse_required_u32(object, "poor")?;
+    let assist = read_optional_text(object, "assist");
+    let lamp = read_optional_text(object, "lamp");
+    let playtype = read_optional_text(object, "playtype");
+    let timestamp = read_optional_text(object, "timestamp");
+
+    if let Some(playtype_style) = normalize_play_style(playtype.as_str()) {
+        if playtype_style != play_style {
+            eprintln!(
+                "reflux warning: playtype mismatch (diff={diff}, playtype={}, title={})",
+                playtype,
+                if title.is_empty() {
+                    title2.as_str()
+                } else {
+                    title.as_str()
+                }
+            );
+        }
+    }
+
+    let misscount = if is_assist_enabled(assist.as_str()) || is_failed_lamp(lamp.as_str()) {
+        9999
+    } else {
+        bad.saturating_add(poor)
+    };
+
+    let title_for_fingerprint = if title.is_empty() {
+        title2.as_str()
+    } else {
+        title.as_str()
+    };
+    let secondary_fingerprint = format!("{title_for_fingerprint}::{diff}::{score}::{bad}::{poor}");
+
+    Ok(LatestRecord {
+        timestamp,
+        title: if title.is_empty() {
+            title2.clone()
+        } else {
+            title
+        },
+        title2,
+        play_style: play_style.to_string(),
+        difficulty: difficulty.to_string(),
+        score,
+        misscount,
+        secondary_fingerprint,
+    })
+}
+
+fn read_required_text(
+    object: &serde_json::Map<String, Value>,
+    field_name: &str,
+) -> Result<String, String> {
+    let value = read_optional_text(object, field_name);
+    if value.is_empty() {
+        return Err(format!("latest.json is missing field '{field_name}'."));
+    }
+    Ok(value)
+}
+
+fn read_optional_text(object: &serde_json::Map<String, Value>, field_name: &str) -> String {
+    let Some(value) = object.get(field_name) else {
+        return String::new();
+    };
+    match value {
+        Value::String(raw) => raw.trim().to_string(),
+        Value::Number(number) => number.to_string(),
+        Value::Bool(boolean) => {
+            if *boolean {
+                "true".to_string()
+            } else {
+                "false".to_string()
+            }
+        }
+        _ => String::new(),
+    }
+}
+
+fn parse_required_u32(
+    object: &serde_json::Map<String, Value>,
+    field_name: &str,
+) -> Result<u32, String> {
+    let Some(value) = object.get(field_name) else {
+        return Err(format!("latest.json is missing field '{field_name}'."));
+    };
+    parse_u32_value(value)
+        .ok_or_else(|| format!("latest.json field '{field_name}' is not a non-negative integer."))
+}
+
+fn parse_u32_value(value: &Value) -> Option<u32> {
+    match value {
+        Value::Number(number) => {
+            if let Some(raw) = number.as_u64() {
+                u32::try_from(raw).ok()
+            } else if let Some(raw) = number.as_i64() {
+                if raw < 0 {
+                    None
+                } else {
+                    u32::try_from(raw as u64).ok()
+                }
+            } else {
+                None
+            }
+        }
+        Value::String(raw) => parse_optional_u32_text(raw),
+        _ => None,
+    }
+}
+
+fn parse_optional_u32_text(raw: &str) -> Option<u32> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed == "-" {
+        return None;
+    }
+    if !trimmed.chars().all(|character| character.is_ascii_digit()) {
+        return None;
+    }
+    trimmed.parse::<u32>().ok()
+}
+
+fn map_diff_to_chart(diff: &str) -> Option<(&'static str, &'static str)> {
+    let normalized = diff.trim().to_ascii_uppercase();
+    match normalized.as_str() {
+        "SPB" => Some(("SP", "BEGINNER")),
+        "SPN" => Some(("SP", "NORMAL")),
+        "SPH" => Some(("SP", "HYPER")),
+        "SPA" => Some(("SP", "ANOTHER")),
+        "SPL" => Some(("SP", "LEGGENDARIA")),
+        "DPB" => Some(("DP", "BEGINNER")),
+        "DPN" => Some(("DP", "NORMAL")),
+        "DPH" => Some(("DP", "HYPER")),
+        "DPA" => Some(("DP", "ANOTHER")),
+        "DPL" => Some(("DP", "LEGGENDARIA")),
+        _ => None,
+    }
+}
+
+fn normalize_play_style(raw_play_style: &str) -> Option<&'static str> {
+    match raw_play_style.trim().to_ascii_uppercase().as_str() {
+        "SP" | "SINGLE" | "SINGLEPLAY" => Some("SP"),
+        "DP" | "DOUBLE" | "DOUBLEPLAY" => Some("DP"),
+        _ => None,
+    }
+}
+
+fn is_assist_enabled(raw_assist: &str) -> bool {
+    let normalized = raw_assist.trim().to_ascii_uppercase();
+    !normalized.is_empty() && normalized != "OFF"
+}
+
+fn is_failed_lamp(raw_lamp: &str) -> bool {
+    matches!(
+        raw_lamp.trim().to_ascii_uppercase().as_str(),
+        "F" | "FAILED"
+    )
+}
+
+fn resolve_title_search_key(
+    latest: &LatestRecord,
+    catalog: &AliasCatalog,
+) -> Result<String, (String, u32)> {
+    let primary_title = latest.title.trim();
+    let fallback_title = latest.title2.trim();
+
+    let primary_attempt = resolve_title_attempt(
+        catalog,
+        primary_title,
+        latest.play_style.as_str(),
+        latest.difficulty.as_str(),
+    );
+    if primary_attempt.has_alias {
+        return choose_candidate(primary_title, primary_attempt);
+    }
+
+    let fallback_attempt = resolve_title_attempt(
+        catalog,
+        fallback_title,
+        latest.play_style.as_str(),
+        latest.difficulty.as_str(),
+    );
+    if fallback_attempt.has_alias {
+        return choose_candidate(fallback_title, fallback_attempt);
+    }
+
+    let unresolved_title = if !primary_title.is_empty() {
+        primary_title.to_string()
+    } else {
+        fallback_title.to_string()
+    };
+    Err((unresolved_title, 0))
+}
+
+fn resolve_title_attempt(
+    catalog: &AliasCatalog,
+    raw_title: &str,
+    play_style: &str,
+    difficulty: &str,
+) -> TitleResolutionAttempt {
+    let has_alias = catalog.has_alias_exact(raw_title);
+    let candidates = if has_alias {
+        catalog.resolve_chart_candidates_exact(raw_title, play_style, difficulty)
+    } else {
+        Vec::new()
+    };
+    TitleResolutionAttempt {
+        has_alias,
+        candidates,
+    }
+}
+
+fn choose_candidate(
+    unresolved_title: &str,
+    attempt: TitleResolutionAttempt,
+) -> Result<String, (String, u32)> {
+    match attempt.candidates.as_slice() {
+        [single] => Ok(single.clone()),
+        _ => Err((
+            unresolved_title.to_string(),
+            attempt.candidates.len().try_into().unwrap_or(u32::MAX),
+        )),
+    }
+}
+
+fn load_alias_catalog() -> AliasCatalog {
+    let raw_json = include_str!("../../../../worker/src/master/generated/iidx-song-master.json");
+    let snapshot = match serde_json::from_str::<WorkerChartMasterSnapshot>(raw_json) {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            eprintln!("reflux: failed to load alias catalog from chart master: {error}");
+            return AliasCatalog::default();
+        }
+    };
+
+    let mut alias_to_title_search_keys = HashMap::new();
+    let mut chart_index = HashSet::new();
+
+    for chart in &snapshot.charts {
+        let Some(play_style) = normalize_play_style(chart.play_style.as_str()) else {
+            continue;
+        };
+        let Some((_, difficulty)) = map_diff_to_chart(chart.difficulty.as_str()) else {
+            continue;
+        };
+        let title_search_key = chart.title_search_key.trim();
+        if title_search_key.is_empty() {
+            continue;
+        }
+
+        chart_index.insert(ChartIndexKey {
+            play_style: play_style.to_string(),
+            difficulty: difficulty.to_string(),
+            title_search_key: title_search_key.to_string(),
+        });
+        insert_alias_mapping(
+            &mut alias_to_title_search_keys,
+            chart.title.as_str(),
+            title_search_key,
+        );
+    }
+
+    for (alias, title_search_key) in &snapshot.aliases {
+        insert_alias_mapping(&mut alias_to_title_search_keys, alias, title_search_key);
+    }
+
+    AliasCatalog {
+        alias_to_title_search_keys,
+        chart_index,
+    }
+}
+
+fn insert_alias_mapping(
+    alias_to_title_search_keys: &mut HashMap<String, Vec<String>>,
+    raw_alias: &str,
+    raw_title_search_key: &str,
+) {
+    let alias = raw_alias.trim();
+    let title_search_key = raw_title_search_key.trim();
+    if alias.is_empty() || title_search_key.is_empty() {
+        return;
+    }
+
+    let entry = alias_to_title_search_keys
+        .entry(alias.to_string())
+        .or_default();
+    if !entry.iter().any(|value| value == title_search_key) {
+        entry.push(title_search_key.to_string());
+    }
+}
+
+#[derive(Clone, Debug)]
+struct DiffColumnIndices {
+    play_style: &'static str,
+    difficulty: &'static str,
+    lamp_index: usize,
+    score_index: usize,
+    misscount_index: usize,
+}
+
+fn load_tracker_cache(path: &Path, catalog: &AliasCatalog) -> Result<TrackerCache, String> {
+    if !path.exists() {
+        return Err(format!(
+            "Failed to read {}: file does not exist.",
+            path.to_string_lossy()
+        ));
+    }
+    let raw_tsv = fs::read_to_string(path)
+        .map_err(|error| format!("Failed to read {}: {error}", path.to_string_lossy()))?;
+    parse_tracker_cache(&raw_tsv, catalog)
+}
+
+fn parse_tracker_cache(raw_tsv: &str, catalog: &AliasCatalog) -> Result<TrackerCache, String> {
+    let mut lines = raw_tsv.lines();
+    let header = lines
+        .next()
+        .ok_or_else(|| "tracker.tsv is missing a header row.".to_string())?;
+    let columns = header.split('\t').collect::<Vec<_>>();
+    let title_index = find_header_index(&columns, "title")
+        .ok_or_else(|| "tracker.tsv header is missing 'title'.".to_string())?;
+
+    let diff_indices = DIFF_CODES
+        .iter()
+        .filter_map(|diff| {
+            let (play_style, difficulty) = map_diff_to_chart(diff)?;
+            let lamp_index = find_header_index(&columns, format!("{diff} Lamp").as_str())?;
+            let score_index = find_header_index(&columns, format!("{diff} EX Score").as_str())?;
+            let misscount_index =
+                find_header_index(&columns, format!("{diff} Miss Count").as_str())?;
+            Some(DiffColumnIndices {
+                play_style,
+                difficulty,
+                lamp_index,
+                score_index,
+                misscount_index,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    if diff_indices.is_empty() {
+        return Err("tracker.tsv header does not contain chart columns.".to_string());
+    }
+
+    let mut best_by_chart = HashMap::new();
+    for line in lines {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let row = line.split('\t').collect::<Vec<_>>();
+        let title = row.get(title_index).copied().unwrap_or("").trim();
+        if title.is_empty() {
+            continue;
+        }
+
+        for diff in &diff_indices {
+            let raw_score = row.get(diff.score_index).copied().unwrap_or("");
+            let Some(score) = parse_optional_u32_text(raw_score) else {
+                continue;
+            };
+
+            let raw_lamp = row.get(diff.lamp_index).copied().unwrap_or("");
+            let raw_misscount = row.get(diff.misscount_index).copied().unwrap_or("");
+            let misscount = normalize_tracker_misscount(raw_lamp, raw_misscount);
+
+            let candidates =
+                catalog.resolve_chart_candidates_exact(title, diff.play_style, diff.difficulty);
+            if candidates.len() != 1 {
+                continue;
+            }
+            let title_search_key = candidates[0].clone();
+            let key = ChartIndexKey {
+                play_style: diff.play_style.to_string(),
+                difficulty: diff.difficulty.to_string(),
+                title_search_key,
+            };
+            let next = TrackerBestEntry { score, misscount };
+            match best_by_chart.get(&key).copied() {
+                Some(current) => {
+                    if is_better_tracker_entry(next, current) {
+                        best_by_chart.insert(key, next);
+                    }
+                }
+                None => {
+                    best_by_chart.insert(key, next);
+                }
+            }
+        }
+    }
+
+    Ok(TrackerCache { best_by_chart })
+}
+
+fn normalize_tracker_misscount(raw_lamp: &str, raw_misscount: &str) -> Option<u32> {
+    if is_failed_lamp(raw_lamp) {
+        return Some(9999);
+    }
+
+    let normalized = raw_misscount.trim();
+    if normalized == "-" {
+        return Some(9999);
+    }
+    parse_optional_u32_text(normalized)
+}
+
+fn is_better_tracker_entry(next: TrackerBestEntry, current: TrackerBestEntry) -> bool {
+    if next.score != current.score {
+        return next.score > current.score;
+    }
+    normalized_bp_rank(next.misscount) < normalized_bp_rank(current.misscount)
+}
+
+fn normalized_bp_rank(misscount: Option<u32>) -> u32 {
+    misscount.unwrap_or(u32::MAX)
+}
+
+fn find_header_index(columns: &[&str], target: &str) -> Option<usize> {
+    columns
+        .iter()
+        .position(|column| column.trim().eq_ignore_ascii_case(target))
+}
+
+fn hash_text(raw_text: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    raw_text.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn path_key(path: &Path) -> String {
+    let normalized = path
+        .canonicalize()
+        .unwrap_or_else(|_| {
+            if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                env::current_dir()
+                    .map(|current_dir| current_dir.join(path))
+                    .unwrap_or_else(|_| path.to_path_buf())
+            }
+        })
+        .to_string_lossy()
+        .replace('/', "\\");
+
+    normalized
+        .strip_prefix("\\\\?\\UNC\\")
+        .map(|remainder| format!("\\\\{remainder}"))
+        .or_else(|| normalized.strip_prefix("\\\\?\\").map(str::to_string))
+        .unwrap_or(normalized)
+        .to_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{HashMap, HashSet},
+        env, fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use serde_json::Value;
+
+    use crate::{
+        models::{ParsedSourceObservation, ParsedSourceUnresolvedCaseKind, SourcePathsConfig},
+        parsers::{
+            reflux::{
+                parse_tracker_cache, AliasCatalog, ChartIndexKey, RefluxParser, TrackerBestEntry,
+            },
+            ParserInput, SourceParser,
+        },
+    };
+
+    #[test]
+    fn reflux_parser_emits_observation_with_tracker_best_values() {
+        let temp_dir = create_temp_dir("reflux-observation");
+        let latest_path = temp_dir.join("latest.json");
+        let tracker_path = temp_dir.join("tracker.tsv");
+
+        write_file(
+            &tracker_path,
+            "title\tDPL Lamp\tDPL EX Score\tDPL Miss Count\nSong A\tAC\t2700\t11\n",
+        );
+        write_file(
+            &latest_path,
+            r#"{"title":"Song A","title2":"Song A Alt","diff":"DPL","exscore":"2653","bad":"4","poor":"13","assist":"OFF","lamp":"AC","playtype":"DP"}"#,
+        );
+
+        let mut parser = RefluxParser::new_with_catalog(
+            &SourcePathsConfig {
+                reflux_latest_json: latest_path.to_string_lossy().into_owned(),
+                reflux_tracker_tsv: tracker_path.to_string_lossy().into_owned(),
+                ..SourcePathsConfig::default()
+            },
+            build_catalog(&[("Song A", "Song A", "DP", "LEGGENDARIA")]),
+        );
+
+        let parsed_change = parser
+            .parse(&ParserInput {
+                changed_path: latest_path.clone(),
+            })
+            .expect("parse should succeed")
+            .expect("parse should emit a change");
+
+        assert!(parsed_change.unresolved_cases.is_empty());
+        assert_eq!(parsed_change.observations.len(), 1);
+
+        let observation = &parsed_change.observations[0];
+        assert_eq!(observation.play_style.as_deref(), Some("DP"));
+        assert_eq!(observation.difficulty, "LEGGENDARIA");
+        assert_eq!(observation.title_search_key, "Song A");
+        assert_eq!(observation.score, 2653);
+        assert_eq!(observation.misscount, 17);
+        assert_source_meta_extras(observation, Some(2700), Some(11), 2653, 17);
+
+        let _ = fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn reflux_parser_uses_title2_when_title_alias_is_missing() {
+        let temp_dir = create_temp_dir("reflux-title2");
+        let latest_path = temp_dir.join("latest.json");
+        let tracker_path = temp_dir.join("tracker.tsv");
+
+        write_file(
+            &tracker_path,
+            "title\tDPL Lamp\tDPL EX Score\tDPL Miss Count\n",
+        );
+        write_file(
+            &latest_path,
+            r#"{"title":"Unknown Song","title2":"Song A Alt","diff":"DPL","exscore":"2300","bad":"1","poor":"2","assist":"OFF","lamp":"AC","playtype":"DP"}"#,
+        );
+
+        let mut parser = RefluxParser::new_with_catalog(
+            &SourcePathsConfig {
+                reflux_latest_json: latest_path.to_string_lossy().into_owned(),
+                reflux_tracker_tsv: tracker_path.to_string_lossy().into_owned(),
+                ..SourcePathsConfig::default()
+            },
+            build_catalog(&[("Song A Alt", "Song A", "DP", "LEGGENDARIA")]),
+        );
+
+        let parsed_change = parser
+            .parse(&ParserInput {
+                changed_path: latest_path.clone(),
+            })
+            .expect("parse should succeed")
+            .expect("parse should emit a change");
+
+        assert!(parsed_change.unresolved_cases.is_empty());
+        assert_eq!(parsed_change.observations.len(), 1);
+        assert_eq!(parsed_change.observations[0].title_search_key, "Song A");
+
+        let _ = fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn reflux_parser_emits_unresolved_alias_when_chart_is_not_unique() {
+        let temp_dir = create_temp_dir("reflux-unresolved");
+        let latest_path = temp_dir.join("latest.json");
+        let tracker_path = temp_dir.join("tracker.tsv");
+
+        write_file(
+            &tracker_path,
+            "title\tDPL Lamp\tDPL EX Score\tDPL Miss Count\n",
+        );
+        write_file(
+            &latest_path,
+            r#"{"title":"Song A","title2":"Song A Alt","diff":"DPL","exscore":"2100","bad":"3","poor":"4","assist":"OFF","lamp":"AC","playtype":"DP"}"#,
+        );
+
+        let mut parser = RefluxParser::new_with_catalog(
+            &SourcePathsConfig {
+                reflux_latest_json: latest_path.to_string_lossy().into_owned(),
+                reflux_tracker_tsv: tracker_path.to_string_lossy().into_owned(),
+                ..SourcePathsConfig::default()
+            },
+            build_catalog(&[
+                ("Song A", "Song A#1", "DP", "LEGGENDARIA"),
+                ("Song A", "Song A#2", "DP", "LEGGENDARIA"),
+            ]),
+        );
+
+        let parsed_change = parser
+            .parse(&ParserInput {
+                changed_path: latest_path.clone(),
+            })
+            .expect("parse should succeed")
+            .expect("parse should emit a change");
+
+        assert!(parsed_change.observations.is_empty());
+        assert_eq!(parsed_change.unresolved_cases.len(), 1);
+        assert_eq!(
+            parsed_change.unresolved_cases[0].kind,
+            ParsedSourceUnresolvedCaseKind::UnresolvedAlias
+        );
+        assert_eq!(
+            parsed_change.unresolved_cases[0].recent_candidate_count,
+            Some(2)
+        );
+
+        let _ = fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn reflux_parser_skips_repeated_payloads_by_fingerprint() {
+        let temp_dir = create_temp_dir("reflux-dedupe");
+        let latest_path = temp_dir.join("latest.json");
+        let tracker_path = temp_dir.join("tracker.tsv");
+
+        write_file(
+            &tracker_path,
+            "title\tDPL Lamp\tDPL EX Score\tDPL Miss Count\n",
+        );
+        write_file(
+            &latest_path,
+            r#"{"title":"Song A","title2":"Song A Alt","diff":"DPL","exscore":"2000","bad":"5","poor":"6","assist":"OFF","lamp":"AC","playtype":"DP","gaugepercent":"88"}"#,
+        );
+
+        let mut parser = RefluxParser::new_with_catalog(
+            &SourcePathsConfig {
+                reflux_latest_json: latest_path.to_string_lossy().into_owned(),
+                reflux_tracker_tsv: tracker_path.to_string_lossy().into_owned(),
+                ..SourcePathsConfig::default()
+            },
+            build_catalog(&[("Song A", "Song A", "DP", "LEGGENDARIA")]),
+        );
+
+        let first = parser
+            .parse(&ParserInput {
+                changed_path: latest_path.clone(),
+            })
+            .expect("first parse should succeed");
+        assert!(first.is_some());
+
+        write_file(
+            &latest_path,
+            r#"{"title":"Song A","title2":"Song A Alt","diff":"DPL","exscore":"2000","bad":"5","poor":"6","assist":"OFF","lamp":"AC","playtype":"DP","gaugepercent":"99"}"#,
+        );
+
+        let second = parser
+            .parse(&ParserInput {
+                changed_path: latest_path.clone(),
+            })
+            .expect("second parse should succeed");
+        assert!(second.is_none());
+
+        let _ = fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn parse_tracker_cache_prefers_higher_score_then_lower_bp() {
+        let catalog = build_catalog(&[("Song A", "Song A", "DP", "LEGGENDARIA")]);
+        let cache = parse_tracker_cache(
+            "title\tDPL Lamp\tDPL EX Score\tDPL Miss Count\n\
+            Song A\tAC\t2400\t40\n\
+            Song A\tAC\t2500\t30\n\
+            Song A\tAC\t2500\t20\n",
+            &catalog,
+        )
+        .expect("tracker cache should parse");
+
+        let key = ChartIndexKey {
+            play_style: "DP".to_string(),
+            difficulty: "LEGGENDARIA".to_string(),
+            title_search_key: "Song A".to_string(),
+        };
+        assert_eq!(
+            cache.best_by_chart.get(&key).copied(),
+            Some(TrackerBestEntry {
+                score: 2500,
+                misscount: Some(20),
+            })
+        );
+    }
+
+    fn assert_source_meta_extras(
+        observation: &ParsedSourceObservation,
+        expected_best_score: Option<u32>,
+        expected_best_misscount: Option<u32>,
+        expected_current_score: u32,
+        expected_current_misscount: u32,
+    ) {
+        let extras = observation
+            .source_meta_extras
+            .as_ref()
+            .expect("source_meta_extras should be present");
+        assert_eq!(
+            read_optional_u32(extras.get("best_score")),
+            expected_best_score
+        );
+        assert_eq!(
+            read_optional_u32(extras.get("best_misscount")),
+            expected_best_misscount
+        );
+        assert_eq!(
+            read_optional_u32(extras.get("current_score")),
+            Some(expected_current_score)
+        );
+        assert_eq!(
+            read_optional_u32(extras.get("current_misscount")),
+            Some(expected_current_misscount)
+        );
+    }
+
+    fn read_optional_u32(value: Option<&Value>) -> Option<u32> {
+        match value {
+            Some(Value::Number(number)) => number.as_u64().and_then(|raw| u32::try_from(raw).ok()),
+            Some(Value::Null) | None => None,
+            _ => None,
+        }
+    }
+
+    fn build_catalog(entries: &[(&str, &str, &str, &str)]) -> AliasCatalog {
+        let mut alias_to_title_search_keys: HashMap<String, Vec<String>> = HashMap::new();
+        let mut chart_index = HashSet::new();
+
+        for (alias, title_search_key, play_style, difficulty) in entries {
+            alias_to_title_search_keys
+                .entry((*alias).to_string())
+                .or_default()
+                .push((*title_search_key).to_string());
+            chart_index.insert(ChartIndexKey {
+                play_style: (*play_style).to_string(),
+                difficulty: (*difficulty).to_string(),
+                title_search_key: (*title_search_key).to_string(),
+            });
+        }
+
+        AliasCatalog {
+            alias_to_title_search_keys,
+            chart_index,
+        }
+    }
+
+    fn create_temp_dir(prefix: &str) -> PathBuf {
+        let unique_suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before epoch")
+            .as_nanos();
+        let temp_dir = env::temp_dir().join(format!("infinitas-arena-{prefix}-{unique_suffix}"));
+        fs::create_dir_all(&temp_dir).expect("temp dir should be created");
+        temp_dir
+    }
+
+    fn write_file(path: &PathBuf, contents: &str) {
+        fs::write(path, contents).expect("fixture file should be written");
+    }
+}

--- a/apps/client/src-tauri/src/watchers/mod.rs
+++ b/apps/client/src-tauri/src/watchers/mod.rs
@@ -417,6 +417,10 @@ fn resolve_watched_files(
                 "inf-notebook / records/summary.json",
             )?])
         }
+        SourceType::Reflux => Ok(vec![
+            require_path(&source_paths.reflux_latest_json, "Reflux / latest.json")?,
+            require_path(&source_paths.reflux_tracker_tsv, "Reflux / tracker.tsv")?,
+        ]),
     }
 }
 

--- a/apps/client/src/components/SourceUnresolvedDialog.tsx
+++ b/apps/client/src/components/SourceUnresolvedDialog.tsx
@@ -46,7 +46,7 @@ export function SourceUnresolvedDialog({ dialog, onAction }: SourceUnresolvedDia
           aria-labelledby="source-unresolved-title"
         >
           <div className="border-b border-white/10 p-6 text-center">
-            <p className="mb-3 text-[10px] font-black uppercase tracking-[0.35em] text-amber-300">inf-notebook</p>
+            <p className="mb-3 text-[10px] font-black uppercase tracking-[0.35em] text-amber-300">{`source=${dialog.originLabel}`}</p>
             <h2 id="source-unresolved-title" className="text-2xl font-black tracking-tight text-white">
               登録先の譜面が一致しません
             </h2>
@@ -100,7 +100,7 @@ export function SourceUnresolvedDialog({ dialog, onAction }: SourceUnresolvedDia
           aria-labelledby="source-unresolved-title"
         >
           <div className="p-6 text-center">
-            <p className="mb-3 text-[10px] font-black uppercase tracking-[0.35em] text-slate-300">inf-notebook</p>
+            <p className="mb-3 text-[10px] font-black uppercase tracking-[0.35em] text-slate-300">{`source=${dialog.originLabel}`}</p>
             <h2 id="source-unresolved-title" className="text-2xl font-black tracking-tight text-white">
               スコアを特定できませんでした
             </h2>
@@ -141,7 +141,7 @@ export function SourceUnresolvedDialog({ dialog, onAction }: SourceUnresolvedDia
           aria-labelledby="source-unresolved-title"
         >
           <div className="p-6 text-center">
-            <p className="mb-3 text-[10px] font-black uppercase tracking-[0.35em] text-amber-300">inf-notebook</p>
+            <p className="mb-3 text-[10px] font-black uppercase tracking-[0.35em] text-amber-300">{`source=${dialog.originLabel}`}</p>
             <h2 id="source-unresolved-title" className="text-2xl font-black tracking-tight text-white">
               譜面を特定できませんでした
             </h2>
@@ -183,7 +183,7 @@ export function SourceUnresolvedDialog({ dialog, onAction }: SourceUnresolvedDia
         aria-labelledby="source-unresolved-title"
       >
         <div className="p-6 text-center">
-          <p className="mb-3 text-[10px] font-black uppercase tracking-[0.35em] text-red-300">inf-notebook</p>
+          <p className="mb-3 text-[10px] font-black uppercase tracking-[0.35em] text-red-300">{`source=${dialog.originLabel}`}</p>
           <h2 id="source-unresolved-title" className="text-2xl font-black tracking-tight text-white">
             スコアを一意に特定できませんでした
           </h2>

--- a/apps/client/src/dev/visual-scenarios.ts
+++ b/apps/client/src/dev/visual-scenarios.ts
@@ -68,10 +68,13 @@ const BASE_SETTINGS: Omit<ClientSettings, "playerId" | "displayName" | "source" 
     dakenTodayUpdateXml: "",
     notebookExportRecentJson: "",
     notebookRecordsRecentJson: "",
+    refluxLatestJson: "",
+    refluxTrackerTsv: "",
   },
   sourceDirectories: {
     dakenDirectory: "",
     notebookDirectory: "",
+    refluxDirectory: "",
   },
   voiceEnabled: true,
   voiceVolume: 80,

--- a/apps/client/src/pages/SettingsPage.tsx
+++ b/apps/client/src/pages/SettingsPage.tsx
@@ -44,6 +44,14 @@ const SOURCE_OPTIONS = [
     directoryPlaceholder: "C:\\Users\\you\\Documents\\inf-notebook",
   },
   {
+    id: "reflux" as const,
+    name: "Reflux",
+    description: "latest.json を監視",
+    usesDirectory: true,
+    directoryLabel: "Reflux Directory (contains Reflux.exe)",
+    directoryPlaceholder: "C:\\Users\\you\\Documents\\Reflux",
+  },
+  {
     id: "daken_counter_v3" as const,
     name: "打鍵カウンタv3",
     description: "ローカルWebSocket (today_updates) を監視",
@@ -505,6 +513,8 @@ export function SettingsPage({ roomJoined, onNavigateToLobby }: SettingsPageProp
                 ? `LOBBY入場時に ws://localhost:${draft.dakenCounterV3Port} へ接続します。PLAYING開始時に接続確認し、失敗時は「${DAKEN_COUNTER_V3_CONNECTION_WARNING}」を表示します。`
                 : draft.source === "inf_daken_counter"
                 ? "選択したフォルダ配下の today_update.xml を自動で監視します。"
+                : draft.source === "reflux"
+                ? "選択したフォルダ配下の latest.json を監視し、tracker.tsv からベスト値を補完します。"
                 : "選択したフォルダ配下の records/summary.json を監視し、export/recent.json から score/misscount を補完します。"}
             </p>
             {validationMessage ? <p className="text-sm font-semibold text-red-400">{validationMessage}</p> : null}

--- a/apps/client/src/runtime/runtime-config.ts
+++ b/apps/client/src/runtime/runtime-config.ts
@@ -4,6 +4,8 @@ export interface RuntimeSourcePathDefaults {
   dakenTodayUpdateXml: string | undefined;
   notebookExportRecentJson: string | undefined;
   notebookRecordsRecentJson: string | undefined;
+  refluxLatestJson: string | undefined;
+  refluxTrackerTsv: string | undefined;
 }
 
 export interface RuntimeSettingsDefaults {
@@ -129,6 +131,8 @@ export const runtimeConfig: RuntimeConfig = {
       dakenTodayUpdateXml: readSearchParam("dakenPath"),
       notebookExportRecentJson: readSearchParam("notebookPath"),
       notebookRecordsRecentJson: readSearchParam("recordsPath"),
+      refluxLatestJson: readSearchParam("refluxLatestPath"),
+      refluxTrackerTsv: readSearchParam("refluxTrackerPath"),
     },
   },
 };

--- a/apps/client/src/stores/settings-store.ts
+++ b/apps/client/src/stores/settings-store.ts
@@ -15,11 +15,14 @@ export interface SourcePaths {
   dakenTodayUpdateXml: string;
   notebookExportRecentJson: string;
   notebookRecordsRecentJson: string;
+  refluxLatestJson: string;
+  refluxTrackerTsv: string;
 }
 
 export interface SourceDirectories {
   dakenDirectory: string;
   notebookDirectory: string;
+  refluxDirectory: string;
 }
 
 export interface ClientSettings {
@@ -66,6 +69,8 @@ function createDefaultSourcePaths(): SourcePaths {
     dakenTodayUpdateXml: "",
     notebookExportRecentJson: "",
     notebookRecordsRecentJson: "",
+    refluxLatestJson: "",
+    refluxTrackerTsv: "",
   };
 }
 
@@ -73,6 +78,7 @@ function createDefaultSourceDirectories(): SourceDirectories {
   return {
     dakenDirectory: "",
     notebookDirectory: "",
+    refluxDirectory: "",
   };
 }
 
@@ -188,6 +194,15 @@ function extractNotebookDirectory(paths: Partial<SourcePaths>): string {
 
 function deriveSourceDirectories(paths: Partial<SourcePaths>): SourceDirectories {
   const dakenCandidate = paths.dakenTodayUpdateXml?.trim() ?? "";
+  const refluxCandidate = paths.refluxLatestJson?.trim() || paths.refluxTrackerTsv?.trim() || "";
+  const refluxBaseDirectory =
+    refluxCandidate.length === 0
+      ? ""
+      : normalizeDirectory(
+          refluxCandidate
+            .replace(/[\\/]latest\.json$/i, "")
+            .replace(/[\\/]tracker\.tsv$/i, ""),
+        ) || extractParentDirectory(refluxCandidate);
 
   return {
     dakenDirectory:
@@ -195,6 +210,7 @@ function deriveSourceDirectories(paths: Partial<SourcePaths>): SourceDirectories
         ? ""
         : normalizeDirectory(dakenCandidate.replace(/[\\/]today_update\.xml$/i, "")) || extractParentDirectory(dakenCandidate),
     notebookDirectory: extractNotebookDirectory(paths),
+    refluxDirectory: refluxBaseDirectory,
   };
 }
 
@@ -212,6 +228,14 @@ export function deriveSourcePaths(sourceDirectories: SourceDirectories): SourceP
       sourceDirectories.notebookDirectory.length === 0
         ? ""
         : joinPath(sourceDirectories.notebookDirectory, ["records", "summary.json"]),
+    refluxLatestJson:
+      sourceDirectories.refluxDirectory.length === 0
+        ? ""
+        : joinPath(sourceDirectories.refluxDirectory, ["latest.json"]),
+    refluxTrackerTsv:
+      sourceDirectories.refluxDirectory.length === 0
+        ? ""
+        : joinPath(sourceDirectories.refluxDirectory, ["tracker.tsv"]),
   };
 }
 
@@ -247,6 +271,8 @@ function createDefaultSettings(): ClientSettings {
     dakenTodayUpdateXml: runtimeConfig.settingsDefaults.sourcePaths.dakenTodayUpdateXml ?? "",
     notebookExportRecentJson: runtimeConfig.settingsDefaults.sourcePaths.notebookExportRecentJson ?? "",
     notebookRecordsRecentJson: runtimeConfig.settingsDefaults.sourcePaths.notebookRecordsRecentJson ?? "",
+    refluxLatestJson: runtimeConfig.settingsDefaults.sourcePaths.refluxLatestJson ?? "",
+    refluxTrackerTsv: runtimeConfig.settingsDefaults.sourcePaths.refluxTrackerTsv ?? "",
   };
   const sourceDirectories = {
     ...createDefaultSourceDirectories(),
@@ -283,6 +309,9 @@ function normalizeSettings(rawSettings: PartialClientSettings | null): ClientSet
   }
   if (rawSettings?.sourceDirectories?.notebookDirectory !== undefined) {
     normalizedRawDirectories.notebookDirectory = normalizeDirectory(rawSettings.sourceDirectories.notebookDirectory);
+  }
+  if (rawSettings?.sourceDirectories?.refluxDirectory !== undefined) {
+    normalizedRawDirectories.refluxDirectory = normalizeDirectory(rawSettings.sourceDirectories.refluxDirectory);
   }
   const pathHints: SourcePaths = {
     ...defaults.sourcePaths,
@@ -331,6 +360,10 @@ export function getActiveSourceDirectory(settings: Pick<ClientSettings, "source"
 
   if (settings.source === "inf-notebook") {
     return settings.sourceDirectories.notebookDirectory;
+  }
+
+  if (settings.source === "reflux") {
+    return settings.sourceDirectories.refluxDirectory;
   }
 
   return "";
@@ -417,6 +450,11 @@ export const settingsStore = {
               ...state.draft.sourceDirectories,
               dakenDirectory: normalizeDirectory(directory),
             }
+          : source === "reflux"
+            ? {
+                ...state.draft.sourceDirectories,
+                refluxDirectory: normalizeDirectory(directory),
+              }
           : {
               ...state.draft.sourceDirectories,
               notebookDirectory: normalizeDirectory(directory),

--- a/apps/client/src/stores/source-store.ts
+++ b/apps/client/src/stores/source-store.ts
@@ -123,6 +123,13 @@ const DAKEN_COUNTER_V3_WARNING_MESSAGE =
 const DAKEN_COUNTER_V3_HISTORY_LIMIT = 512;
 const DAKEN_COUNTER_V3_RECONNECT_DELAY_MS = 2000;
 
+function formatSourceOriginLabel(source: SourceType): string {
+  if (source === "reflux") {
+    return "Reflux";
+  }
+  return source;
+}
+
 const initialState: SourceStoreState = {
   watcherState: {
     status: "IDLE",
@@ -848,6 +855,7 @@ function buildUnresolvedDialogsFromParserOutput(
     return [];
   }
 
+  const originLabel = formatSourceOriginLabel(parserOutput.source);
   const unresolvedCases = parserOutput.unresolvedCases ?? [];
   const dialogs: SourceUnresolvedDialog[] = [];
   for (const unresolvedCase of unresolvedCases) {
@@ -856,7 +864,7 @@ function buildUnresolvedDialogsFromParserOutput(
         id: nextUnresolvedDialogId(),
         kind: "unresolved_alias_catalog",
         source: parserOutput.source,
-        originLabel: parserOutput.source,
+        originLabel,
         chart: buildDialogChartInfo(unresolvedCase, metricContext),
         errorCode: "NB-UNRESOLVED-ALIAS",
       });
@@ -868,7 +876,7 @@ function buildUnresolvedDialogsFromParserOutput(
         id: nextUnresolvedDialogId(),
         kind: "resolved_partial",
         source: parserOutput.source,
-        originLabel: parserOutput.source,
+        originLabel,
         chart: buildDialogChartInfo(unresolvedCase, metricContext),
       });
       continue;
@@ -879,7 +887,7 @@ function buildUnresolvedDialogsFromParserOutput(
         id: nextUnresolvedDialogId(),
         kind: "ambiguous_recent",
         source: parserOutput.source,
-        originLabel: parserOutput.source,
+        originLabel,
         chart: buildDialogChartInfo(unresolvedCase, metricContext),
         candidateCount: Math.max(2, unresolvedCase.recentCandidateCount ?? 2),
         errorCode: "NB-AMBIGUOUS-RECENT",
@@ -892,6 +900,7 @@ function buildUnresolvedDialogsFromParserOutput(
 
 function buildUnresolvedAliasDialog(
   source: SourceType,
+  originLabel: string,
   pending: {
     expectedTarget: NotebookDialogChartInfo;
     parsedResult: NotebookDialogChartInfo;
@@ -903,7 +912,7 @@ function buildUnresolvedAliasDialog(
     id: nextUnresolvedDialogId(),
     kind: "unresolved_alias",
     source,
-    originLabel: source,
+    originLabel,
     expectedTarget: pending.expectedTarget,
     parsedResult: pending.parsedResult,
     mismatchReason: pending.mismatchReason,
@@ -974,11 +983,16 @@ function handleWatcherEvent(payload: SourceWatcherEventPayload): void {
     return;
   }
 
+  const originLabel = formatSourceOriginLabel(payload.parserOutput.source);
   const unresolvedDialogs = buildUnresolvedDialogsFromParserOutput(payload.parserOutput);
-  const outcome = submitParsedSourceChange(payload.parserOutput, payload.parserOutput.source);
+  const outcome = submitParsedSourceChange(payload.parserOutput, originLabel);
   if (outcome.pendingUnresolvedAlias) {
     unresolvedDialogs.push(
-      buildUnresolvedAliasDialog(payload.parserOutput.source, outcome.pendingUnresolvedAlias),
+      buildUnresolvedAliasDialog(
+        payload.parserOutput.source,
+        originLabel,
+        outcome.pendingUnresolvedAlias,
+      ),
     );
   }
 
@@ -1000,6 +1014,14 @@ function getMissingPathMessage(source: SourceType, paths: SourcePaths): string |
 
   if (source === "inf-notebook" && paths.notebookRecordsRecentJson.trim().length === 0) {
     return "Set inf-notebook / records/summary.json before starting the watcher.";
+  }
+
+  if (source === "reflux" && paths.refluxLatestJson.trim().length === 0) {
+    return "Set Reflux / latest.json before starting the watcher.";
+  }
+
+  if (source === "reflux" && paths.refluxTrackerTsv.trim().length === 0) {
+    return "Set Reflux / tracker.tsv before starting the watcher.";
   }
 
   return null;
@@ -1095,7 +1117,7 @@ export const sourceStore = {
       }
     } else if (activeDialog.kind === "resolved_partial") {
       roomStore.noteLocalEvent(
-        "Source auto-submit skipped: inf-notebook resolved_partial requires re-registration.",
+        `Source auto-submit skipped: ${activeDialog.originLabel} resolved_partial requires re-registration.`,
       );
     } else if (activeDialog.kind === "unresolved_alias_catalog") {
       roomStore.noteLocalEvent(

--- a/packages/shared/src/enums/source.ts
+++ b/packages/shared/src/enums/source.ts
@@ -1,3 +1,3 @@
-export const SOURCE_TYPES = ["inf_daken_counter", "inf-notebook", "daken_counter_v3"] as const;
+export const SOURCE_TYPES = ["inf_daken_counter", "inf-notebook", "daken_counter_v3", "reflux"] as const;
 
 export type SourceType = (typeof SOURCE_TYPES)[number];

--- a/tasks/issue-95-reflux.md
+++ b/tasks/issue-95-reflux.md
@@ -1,0 +1,58 @@
+# issue-95-reflux
+
+## Purpose
+- Reflux が出力する `latest.json` と `tracker.tsv` を取り込み、既存の結果送信フローへ統合する。
+- Reflux 由来の未解決譜面を既存 `unresolved_alias` 導線に載せ、`source=Reflux` を表示可能にする。
+
+## Non-goals
+- Worker/DO のWS契約やFSMの仕様変更は行わない。
+- 既存 `inf-notebook` / `inf_daken_counter` の取り込み仕様を変更しない。
+- Reflux 以外の外部ツール追加や設定画面の広域リファクタは行わない。
+
+## Changes
+- 設定モデル/設定UIに Reflux 用ディレクトリ設定（`Reflux.exe` 同居フォルダ指定）を追加し、`latest.json` / `tracker.tsv` の存在検証を実装する。
+- Reflux `latest.json` 監視処理を追加し、短時間待機 + 安全読込 + 重複送信抑止（内容ハッシュ主判定）を実装する。
+- `tracker.tsv` の全読込キャッシュと更新時再読込を実装し、ベストスコア/ベストBPを譜面単位で解決する。
+- `title` 優先 + `title2` フォールバック、`diff` 変換表による譜面同定、`playtype` 不一致時警告ログを実装する。
+- 未解決ケースを既存 `unresolved_alias` 連携へ接続し、UI/内部データ双方で `source=Reflux` を扱えるようにする。
+- 必要な単体テスト/既存テスト更新を追加する。
+
+## Impact
+- Users: Reflux フォルダを設定するだけでリザルト取り込みが可能になる。
+- Data: 設定保存データに Reflux フォルダ情報が追加される可能性がある。
+- Compatibility: 既存設定読込互換を維持しつつ新規設定項目を追加する。
+- Cloudflare: なし（client / shared 中心）。
+
+## Target Files / Layers
+- Files:
+  - `packages/shared/src/enums/source.ts`
+  - `apps/client/src/stores/settings-store.ts`
+  - `apps/client/src/pages/SettingsPage.tsx`
+  - `apps/client/src/stores/source-store.ts`
+  - `apps/client/src/services/*`（監視/パーサ/送信統合の局所差分）
+  - `apps/client/src/components/*`（`unresolved_alias` 表示が必要な場合のみ）
+  - `apps/client/src/**/*.test.ts`（追加/更新）
+- Layers: client / shared
+
+## Test Focus
+- 技術的検証: client build, lint, 変更箇所テスト
+- 監視ソース検証: latest.json 監視、重複抑止、JSON破損耐性、tracker.tsv 再読込
+- 同定検証: title/title2 フォールバック、diff 変換、playtype 不一致警告継続
+- 未解決検証: unresolved_alias 連携と `source=Reflux` 表示
+- 差分検証: 目的ファイル限定、不要整形なし、UTF-8 no BOM / LF 維持
+
+## Rollback Plan
+- Reflux 追加差分（設定・監視・パーサ・UI表示）を一括revertし、既存2ソースのみ運用へ戻す。
+
+## Commit Split Plan
+1. shared/client の設定モデルとUIに Reflux 設定を追加し、入力検証と永続化を実装
+2. Reflux 監視/パース/同定/ベスト値解決を既存送信経路へ統合
+3. unresolved_alias 表示拡張とテスト整備
+
+## Checklist
+- [x] Design doc alignment confirmed (if required)
+- [x] Impact scope identified
+- [x] Implementation completed
+- [x] Tests completed
+- [x] Regression checks completed
+- [x] Documentation updates completed (if required)


### PR DESCRIPTION
## 目的
- Reflux の `latest.json` / `tracker.tsv` を監視ソースとして追加し、既存の結果送信フローへ統合します。
- Reflux 由来の未解決ケースを既存 `unresolved_alias` 導線へ載せ、`source=Reflux` を UI 表示できるようにします。

## 変更点
- shared/client の SourceType と settings に `reflux` を追加
- Settings で Reflux フォルダ（`Reflux.exe` 同居フォルダ）を指定し、`latest.json` / `tracker.tsv` を自動解決
- Tauri 側 watcher/validation に Reflux パス要件を追加
- Reflux 専用 parser を新規追加
  - `latest.json` デバウンス + リトライ読込
  - `diff` 変換、`title` 優先 + `title2` フォールバック、`playtype` 不一致警告
  - 重複抑止（内容ハッシュ主判定 + 補助 fingerprint）
  - `assist=ON` or `lamp=F` の BP=9999 正規化
  - `tracker.tsv` 全読込キャッシュ + 更新時再読込
  - ベスト値選定（score 最大、同点時 BP 最小）
- unresolved_alias ダイアログで `source=...` を表示し、Reflux を識別可能化

## テスト
- `npm run typecheck:client`
- `npm run lint`
- `cargo test reflux --manifest-path apps/client/src-tauri/Cargo.toml`

Closes #95