### PR TITLE
LEGGENDARIA 許可設定を追加しマッチ候補抽選へ全経路適用

### DIFF
--- a/apps/client/src/dev/visual-scenarios.ts
+++ b/apps/client/src/dev/visual-scenarios.ts
@@ -82,6 +82,7 @@ const BASE_SETTINGS: Omit<ClientSettings, "playerId" | "displayName" | "source" 
   enablePresentationSe: true,
   bitUnlockEnabled: false,
   djpUnlockEnabled: false,
+  allowLeggendaria: false,
   ownedPackIds: [],
 };
 

--- a/apps/client/src/pages/LobbyPage.tsx
+++ b/apps/client/src/pages/LobbyPage.tsx
@@ -158,6 +158,7 @@ export function LobbyPage() {
         source: savedSettings.source,
         bitUnlockEnabled: savedSettings.bitUnlockEnabled,
         djpUnlockEnabled: savedSettings.djpUnlockEnabled,
+        allowLeggendaria: savedSettings.allowLeggendaria,
         ownedPackIds: savedSettings.ownedPackIds,
       },
     );

--- a/apps/client/src/pages/RoomPage.tsx
+++ b/apps/client/src/pages/RoomPage.tsx
@@ -2593,7 +2593,7 @@ export function RoomPage() {
               </div>
               <div className="rounded-2xl border border-white/10 bg-black/20 p-4 xl:col-span-2">
                 <p className="text-[10px] font-black uppercase tracking-[0.35em] text-gray-500">Song Unlock Filter (START MATCH Fixed)</p>
-                <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+                <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-5">
                   <div className="rounded-xl border border-white/10 bg-white/5 p-3 text-sm font-bold text-gray-300">
                     Fixed: {snapshot.match_song_unlock_filter === null ? "NO" : "YES"}
                   </div>
@@ -2602,6 +2602,9 @@ export function RoomPage() {
                   </div>
                   <div className="rounded-xl border border-white/10 bg-white/5 p-3 text-sm font-bold text-gray-300">
                     DJP: {snapshot.match_song_unlock_filter?.include_djp ? "ON" : "OFF"}
+                  </div>
+                  <div className="rounded-xl border border-white/10 bg-white/5 p-3 text-sm font-bold text-gray-300">
+                    LEGGENDARIA: {snapshot.match_song_unlock_filter?.include_leggendaria ? "ON" : "OFF"}
                   </div>
                   <div className="rounded-xl border border-white/10 bg-white/5 p-3 text-sm font-bold text-gray-300">
                     Common Packs:{" "}
@@ -2618,7 +2621,8 @@ export function RoomPage() {
                     >
                       {player.display_name}: BIT{" "}
                       {player.song_unlocks?.bit_unlocked ? "ON" : "OFF"} / DJP{" "}
-                      {player.song_unlocks?.djp_unlocked ? "ON" : "OFF"} / PACKS{" "}
+                      {player.song_unlocks?.djp_unlocked ? "ON" : "OFF"} / LEGG{" "}
+                      {player.song_unlocks?.allow_leggendaria ? "ON" : "OFF"} / PACKS{" "}
                       {player.song_unlocks?.owned_pack_ids.length
                         ? player.song_unlocks.owned_pack_ids.join(", ")
                         : "-"}

--- a/apps/client/src/pages/SettingsPage.tsx
+++ b/apps/client/src/pages/SettingsPage.tsx
@@ -692,14 +692,14 @@ export function SettingsPage({ roomJoined, onNavigateToLobby }: SettingsPageProp
           </div>
 
           <div className="space-y-6 rounded-2xl border border-white/5 bg-[#252526] p-6">
-            <div className="flex gap-4 border-b border-white/5 pb-6">
+            <div className="grid gap-4 border-b border-white/5 pb-6 md:grid-cols-3">
               <button
                 type="button"
                 disabled={roomJoined}
                 onClick={() => {
                   settingsStore.update("bitUnlockEnabled", !draft.bitUnlockEnabled);
                 }}
-                className={`flex flex-1 items-center justify-between rounded-xl border p-4 transition-all ${
+                className={`flex items-center justify-between rounded-xl border p-4 transition-all ${
                   draft.bitUnlockEnabled
                     ? "border-cyan-500 bg-cyan-500/10 text-cyan-400 shadow-[0_0_15px_rgba(6,182,212,0.15)]"
                     : "border-white/5 bg-[#1e1e1e] text-gray-400 hover:border-white/20"
@@ -714,7 +714,7 @@ export function SettingsPage({ roomJoined, onNavigateToLobby }: SettingsPageProp
                 onClick={() => {
                   settingsStore.update("djpUnlockEnabled", !draft.djpUnlockEnabled);
                 }}
-                className={`flex flex-1 items-center justify-between rounded-xl border p-4 transition-all ${
+                className={`flex items-center justify-between rounded-xl border p-4 transition-all ${
                   draft.djpUnlockEnabled
                     ? "border-cyan-500 bg-cyan-500/10 text-cyan-400 shadow-[0_0_15px_rgba(6,182,212,0.15)]"
                     : "border-white/5 bg-[#1e1e1e] text-gray-400 hover:border-white/20"
@@ -722,6 +722,21 @@ export function SettingsPage({ roomJoined, onNavigateToLobby }: SettingsPageProp
               >
                 <span className="font-bold">DJP解禁曲</span>
                 {draft.djpUnlockEnabled ? <CheckSquare size={20} /> : <Square size={20} />}
+              </button>
+              <button
+                type="button"
+                disabled={roomJoined}
+                onClick={() => {
+                  settingsStore.update("allowLeggendaria", !draft.allowLeggendaria);
+                }}
+                className={`flex items-center justify-between rounded-xl border p-4 transition-all ${
+                  draft.allowLeggendaria
+                    ? "border-cyan-500 bg-cyan-500/10 text-cyan-400 shadow-[0_0_15px_rgba(6,182,212,0.15)]"
+                    : "border-white/5 bg-[#1e1e1e] text-gray-400 hover:border-white/20"
+                } ${roomJoined ? "cursor-not-allowed opacity-70" : ""}`}
+              >
+                <span className="font-bold">LEGGENDARIA譜面</span>
+                {draft.allowLeggendaria ? <CheckSquare size={20} /> : <Square size={20} />}
               </button>
             </div>
 

--- a/apps/client/src/services/e2e-scenario-runner.ts
+++ b/apps/client/src/services/e2e-scenario-runner.ts
@@ -34,6 +34,7 @@ function buildRoomConnectionSettings() {
     source: settings.source,
     bitUnlockEnabled: settings.bitUnlockEnabled,
     djpUnlockEnabled: settings.djpUnlockEnabled,
+    allowLeggendaria: settings.allowLeggendaria,
     ownedPackIds: settings.ownedPackIds,
   };
 }

--- a/apps/client/src/services/ws-client.ts
+++ b/apps/client/src/services/ws-client.ts
@@ -21,6 +21,7 @@ interface RoomSocketClientOptions {
   source: SourceType;
   bitUnlockEnabled: boolean;
   djpUnlockEnabled: boolean;
+  allowLeggendaria: boolean;
   ownedPackIds: number[];
   joinCode?: string | null;
   onMessage: (message: ServerMessage) => void;
@@ -71,6 +72,7 @@ export class RoomSocketClient {
           song_unlocks: {
             bit_unlocked: this.options.bitUnlockEnabled,
             djp_unlocked: this.options.djpUnlockEnabled,
+            allow_leggendaria: this.options.allowLeggendaria,
             owned_pack_ids: this.options.ownedPackIds,
           },
         },

--- a/apps/client/src/stores/room-store.ts
+++ b/apps/client/src/stores/room-store.ts
@@ -53,6 +53,7 @@ export interface RoomConnectionSettings {
   source: SourceType;
   bitUnlockEnabled: boolean;
   djpUnlockEnabled: boolean;
+  allowLeggendaria: boolean;
   ownedPackIds: number[];
 }
 
@@ -563,6 +564,7 @@ function startSocketConnection(
     source: settings.source,
     bitUnlockEnabled: settings.bitUnlockEnabled,
     djpUnlockEnabled: settings.djpUnlockEnabled,
+    allowLeggendaria: settings.allowLeggendaria,
     ownedPackIds: settings.ownedPackIds,
     joinCode: connection.joinCode,
     onMessage(message) {

--- a/apps/client/src/stores/settings-store.ts
+++ b/apps/client/src/stores/settings-store.ts
@@ -39,6 +39,7 @@ export interface ClientSettings {
   enablePresentationSe: boolean;
   bitUnlockEnabled: boolean;
   djpUnlockEnabled: boolean;
+  allowLeggendaria: boolean;
   ownedPackIds: number[];
 }
 
@@ -63,6 +64,7 @@ interface PartialClientSettings {
   enablePresentationSe?: boolean;
   bitUnlockEnabled?: boolean;
   djpUnlockEnabled?: boolean;
+  allowLeggendaria?: boolean;
   ownedPackIds?: number[];
 }
 
@@ -300,6 +302,7 @@ function createDefaultSettings(): ClientSettings {
     enablePresentationSe: true,
     bitUnlockEnabled: false,
     djpUnlockEnabled: false,
+    allowLeggendaria: false,
     ownedPackIds: [],
   };
 }
@@ -345,6 +348,7 @@ function normalizeSettings(rawSettings: PartialClientSettings | null): ClientSet
     enablePresentationSe: rawSettings?.enablePresentationSe ?? defaults.enablePresentationSe,
     bitUnlockEnabled: rawSettings?.bitUnlockEnabled === true,
     djpUnlockEnabled: rawSettings?.djpUnlockEnabled === true,
+    allowLeggendaria: rawSettings?.allowLeggendaria === true,
     ownedPackIds,
   };
 }

--- a/apps/worker/src/durable/room-object.ts
+++ b/apps/worker/src/durable/room-object.ts
@@ -434,6 +434,7 @@ function parseSongUnlockSettings(rawClientCapabilities: unknown): SongUnlockSett
     return {
       bit_unlocked: false,
       djp_unlocked: false,
+      allow_leggendaria: false,
       owned_pack_ids: [],
     };
   }
@@ -443,6 +444,7 @@ function parseSongUnlockSettings(rawClientCapabilities: unknown): SongUnlockSett
     return {
       bit_unlocked: false,
       djp_unlocked: false,
+      allow_leggendaria: false,
       owned_pack_ids: [],
     };
   }
@@ -450,6 +452,7 @@ function parseSongUnlockSettings(rawClientCapabilities: unknown): SongUnlockSett
   return {
     bit_unlocked: rawSongUnlocks.bit_unlocked === true,
     djp_unlocked: rawSongUnlocks.djp_unlocked === true,
+    allow_leggendaria: rawSongUnlocks.allow_leggendaria === true,
     owned_pack_ids: normalizeOwnedPackIds(rawSongUnlocks.owned_pack_ids),
   };
 }
@@ -1671,6 +1674,7 @@ export class RoomDurableObject {
               match_song_unlock_filter: {
                 include_bit: matchSongUnlockFilter.include_bit,
                 include_djp: matchSongUnlockFilter.include_djp,
+                include_leggendaria: matchSongUnlockFilter.include_leggendaria,
                 common_pack_ids: matchSongUnlockFilter.common_pack_ids,
               },
             }),

--- a/apps/worker/src/durable/room-state.test.mjs
+++ b/apps/worker/src/durable/room-state.test.mjs
@@ -9,7 +9,7 @@ function buildChart(chartKey, titleSearchKey, title, level, options = {}) {
     inf_pack_id: options.inf_pack_id ?? null,
     expected_key: {
       play_style: "SP",
-      difficulty: "HYPER",
+      difficulty: options.difficulty ?? "HYPER",
       title_search_key: titleSearchKey,
     },
     display: {
@@ -27,12 +27,17 @@ function createChartMaster() {
     buildChart("chart-bit", "chart-bit", "Chart Bit", 10, { inf_unlock_type: "bit" }),
     buildChart("chart-djp", "chart-djp", "Chart Djp", 10, { inf_unlock_type: "djp" }),
     buildChart("chart-pack-2", "chart-pack-2", "Chart Pack 2", 10, { inf_unlock_type: "pack", inf_pack_id: 2 }),
+    buildChart("chart-leg", "chart-leg", "Chart Leg", 12, { difficulty: "LEGGENDARIA" }),
   ];
   const chartsByKey = new Map(charts.map((chart) => [chart.chart_key, chart]));
 
   const canUseByUnlockFilter = (chart, unlockFilter) => {
     if (!unlockFilter) {
       return true;
+    }
+
+    if (!unlockFilter.include_leggendaria && chart.expected_key.difficulty === "LEGGENDARIA") {
+      return false;
     }
 
     switch (chart.inf_unlock_type) {
@@ -212,11 +217,13 @@ test("START_MATCH snapshot filter allows only shared unlock conditions", () => {
     host: {
       bit_unlocked: true,
       djp_unlocked: false,
+      allow_leggendaria: true,
       owned_pack_ids: [2, 3],
     },
     guest: {
       bit_unlocked: true,
       djp_unlocked: true,
+      allow_leggendaria: false,
       owned_pack_ids: [2],
     },
   });
@@ -229,6 +236,7 @@ test("START_MATCH snapshot filter allows only shared unlock conditions", () => {
   assert.deepEqual(pickingSnapshot.match_song_unlock_filter, {
     include_bit: true,
     include_djp: false,
+    include_leggendaria: false,
     common_pack_ids: [2],
   });
 
@@ -237,7 +245,59 @@ test("START_MATCH snapshot filter allows only shared unlock conditions", () => {
     state.submitPick("guest", "chart-djp", new Date("2026-03-08T00:01:11.000Z")),
     { ok: false, reason: "INVALID_PICK_CHART_KEY" },
   );
+  assert.deepEqual(
+    state.submitPick("guest", "chart-leg", new Date("2026-03-08T00:01:11.500Z")),
+    { ok: false, reason: "INVALID_PICK_CHART_KEY" },
+  );
   assert.equal(state.submitPick("guest", "chart-pack-2", new Date("2026-03-08T00:01:12.000Z")).ok, true);
+});
+
+test("START_MATCH filter stays fixed after reconnect capability change", () => {
+  const state = createState({}, {
+    host: {
+      bit_unlocked: true,
+      djp_unlocked: true,
+      allow_leggendaria: false,
+      owned_pack_ids: [2],
+    },
+    guest: {
+      bit_unlocked: true,
+      djp_unlocked: true,
+      allow_leggendaria: false,
+      owned_pack_ids: [2],
+    },
+  });
+
+  assert.equal(state.setPlayerReady("host", true).ok, true);
+  assert.equal(state.setPlayerReady("guest", true).ok, true);
+  assert.deepEqual(state.startMatch("host", new Date("2026-03-08T00:01:00.000Z")), { ok: true });
+
+  const startSnapshot = state.toSnapshot();
+  assert.equal(startSnapshot.match_song_unlock_filter?.include_leggendaria, false);
+
+  const disconnected = state.markPlayerDisconnected("guest", new Date("2026-03-08T00:01:10.000Z"));
+  assert.equal(disconnected.changed, true);
+
+  const reconnect = state.joinPlayer({
+    player_id: "guest",
+    display_name: "Guest",
+    source: "inf_daken_counter",
+    song_unlocks: {
+      bit_unlocked: true,
+      djp_unlocked: true,
+      allow_leggendaria: true,
+      owned_pack_ids: [2],
+    },
+    now: new Date("2026-03-08T00:01:12.000Z"),
+  });
+  assert.deepEqual(reconnect, { ok: true, join_type: "RECONNECT" });
+
+  assert.equal(state.submitPick("host", "chart-1", new Date("2026-03-08T00:01:20.000Z")).ok, true);
+  assert.deepEqual(
+    state.submitPick("guest", "chart-leg", new Date("2026-03-08T00:01:21.000Z")),
+    { ok: false, reason: "INVALID_PICK_CHART_KEY" },
+  );
+  assert.equal(state.submitPick("guest", "chart-2", new Date("2026-03-08T00:01:22.000Z")).ok, true);
 });
 
 test("RESULT -> LOBBY clears ready and match transient state without auto-start", () => {

--- a/apps/worker/src/durable/room-state.ts
+++ b/apps/worker/src/durable/room-state.ts
@@ -354,6 +354,7 @@ function normalizeSongUnlockSettings(value: SongUnlockSettings | undefined): Son
   return {
     bit_unlocked: value?.bit_unlocked === true,
     djp_unlocked: value?.djp_unlocked === true,
+    allow_leggendaria: value?.allow_leggendaria === true,
     owned_pack_ids: normalizeOwnedPackIds(value?.owned_pack_ids),
   };
 }
@@ -362,6 +363,7 @@ function cloneSongUnlockSettings(value: SongUnlockSettings): SongUnlockSettings 
   return {
     bit_unlocked: value.bit_unlocked,
     djp_unlocked: value.djp_unlocked,
+    allow_leggendaria: value.allow_leggendaria === true,
     owned_pack_ids: [...value.owned_pack_ids],
   };
 }
@@ -370,6 +372,7 @@ function cloneMatchSongUnlockFilter(value: MatchSongUnlockFilter): MatchSongUnlo
   return {
     include_bit: value.include_bit,
     include_djp: value.include_djp,
+    include_leggendaria: value.include_leggendaria === true,
     common_pack_ids: [...value.common_pack_ids],
   };
 }
@@ -379,12 +382,14 @@ function computeMatchSongUnlockFilter(players: InternalPlayer[]): MatchSongUnloc
     return {
       include_bit: false,
       include_djp: false,
+      include_leggendaria: false,
       common_pack_ids: [],
     };
   }
 
   const includeBit = players.every((player) => player.song_unlocks.bit_unlocked);
   const includeDjp = players.every((player) => player.song_unlocks.djp_unlocked);
+  const includeLeggendaria = players.every((player) => player.song_unlocks.allow_leggendaria);
 
   const commonPackIds = players
     .map((player) => new Set(player.song_unlocks.owned_pack_ids))
@@ -399,6 +404,7 @@ function computeMatchSongUnlockFilter(players: InternalPlayer[]): MatchSongUnloc
   return {
     include_bit: includeBit,
     include_djp: includeDjp,
+    include_leggendaria: includeLeggendaria,
     common_pack_ids: Array.from(commonPackIds).sort((left, right) => left - right),
   };
 }

--- a/apps/worker/src/master/chart-master.test.mjs
+++ b/apps/worker/src/master/chart-master.test.mjs
@@ -240,7 +240,21 @@ test("pickRandomUnusedChart respects preferred options and used chart keys", () 
 });
 
 test("unlock filter applies to search and resolve", () => {
-  const master = createRoomChartMaster(createSnapshot());
+  const snapshot = createSnapshot();
+  snapshot.charts.push({
+    chart_id: 105,
+    play_style: "SP",
+    difficulty: "LEGGENDARIA",
+    level: 12,
+    title: "Legend Star",
+    title_qualifier: "",
+    artist: "Unit C",
+    genre: "HARDCORE",
+    title_search_key: "legend star",
+    inf_unlock_type: "initial",
+    inf_pack_id: null,
+  });
+  const master = createRoomChartMaster(snapshot);
 
   const filteredSearch = master.searchCharts({
     play_style: "SP",
@@ -248,6 +262,7 @@ test("unlock filter applies to search and resolve", () => {
     unlock_filter: {
       include_bit: true,
       include_djp: false,
+      include_leggendaria: false,
       common_pack_ids: [],
     },
   });
@@ -263,6 +278,7 @@ test("unlock filter applies to search and resolve", () => {
     {
       include_bit: true,
       include_djp: false,
+      include_leggendaria: false,
       common_pack_ids: [],
     },
   );
@@ -275,8 +291,24 @@ test("unlock filter applies to search and resolve", () => {
     {
       include_bit: true,
       include_djp: false,
+      include_leggendaria: false,
       common_pack_ids: [],
     },
   );
   assert.equal(rejected, null);
+
+  const leggendariaAllowed = master.searchCharts({
+    play_style: "SP",
+    level_filter: "ANY",
+    unlock_filter: {
+      include_bit: true,
+      include_djp: false,
+      include_leggendaria: true,
+      common_pack_ids: [],
+    },
+  });
+  assert.equal(
+    leggendariaAllowed.charts.some((chart) => chart.chart_key === "SP::LEGGENDARIA::legend star"),
+    true,
+  );
 });

--- a/apps/worker/src/master/chart-master.ts
+++ b/apps/worker/src/master/chart-master.ts
@@ -205,6 +205,10 @@ function canUseChartByUnlockFilter(
     return true;
   }
 
+  if (!unlockFilter.include_leggendaria && chart.difficulty === "LEGGENDARIA") {
+    return false;
+  }
+
   switch (normalizeUnlockType(chart.inf_unlock_type)) {
     case "initial":
       return true;

--- a/docs/design/02_ws_protocol.md
+++ b/docs/design/02_ws_protocol.md
@@ -46,7 +46,7 @@
 - `ROOM_JOIN`
   - payload: `{ join_code?: string, display_name: string, source: "inf_daken_counter"|"inf-notebook"|"daken_counter_v3"|"reflux", client_version?: string, client_capabilities?: object }`
   - 備考: WS接続直後に必ず送る（DOがJOIN完了するまでstate配信しない）
-  - 備考: `client_capabilities.song_unlocks = { bit_unlocked: boolean, djp_unlocked: boolean, owned_pack_ids: number[] }` を送ると、`START_MATCH` 時の共通解禁フィルタ計算に利用される
+  - 備考: `client_capabilities.song_unlocks = { bit_unlocked: boolean, djp_unlocked: boolean, allow_leggendaria: boolean, owned_pack_ids: number[] }` を送ると、`START_MATCH` 時の共通解禁フィルタ計算に利用される
 - `ROOM_LEAVE`
   - payload: `{}`
 
@@ -165,9 +165,9 @@
   "settings": { "...": "..." },
   "host_player_id": "string",
   "players": [
-    { "player_id": "string", "display_name": "string", "source": "inf_daken_counter|inf-notebook|daken_counter_v3|reflux", "song_unlocks": { "bit_unlocked": false, "djp_unlocked": false, "owned_pack_ids": [] }, "connected": true, "ready": false }
+    { "player_id": "string", "display_name": "string", "source": "inf_daken_counter|inf-notebook|daken_counter_v3|reflux", "song_unlocks": { "bit_unlocked": false, "djp_unlocked": false, "allow_leggendaria": false, "owned_pack_ids": [] }, "connected": true, "ready": false }
   ],
-  "match_song_unlock_filter": { "include_bit": false, "include_djp": false, "common_pack_ids": [] },
+  "match_song_unlock_filter": { "include_bit": false, "include_djp": false, "include_leggendaria": false, "common_pack_ids": [] },
   "picks": [
     { "player_id": "string", "pick_chart_key": "string", "accepted_at": "ISO8601" }
   ],

--- a/docs/design/03_data_model.md
+++ b/docs/design/03_data_model.md
@@ -28,7 +28,7 @@
 - `closed_at: datetime|null`
 - `close_reason: ALL_ROUNDS_COMPLETED|MATCH_TTL_EXPIRED|READY_CHECK_TTL_EXPIRED|HOST_DISCONNECTED|HOST_ABORTED|PICKING_ABORTED|FORCE_CLOSED|null`
 - `result_ready_payload: object|null`（`RESULT` 中は保持し、`RESULT -> LOBBY` 復帰時にクリア。`summary.is_rated / rated_block_reason / rating_*` を含む）
-- `match_song_unlock_filter: { include_bit: bool, include_djp: bool, common_pack_ids: int[] }|null`（`START_MATCH` 成功時に固定し、マッチ中の選曲候補抽出へ適用）
+- `match_song_unlock_filter: { include_bit: bool, include_djp: bool, include_leggendaria: bool, common_pack_ids: int[] }|null`（`START_MATCH` 成功時に固定し、マッチ中の選曲候補抽出へ適用）
 - `event_seq: int`
 
 ### 2.2 RoomSettings（Ph1）
@@ -43,7 +43,7 @@
 - `player_id: string`
 - `display_name: string`
 - `source: inf_daken_counter|inf-notebook|daken_counter_v3|reflux`（端末設定）
-- `song_unlocks: { bit_unlocked: bool, djp_unlocked: bool, owned_pack_ids: int[] }`（クライアント申告。共通解禁フィルタ計算に使用）
+- `song_unlocks: { bit_unlocked: bool, djp_unlocked: bool, allow_leggendaria: bool, owned_pack_ids: int[] }`（クライアント申告。共通解禁フィルタ計算に使用）
 - `connected: bool`
 - `ready: bool`
 - `joined_at: datetime`

--- a/packages/shared/src/models/song-unlock.ts
+++ b/packages/shared/src/models/song-unlock.ts
@@ -1,11 +1,13 @@
 export interface SongUnlockSettings {
   bit_unlocked: boolean;
   djp_unlocked: boolean;
+  allow_leggendaria: boolean;
   owned_pack_ids: number[];
 }
 
 export interface MatchSongUnlockFilter {
   include_bit: boolean;
   include_djp: boolean;
+  include_leggendaria: boolean;
   common_pack_ids: number[];
 }

--- a/tasks/codex-issue-121-allow-leggendaria.md
+++ b/tasks/codex-issue-121-allow-leggendaria.md
@@ -1,0 +1,55 @@
+# codex-issue-121-allow-leggendaria
+
+## Purpose
+- 個人設定として LEGGENDARIA 許可/不許可を追加し、マッチ候補抽選の全経路へ一貫適用する。
+
+## Non-goals
+- LEGGENDARIA 以外のフィルタ条件や選曲ロジック全体の再設計は行わない。
+- 監視ソース I/O 仕様や Cloudflare リソース構成は変更しない。
+
+## Changes
+- クライアント設定に `allowLeggendaria: boolean` を追加し、初期値を `false` にする。
+- 設定 UI から切り替え可能にし、入室中は変更不可（disabled）にする。
+- `ROOM_JOIN` capability に設定値を含め、DO 側 player 情報へ保持する。
+- `START_MATCH` 時点で `include_leggendaria = players.every(player => player.allow_leggendaria)` を確定する。
+- `searchCharts` / ランダム抽選 / 重複差し替え再抽選 / BPL 3曲目ランダムへ同一フィルタを適用する。
+- 必要なテストを更新し、マッチ開始後の設定変更が当該マッチへ反映されないことを担保する。
+
+## Impact
+- Users: 設定画面で LEGGENDARIA 許可を制御できる。全員許可時のみ候補に出る。
+- Data: クライアント設定と room 内 player capability に新規 boolean が追加される。
+- Compatibility: WS capability に新規フィールド追加（後方互換は既存デフォルト `false` で維持）。
+- Cloudflare: Durable Object のマッチ候補フィルタ確定ロジックに変更が入る。
+
+## Target Files / Layers
+- Files:
+  - `apps/client/src/**/*settings*`
+  - `apps/client/src/**/*room*`
+  - `apps/worker/src/**/*room*`
+  - `packages/shared/src/**/*protocol*`
+  - `docs/design/02_ws_protocol.md`（契約記述差分が必要な場合）
+- Layers: client / worker / shared / docs
+
+## Test Focus
+- QUALITY 1: 型チェック・lint・関連テストの成功
+- QUALITY 2: 差分が目的範囲に限定され、UTF-8 no BOM / LF を維持
+- QUALITY 3: FSM/Protocol 観点で START_MATCH 時固定化と経路一貫性を確認
+- QUALITY 4: 監視ソース I/O 未変更のため対象外
+- QUALITY 5: E2E は今回未実施の場合、残余リスクを明記
+
+## Rollback Plan
+- 追加フィールドとフィルタ条件を元に戻し、旧来の候補抽選条件へ戻す。
+- 必要時は設定 UI のトグル表示を一時的に無効化する。
+
+## Commit Split Plan
+1. 設定/プロトコル型の追加（client/shared）
+2. DO 抽選ロジックと経路適用 + テスト更新
+3. 必要時の設計ドキュメント更新
+
+## Checklist
+- [x] Design doc alignment confirmed (if required)
+- [x] Impact scope identified
+- [x] Implementation completed
+- [x] Tests completed
+- [x] Regression checks completed
+- [x] Documentation updates completed (if required)


### PR DESCRIPTION
## 目的\n- 個人設定として LEGGENDARIA 許可/不許可（デフォルト false）を追加する\n- START_MATCH 時に参加者共通条件として LEGGENDARIA 候補可否を固定し、マッチ中の全選曲経路へ適用する\n\n## 変更点\n- client 設定に llowLeggendaria を追加（Settings 画面トグル、入室中 disabled）\n- ROOM_JOIN の client_capabilities.song_unlocks.allow_leggendaria を送信\n- DO 側で song_unlocks.allow_leggendaria を保持\n- START_MATCH 時に include_leggendaria = players.every(player => player.allow_leggendaria) を固定\n- 候補抽選の全経路（searchCharts / ランダム抽選 / 重複差し替え / BPL 3曲目ランダム）へ同一フィルタ適用\n- 規範ドキュメント更新（WS/Data Model）\n\n## 非変更点\n- 監視ソース I/O 仕様\n- Cloudflare リソース構成\n\n## 影響範囲\n- Users: 全員許可時のみ LEGGENDARIA が候補に出る\n- Compatibility: song_unlocks と match_song_unlock_filter に boolean フィールド追加\n\n## テスト\n- 
pm run typecheck\n- 
pm run lint\n- 
pm run test:worker\n- 
pm run test:client-stats\n\n## 備考\n- Plan Mode artifact: 	asks/codex-issue-121-allow-leggendaria.md\n\nFixes #121\n\n- [x] WORKFLOW.md を確認した\n- [x] QUALITY.md を満たしている