### PR TITLE
feat: 演出SEのデフォルト設定とルーム内一時上書きを追加

### DIFF
--- a/apps/client/src/dev/visual-scenarios.ts
+++ b/apps/client/src/dev/visual-scenarios.ts
@@ -79,6 +79,7 @@ const BASE_SETTINGS: Omit<ClientSettings, "playerId" | "displayName" | "source" 
   voiceEnabled: true,
   voiceVolume: 80,
   voiceMuted: false,
+  enablePresentationSe: true,
   bitUnlockEnabled: false,
   djpUnlockEnabled: false,
   ownedPackIds: [],

--- a/apps/client/src/pages/RoomPage.tsx
+++ b/apps/client/src/pages/RoomPage.tsx
@@ -15,6 +15,7 @@ import {
   AlertTriangle,
   Database,
   ShieldAlert,
+  Volume2,
 } from "lucide-react";
 import { useDeferredValue, useEffect, useRef, useState, type ReactNode } from "react";
 import { DebugInjectionPanel } from "../components/DebugInjectionPanel";
@@ -43,7 +44,13 @@ import {
 import { runtimeConfig } from "../runtime/runtime-config";
 import { useLocalResultArchiveStore } from "../services/result-archive";
 import { listCharts, listRoomCharts } from "../services/worker-api-client";
-import { playLobbyNotificationSound, useVoicePlaybackStore } from "../services/voice-announcer";
+import {
+  clearRoomPresentationSeOverride,
+  getRoomPresentationSeOverride,
+  playLobbyNotificationSound,
+  setRoomPresentationSeOverride,
+  useVoicePlaybackStore,
+} from "../services/voice-announcer";
 import { roomStore, useRoomStore, type RoomConnectionStatus } from "../stores/room-store";
 import { isVoicePlaybackEnabled, useSettingsStore } from "../stores/settings-store";
 import { formatDateTime, stringifyJson } from "../utils/format";
@@ -634,6 +641,8 @@ export function RoomPage() {
   const [copiedRoomId, setCopiedRoomId] = useState(false);
   const [copiedJoinCode, setCopiedJoinCode] = useState(false);
   const [showHostLeaveConfirm, setShowHostLeaveConfirm] = useState(false);
+  const [showRoomAudioMenu, setShowRoomAudioMenu] = useState(false);
+  const [roomPresentationSeEnabled, setRoomPresentationSeEnabled] = useState(savedSettings.enablePresentationSe);
   const [arenaLobbyLogs, setArenaLobbyLogs] = useState<RoomArenaLogEntry[]>([]);
   const [pendingOwnPickCutIn, setPendingOwnPickCutIn] = useState<ChartSearchEntry | null>(null);
   const [ownPickCutInChart, setOwnPickCutInChart] = useState<ChartSearchEntry | null>(null);
@@ -1021,11 +1030,31 @@ export function RoomPage() {
   useEffect(() => {
     setPendingOwnPickCutIn(null);
     setOwnPickCutInChart(null);
+    setShowRoomAudioMenu(false);
     if (cutInTimeoutRef.current !== null) {
       window.clearTimeout(cutInTimeoutRef.current);
       cutInTimeoutRef.current = null;
     }
   }, [snapshot?.room_id]);
+
+  useEffect(() => {
+    if (snapshot === null) {
+      clearRoomPresentationSeOverride();
+      return;
+    }
+
+    const roomOverride = getRoomPresentationSeOverride(snapshot.room_id);
+    setRoomPresentationSeEnabled(roomOverride ?? savedSettings.enablePresentationSe);
+  }, [savedSettings.enablePresentationSe, snapshot?.room_id]);
+
+  useEffect(() => {
+    const roomId = roomStore.getState().snapshot?.room_id ?? null;
+    if (roomId === null) {
+      return;
+    }
+
+    setRoomPresentationSeOverride(roomId, roomPresentationSeEnabled);
+  }, [roomPresentationSeEnabled]);
 
   useEffect(() => {
     if (pendingOwnPickCutIn === null || mySubmittedPick?.pick_chart_key !== pendingOwnPickCutIn.chart_key) {
@@ -1476,6 +1505,7 @@ export function RoomPage() {
     : isVoicePlaybackEnabled(savedSettings)
       ? `Volume ${savedSettings.voiceVolume}`
       : "Sound disabled";
+  const roomPresentationSeStatusLabel = roomPresentationSeEnabled ? "ON" : "OFF";
 
   function requestLeaveRoom(): void {
     if (leaveRoomDisabled) {
@@ -2380,6 +2410,47 @@ export function RoomPage() {
   return (
     <section id="visual-capture-root" className="flex h-full min-h-0 w-full flex-col text-white font-sans">
       {roomSurface}
+
+      {snapshot.room_state !== "CLOSED" ? (
+        <div className="pointer-events-none fixed right-4 top-4 z-[140]">
+          <div className="pointer-events-auto relative">
+            <button
+              type="button"
+              onClick={() => setShowRoomAudioMenu((current) => !current)}
+              className="flex items-center gap-2 rounded-xl border border-white/15 bg-[#111112]/90 px-3 py-2 text-[11px] font-black uppercase tracking-[0.2em] text-gray-200 shadow-[0_12px_24px_rgba(0,0,0,0.45)] backdrop-blur-sm transition-all hover:border-cyan-400/40 hover:text-cyan-200"
+            >
+              <Volume2 size={14} />
+              Room Audio
+            </button>
+            {showRoomAudioMenu ? (
+              <div className="absolute right-0 mt-2 w-[320px] rounded-2xl border border-white/10 bg-[#161618]/95 p-4 shadow-[0_20px_40px_rgba(0,0,0,0.55)] backdrop-blur-sm">
+                <p className="text-[10px] font-black uppercase tracking-[0.3em] text-gray-500">Audio Override</p>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setRoomPresentationSeEnabled((current) => !current);
+                  }}
+                  className={`mt-3 flex w-full items-center justify-between gap-3 rounded-xl border px-4 py-3 text-left transition-all ${
+                    roomPresentationSeEnabled
+                      ? "border-cyan-500/40 bg-cyan-500/10 text-cyan-200"
+                      : "border-white/10 bg-black/20 text-gray-300 hover:border-white/30"
+                  }`}
+                >
+                  <div className="space-y-1">
+                    <p className="text-sm font-bold">演出SEを再生する（この部屋のみ）</p>
+                    <p className="text-xs font-semibold text-gray-500">
+                      退室すると設定画面のデフォルト値に戻ります。
+                    </p>
+                  </div>
+                  <span className="rounded-md border border-white/20 px-2 py-1 text-[10px] font-black uppercase tracking-[0.2em]">
+                    {roomPresentationSeStatusLabel}
+                  </span>
+                </button>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
 
       {runtimeConfig.debugUiEnabled && snapshot.room_state === "PLAYING" && currentRound ? (
         <div className="fixed bottom-6 right-6 z-[160] w-[320px]">

--- a/apps/client/src/pages/SettingsPage.tsx
+++ b/apps/client/src/pages/SettingsPage.tsx
@@ -690,6 +690,26 @@ export function SettingsPage({ roomJoined, onNavigateToLobby }: SettingsPageProp
               <span>Min</span>
               <span>Max</span>
             </div>
+
+            <button
+              type="button"
+              onClick={() => {
+                settingsStore.update("enablePresentationSe", !draft.enablePresentationSe);
+              }}
+              className={`flex w-full items-center justify-between rounded-xl border p-4 text-left transition-all ${
+                draft.enablePresentationSe
+                  ? "border-cyan-500/50 bg-cyan-500/10 text-cyan-300 shadow-[0_0_15px_rgba(6,182,212,0.15)]"
+                  : "border-white/5 bg-[#1e1e1e] text-gray-400 hover:border-white/20"
+              }`}
+            >
+              <div className="space-y-1">
+                <p className="text-sm font-bold">演出SEを再生する</p>
+                <p className="text-[11px] font-semibold text-gray-500">
+                  ルーム入室時の初期値として使われます。
+                </p>
+              </div>
+              {draft.enablePresentationSe ? <CheckSquare size={20} /> : <Square size={20} />}
+            </button>
           </div>
         </section>
 

--- a/apps/client/src/services/voice-announcer.ts
+++ b/apps/client/src/services/voice-announcer.ts
@@ -46,6 +46,19 @@ const SOUND_EFFECT_URLS: Record<SoundEffectKey, string> = {
   error: "/se/error.mp3",
 };
 
+type SoundEffectCategory = "presentation" | "notification";
+
+// Presentation sounds are mood/phase cues. Notification sounds are state awareness cues.
+const SOUND_EFFECT_CATEGORIES: Record<SoundEffectKey, SoundEffectCategory> = {
+  round_intro: "presentation",
+  count_beep: "presentation",
+  match_found: "presentation",
+  phase_locked: "presentation",
+  count_go: "presentation",
+  cancel: "notification",
+  error: "notification",
+};
+
 interface ScheduledCue {
   kind: SoundEffectKey;
   eventId: string;
@@ -85,6 +98,7 @@ let unsubscribeSettingsStore: (() => void) | null = null;
 let activeRoomId: string | null = null;
 let activeRoundToken: string | null = null;
 let activeTimeoutIds: number[] = [];
+let roomPresentationSeOverride: { roomId: string; enabled: boolean } | null = null;
 
 const playedEventIds = new Set<string>();
 const queuedEventIds = new Set<string>();
@@ -106,6 +120,19 @@ function getMasterVolume(): number {
 
 function getEffectiveVolume(volumeMultiplier: number): number {
   return Math.max(0, Math.min(1, getMasterVolume() * volumeMultiplier));
+}
+
+function getSoundEffectCategory(kind: SoundEffectKey): SoundEffectCategory {
+  return SOUND_EFFECT_CATEGORIES[kind];
+}
+
+function isPresentationSeEnabled(): boolean {
+  const roomId = roomStore.getState().snapshot?.room_id ?? null;
+  if (roomId !== null && roomPresentationSeOverride?.roomId === roomId) {
+    return roomPresentationSeOverride.enabled;
+  }
+
+  return settingsStore.getState().saved.enablePresentationSe;
 }
 
 function setVoiceState(partialState: Partial<VoicePlaybackState>): void {
@@ -312,6 +339,24 @@ export async function playLobbyNotificationSound(kind: LobbyNotificationSoundEff
   }
 }
 
+export function getRoomPresentationSeOverride(roomId: string): boolean | null {
+  if (roomPresentationSeOverride?.roomId !== roomId) {
+    return null;
+  }
+
+  return roomPresentationSeOverride.enabled;
+}
+
+export function setRoomPresentationSeOverride(roomId: string, enabled: boolean): void {
+  roomPresentationSeOverride = { roomId, enabled };
+}
+
+export function clearRoomPresentationSeOverride(roomId?: string): void {
+  if (roomId === undefined || roomPresentationSeOverride?.roomId === roomId) {
+    roomPresentationSeOverride = null;
+  }
+}
+
 function clearPlayback(nextPhase: VoicePlaybackPhase, detail: string, enabled: boolean): void {
   if (SOUND_CLEAR_QUEUE_ON_STATE_CHANGE) {
     for (const timeoutId of activeTimeoutIds) {
@@ -430,6 +475,11 @@ function shouldSuppressCue(cue: ScheduledCue): boolean {
 
 async function playCue(cue: ScheduledCue): Promise<void> {
   if (shouldSuppressCue(cue) || !isVoicePlaybackEnabled(settingsStore.getState().saved)) {
+    return;
+  }
+
+  if (getSoundEffectCategory(cue.kind) === "presentation" && !isPresentationSeEnabled()) {
+    playedEventIds.add(cue.eventId);
     return;
   }
 
@@ -579,6 +629,7 @@ export const voiceAnnouncerService = {
     unsubscribeSettingsStore?.();
     unsubscribeRoomStore = null;
     unsubscribeSettingsStore = null;
+    roomPresentationSeOverride = null;
     clearPlayback("IDLE", "Sound cues idle.", isVoicePlaybackEnabled(settingsStore.getState().saved));
   },
 };

--- a/apps/client/src/services/voice-announcer.ts
+++ b/apps/client/src/services/voice-announcer.ts
@@ -52,7 +52,7 @@ type SoundEffectCategory = "presentation" | "notification";
 const SOUND_EFFECT_CATEGORIES: Record<SoundEffectKey, SoundEffectCategory> = {
   round_intro: "presentation",
   count_beep: "presentation",
-  match_found: "presentation",
+  match_found: "notification",
   phase_locked: "presentation",
   count_go: "presentation",
   cancel: "notification",

--- a/apps/client/src/services/voice-announcer.ts
+++ b/apps/client/src/services/voice-announcer.ts
@@ -50,7 +50,7 @@ type SoundEffectCategory = "presentation" | "notification";
 
 // Presentation sounds are mood/phase cues. Notification sounds are state awareness cues.
 const SOUND_EFFECT_CATEGORIES: Record<SoundEffectKey, SoundEffectCategory> = {
-  round_intro: "presentation",
+  round_intro: "notification",
   count_beep: "presentation",
   match_found: "notification",
   phase_locked: "presentation",

--- a/apps/client/src/stores/settings-store.ts
+++ b/apps/client/src/stores/settings-store.ts
@@ -36,6 +36,7 @@ export interface ClientSettings {
   voiceEnabled: boolean;
   voiceVolume: number;
   voiceMuted: boolean;
+  enablePresentationSe: boolean;
   bitUnlockEnabled: boolean;
   djpUnlockEnabled: boolean;
   ownedPackIds: number[];
@@ -59,6 +60,7 @@ interface PartialClientSettings {
   voiceEnabled?: boolean;
   voiceVolume?: number;
   voiceMuted?: boolean;
+  enablePresentationSe?: boolean;
   bitUnlockEnabled?: boolean;
   djpUnlockEnabled?: boolean;
   ownedPackIds?: number[];
@@ -295,6 +297,7 @@ function createDefaultSettings(): ClientSettings {
     voiceEnabled: true,
     voiceVolume: DEFAULT_VOICE_VOLUME,
     voiceMuted: false,
+    enablePresentationSe: true,
     bitUnlockEnabled: false,
     djpUnlockEnabled: false,
     ownedPackIds: [],
@@ -339,6 +342,7 @@ function normalizeSettings(rawSettings: PartialClientSettings | null): ClientSet
     sourcePaths,
     sourceDirectories,
     ...voiceSettings,
+    enablePresentationSe: rawSettings?.enablePresentationSe ?? defaults.enablePresentationSe,
     bitUnlockEnabled: rawSettings?.bitUnlockEnabled === true,
     djpUnlockEnabled: rawSettings?.djpUnlockEnabled === true,
     ownedPackIds,


### PR DESCRIPTION
## 目的
Issue #101 の要件に沿って、演出SEのローカル設定を追加し、ルーム内のみ有効な一時上書きを実装しました。

## 変更点
- Settings の Audio Notice 配下に「演出SEを再生する」トグルを追加（デフォルト ON、永続化）
- 永続設定に enablePresentationSe を追加
- ルーム画面に「演出SEを再生する（この部屋のみ）」トグルを追加
- ルーム入室時に永続設定値で初期化
- ルーム内で切り替えた値を即時反映
- 退室時に一時上書きを破棄（永続設定は変更しない）
- 音再生を presentation / notification に分類し、演出SEのみ新設定で制御
- 通知SE（状態認知用）は従来どおり
- サーバー同期は追加していません（WS payload / DTO / DO 変更なし）

## 非変更
- 選曲時間・各種タイマー
- ラウンド進行ロジック
- WebSocket 仕様
- サーバー保存データ

## 検証
- npm run lint
- npm run typecheck:client
- npm run build:client
- npm run test:client-stats

## 補足
- 既存ユーザーは未設定時フォールバックで ON になるため、初期体験を維持します。