### PR TITLE
Issue116: BPL(3)/BPL(4)対応とBPL-PICKING/統計表示修正

### DIFF
--- a/QUALITY.md
+++ b/QUALITY.md
@@ -59,6 +59,7 @@
 ## 5. E2E（該当変更時のみ必須）
 - 2人で ARENA: create -> ready -> pick -> play(1ラウンド以上) -> result
 - 2人で BPL(3ラウンド): 同様
+- 2人で BPL4(4ラウンド): 同様
 - 重複ピックの差し替え
 - TIMEOUT（soft ttl）と FORCE_ADVANCE
 - `SKIP_HOST_ASSIGN` が v1 では拒否され、強制確定は `FORCE_ADVANCE` で扱われる

--- a/apps/client/src/components/RoomBPL.tsx
+++ b/apps/client/src/components/RoomBPL.tsx
@@ -102,9 +102,26 @@ export function RoomBPLPresentational(props: RoomBPLControlledState) {
 const BPL_MUSIC_SELECT_SECONDS = 45;
 const BPL_PLAY_START_SECONDS = 10;
 const BPL_PLAY_BEGIN_SECONDS = BPL_MUSIC_SELECT_SECONDS + BPL_PLAY_START_SECONDS;
+const BPL_STAGE_COUNT = 4;
+const BPL_REGULATION_LABEL = `${BPL_STAGE_COUNT} STAGES`;
 
 function maskJoinCode(joinCode: string): string {
     return '*'.repeat(joinCode.length);
+}
+
+function formatOrdinal(value: number): string {
+    const mod10 = value % 10;
+    const mod100 = value % 100;
+    if (mod10 === 1 && mod100 !== 11) {
+        return `${value}st`;
+    }
+    if (mod10 === 2 && mod100 !== 12) {
+        return `${value}nd`;
+    }
+    if (mod10 === 3 && mod100 !== 13) {
+        return `${value}rd`;
+    }
+    return `${value}th`;
 }
 
 function getDifficultyBadgeClass(difficulty: string | undefined): string {
@@ -148,7 +165,7 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
     const [resultTimerState, setResultTimer] = useState(10);
     const [currentTurnState, setCurrentTurn] = useState(0); // 0: 1P, 1: 2P
     const [roundCountState, setRoundCount] = useState(1);
-    const [picksState, setPicks] = useState<(Song | null)[]>([null, null, { title: '?????', artist: '', level: '??' }]);
+    const [picksState, setPicks] = useState<(Song | null)[]>(Array.from({ length: BPL_STAGE_COUNT }, () => null));
     const [historyState, setHistory] = useState<HistoryItem[]>([]);
     const [showSearchState, setShowSearch] = useState(false);
     const [lastPickedSongState, setLastPickedSong] = useState<Song | null>(null);
@@ -235,10 +252,11 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
     const playerMetrics = controlled?.playerMetrics ?? {};
     const metricLabel = controlled?.metricLabel ?? 'EX SCORE';
     const resultPlayers = controlled?.resultPlayers ?? {};
-    const resultRegulationLabel = controlled?.resultRegulationLabel ?? '3 STAGES';
+    const resultRegulationLabel = controlled?.resultRegulationLabel ?? BPL_REGULATION_LABEL;
     const finalResultPlayers = controlled?.finalResultPlayers ?? {};
-    const currentPlayingSong = picks[roundCount - 1] || picks[2];
-    const currentResultSong = picks[roundCount - 1] || picks[2];
+    const totalStages = Math.max(1, picks.length);
+    const currentPlayingSong = picks[roundCount - 1] || picks[totalStages - 1] || null;
+    const currentResultSong = picks[roundCount - 1] || picks[totalStages - 1] || null;
     const currentPlayingSongVersion = resolveSongVersionLabel(currentPlayingSong?.version);
     const currentResultSongVersion = resolveSongVersionLabel(currentResultSong?.version);
     const currentPlayingSongPlayStyle = currentPlayingSong?.playStyle ?? '-';
@@ -278,8 +296,9 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
         // 3秒後にカットインを消し、次のターンへ（あるいは終了）
         setTimeout(() => {
             setShowCutIn(false);
-            if (currentTurn === 0) {
-                setCurrentTurn(1);
+            const nextTurn = currentTurn + 1;
+            if (nextTurn < totalStages) {
+                setCurrentTurn(nextTurn);
             } else {
                 // 両者の選曲が完了したら PLAYING へ
                 setRoomStatus('PLAYING');
@@ -386,7 +405,7 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
 
         setHistory(prev => [newItem, ...prev]);
 
-        if (roundCount < 3) {
+        if (roundCount < totalStages) {
             setRoundCount(prev => prev + 1);
             setRoomStatus('PLAYING');
             setPlayTime(0);
@@ -411,10 +430,11 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
     const _currentSong = picks[0]; // TODO: 本来はラウンドに応じた曲を表示
     const leftPlayer = players[0] ?? { id: '1', name: 'HOST', isReady: false, isHost: true, side: 'LEFT' as const };
     const rightPlayer = players[1] ?? { id: '2', name: 'GUEST', isReady: false, isHost: false, side: 'RIGHT' as const };
-    const roundPickerNames = controlled?.roundPickerNames ?? [leftPlayer.name, rightPlayer.name, 'System Random'];
+    const roundPickerNames = controlled?.roundPickerNames ?? Array.from(
+        { length: totalStages },
+        (_, index) => (index % 2 === 0 ? leftPlayer.name : rightPlayer.name),
+    );
     const currentRoundPickerName = roundPickerNames[roundCount - 1] ?? null;
-    const leftPickLabel = roundPickerNames[0] ? `${roundPickerNames[0]}'S PICK` : '1ST PICK';
-    const rightPickLabel = roundPickerNames[1] ? `${roundPickerNames[1]}'S PICK` : '2ND PICK';
 
     return (
         <div className="flex h-screen w-screen bg-[#0f0f10] text-white font-sans overflow-hidden">
@@ -518,11 +538,10 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
                         <div className="h-10 w-[1px] bg-white/10"></div>
                         <div className="text-left">
                             <p className="text-[10px] font-black text-gray-500 uppercase tracking-[0.3em]">Regulation</p>
-                            <h2 className="text-2xl font-black italic tracking-tighter text-gray-300 whitespace-nowrap">3 STAGES</h2>
+                            <h2 className="text-2xl font-black italic tracking-tighter text-gray-300 whitespace-nowrap">{resultRegulationLabel}</h2>
                         </div>
                     </div>
                 </header>
-
                 {/* 中央：VS 対峙セクション */}
                 <div className="flex-1 flex items-center justify-between gap-8 relative px-10">
 
@@ -534,10 +553,10 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
                     {/* 左プレイヤー (1P) */}
                     <div className={`flex-1 max-w-[400px] flex flex-col gap-4 transition-all ${leftPlayer.isReady ? 'scale-105' : ''}`}>
                         <div className={`h-[320px] rounded-3xl border-4 relative overflow-hidden flex flex-col items-center justify-center transition-all ${leftPlayer.isReady
-                            ? (roomStatus === 'SELECTING' && currentTurn === 0 ? 'bg-cyan-500/20 border-white shadow-[0_0_80px_rgba(6,182,212,0.4)] ring-4 ring-cyan-500 ring-opacity-50' : 'bg-cyan-500/10 border-cyan-500 shadow-[0_0_50px_rgba(6,182,212,0.2)]')
+                            ? (roomStatus === 'SELECTING' && currentTurn % 2 === 0 ? 'bg-cyan-500/20 border-white shadow-[0_0_80px_rgba(6,182,212,0.4)] ring-4 ring-cyan-500 ring-opacity-50' : 'bg-cyan-500/10 border-cyan-500 shadow-[0_0_50px_rgba(6,182,212,0.2)]')
                             : 'bg-[#252526] border-white/10'
                             }`}>
-                            {roomStatus === 'SELECTING' && currentTurn === 0 && (
+                            {roomStatus === 'SELECTING' && currentTurn % 2 === 0 && (
                                 <div className="absolute top-0 left-0 right-0 bg-cyan-500 text-black text-center py-1 font-black italic text-xs tracking-[0.3em] animate-pulse">
                                     YOUR TURN
                                 </div>
@@ -558,7 +577,7 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
                                 <CheckCircle2 size={24} /> READY
                             </div>
                         )}
-                        {roomStatus === 'SELECTING' && currentTurn === 0 && (
+                        {roomStatus === 'SELECTING' && currentTurn % 2 === 0 && (
                             <button
                                 onClick={() => {
                                     if (controlled?.onOpenSearch) {
@@ -583,10 +602,10 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
                     {/* 右プレイヤー (2P) */}
                     <div className={`flex-1 max-w-[400px] flex flex-col gap-4 transition-all ${rightPlayer.isReady ? 'scale-105' : ''}`}>
                         <div className={`h-[320px] rounded-3xl border-4 relative overflow-hidden flex flex-col items-center justify-center transition-all ${rightPlayer.isReady
-                            ? (roomStatus === 'SELECTING' && currentTurn === 1 ? 'bg-amber-500/20 border-white shadow-[0_0_80px_rgba(245,158,11,0.4)] ring-4 ring-amber-500 ring-opacity-50' : 'bg-amber-500/10 border-amber-500 shadow-[0_0_50px_rgba(245,158,11,0.2)]')
+                            ? (roomStatus === 'SELECTING' && currentTurn % 2 === 1 ? 'bg-amber-500/20 border-white shadow-[0_0_80px_rgba(245,158,11,0.4)] ring-4 ring-amber-500 ring-opacity-50' : 'bg-amber-500/10 border-amber-500 shadow-[0_0_50px_rgba(245,158,11,0.2)]')
                             : 'bg-[#252526] border-white/10'
                             }`}>
-                            {roomStatus === 'SELECTING' && currentTurn === 1 && (
+                            {roomStatus === 'SELECTING' && currentTurn % 2 === 1 && (
                                 <div className="absolute top-0 left-0 right-0 bg-amber-500 text-black text-center py-1 font-black italic text-xs tracking-[0.3em] animate-pulse">
                                     RIVAL'S TURN
                                 </div>
@@ -610,7 +629,7 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
                                 <Circle size={24} /> WAITING...
                             </div>
                         )}
-                        {roomStatus === 'SELECTING' && currentTurn === 1 && (
+                        {roomStatus === 'SELECTING' && currentTurn % 2 === 1 && (
                             <div className="bg-amber-500/10 text-amber-500 py-4 rounded-2xl font-black italic text-xl border-2 border-amber-500/50 text-center animate-pulse">
                                 SELECTING...
                             </div>
@@ -618,37 +637,44 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
                     </div>
                 </div>
 
-                {/* 下部：ストラテジーエリア（3 round用） */}
+                {/* 下部：ストラテジーエリア */}
                 {roomStatus !== 'PLAYING' ? (
-                    <footer className="mt-4 grid grid-cols-4 gap-4 h-28">
-                        <div className={`rounded-2xl border p-3 flex flex-col justify-center transition-all ${picks[0] ? 'bg-cyan-500/10 border-cyan-500' : 'bg-[#1a1a1b] border-white/5'}`}>
-                            <span className="text-[9px] font-black text-gray-500 uppercase mb-0.5">1st Match</span>
-                            <div className="flex flex-col font-bold">
-                                <span className={picks[0] ? 'text-white text-lg font-black italic truncate' : 'text-cyan-400/50'}>
-                                    {picks[0] ? picks[0].title : leftPickLabel}
-                                </span>
-                                {picks[0]?.artist ? <span className="text-[10px] text-cyan-500 font-black italic tracking-widest truncate">{picks[0].artist}</span> : null}
-                            </div>
-                        </div>
-                        <div className={`rounded-2xl border p-3 flex flex-col justify-center transition-all ${picks[1] ? 'bg-amber-500/10 border-amber-500' : 'bg-[#1a1a1b] border-white/5 border-dashed'}`}>
-                            <span className="text-[9px] font-black text-gray-500 uppercase mb-0.5">2nd Match</span>
-                            <div className="flex flex-col font-bold">
-                                <span className={picks[1] ? 'text-white text-lg font-black italic truncate' : 'text-amber-500/50'}>
-                                    {picks[1] ? picks[1].title : rightPickLabel}
-                                </span>
-                                {picks[1]?.artist ? <span className="text-[10px] text-amber-500 font-black italic tracking-widest leading-none truncate">{picks[1].artist}</span> : null}
-                            </div>
-                        </div>
-                        {/* 3rd STAGE: RANDOM PICK (????? 表示) */}
-                        <div className="bg-gradient-to-br from-[#1a1a1b] to-[#2a1010] border-2 border-red-500 shadow-[0_0_20px_rgba(239,68,68,0.2)] rounded-2xl p-3 flex flex-col justify-center items-center relative group overflow-hidden font-sans animate-pulse">
-                            <div className="absolute text-red-500/10 font-black text-6xl italic -right-2 -bottom-4 select-none">?</div>
-
-                            <span className="text-[10px] font-black text-red-500 uppercase tracking-widest mb-0.5">Final STAGE</span>
-                            <div className="flex flex-col items-center gap-0">
-                                <span className="text-xl font-black italic tracking-[0.2em] text-red-600">?????</span>
-                                <span className="text-[8px] font-bold text-red-900 uppercase">System Random</span>
-                            </div>
-                        </div>
+                    <footer
+                        className="mt-4 grid h-28 gap-4 px-2 md:px-4"
+                        style={{ gridTemplateColumns: `repeat(${totalStages + 1}, minmax(0, 1fr))` }}
+                    >
+                        {picks.map((pick, index) => {
+                            const isHostTurn = index % 2 === 0;
+                            const fallbackLabel = roundPickerNames[index] === 'SYSTEM RANDOM'
+                                ? 'SYSTEM RANDOM'
+                                : roundPickerNames[index]
+                                    ? `${roundPickerNames[index]}'S PICK`
+                                    : `${formatOrdinal(index + 1).toUpperCase()} PICK`;
+                            return (
+                                <div
+                                    key={`pick-slot-${index}`}
+                                    className={`rounded-2xl border p-3 flex flex-col justify-center transition-all ${pick
+                                        ? (isHostTurn ? 'bg-cyan-500/10 border-cyan-500' : 'bg-amber-500/10 border-amber-500')
+                                        : (isHostTurn ? 'bg-[#1a1a1b] border-white/5' : 'bg-[#1a1a1b] border-white/5 border-dashed')
+                                        }`}
+                                >
+                                    <span className="text-[9px] font-black text-gray-500 uppercase mb-0.5">{formatOrdinal(index + 1)} Match</span>
+                                    <div className="flex flex-col font-bold">
+                                        <span className={pick
+                                            ? 'text-white text-lg font-black italic truncate'
+                                            : (isHostTurn ? 'text-cyan-400/50' : 'text-amber-500/50')}
+                                        >
+                                            {pick ? pick.title : fallbackLabel}
+                                        </span>
+                                        {pick?.artist ? (
+                                            <span className={`text-[10px] font-black italic tracking-widest leading-none truncate ${isHostTurn ? 'text-cyan-500' : 'text-amber-500'}`}>
+                                                {pick.artist}
+                                            </span>
+                                        ) : null}
+                                    </div>
+                                </div>
+                            );
+                        })}
                         <div className="bg-white/5 rounded-2xl p-4 flex items-center justify-center">
                             <button
                                 onClick={() => {
@@ -683,7 +709,7 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
                         <div className="flex justify-between items-start mb-12">
                             <div className="flex flex-col gap-2">
                                 <div className="flex items-center gap-4">
-                                    <span className="bg-white text-black px-4 py-1 font-black italic text-2xl tracking-tighter">{roundCount}{roundCount === 1 ? 'st' : roundCount === 2 ? 'nd' : 'rd'} STAGE</span>
+                                    <span className="bg-white text-black px-4 py-1 font-black italic text-2xl tracking-tighter">{formatOrdinal(roundCount)} STAGE</span>
                                     <div className="h-8 w-[2px] bg-white/20" />
                                     <div className="flex flex-col">
                                         <span className="text-[10px] font-black text-gray-500 tracking-widest">ROUND PROGRESS</span>
@@ -701,7 +727,7 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
                                         </span>
                                     )}
                                     <h2 className="text-5xl font-black italic tracking-tighter text-white drop-shadow-[0_0_20px_rgba(255,255,255,0.2)] line-clamp-2 leading-tight break-all">
-                                        {currentPlayingSong?.title || (roundCount === 3 ? "SYSTEM RANDOM (MAX 300)" : "Unknown Track")}
+                                        {currentPlayingSong?.title || 'Unknown Track'}
                                     </h2>
                                     <div className="flex flex-wrap items-center gap-4 mt-1">
                                         <span className="text-xl font-bold text-gray-500 tracking-widest truncate max-w-xs xl:max-w-md">{currentPlayingSong?.artist || '-'}</span>
@@ -855,7 +881,7 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
                                             </span>
                                         )}
                                         <h2 className="text-3xl font-black italic tracking-tighter text-white leading-tight drop-shadow-2xl line-clamp-1">
-                                            {currentResultSong?.title || 'System Random'}
+                                            {currentResultSong?.title || 'Unknown Track'}
                                         </h2>
                                         <div className="mt-1 flex flex-wrap items-center gap-3 max-w-xl">
                                             <p className="text-base font-bold text-gray-400 truncate">{currentResultSong?.artist || '-'}</p>

--- a/apps/client/src/components/SongSearchModalView.tsx
+++ b/apps/client/src/components/SongSearchModalView.tsx
@@ -154,6 +154,7 @@ export interface SongSearchModalViewProps {
     searchPlaceholder?: string;
     subtitle?: string;
     footerLabel?: string;
+    selectionProgressLabel?: string;
 }
 
 export function SongSearchModalView({
@@ -176,6 +177,7 @@ export function SongSearchModalView({
     searchPlaceholder = 'Search by Title or Artist...',
     subtitle = 'Infinitas Arena Battle System',
     footerLabel = 'Project INFINITAS Arena',
+    selectionProgressLabel,
 }: SongSearchModalViewProps) {
     const listViewportRef = useRef<HTMLDivElement | null>(null);
     const loadMoreRef = useRef<HTMLDivElement | null>(null);
@@ -250,6 +252,11 @@ export function SongSearchModalView({
                             <div className="flex flex-col">
                                 <h2 className="text-2xl font-black italic tracking-tighter uppercase text-white drop-shadow-[0_0_10px_rgba(255,255,255,0.3)] leading-none">Pick Music</h2>
                                 <span className="text-[9px] font-black text-cyan-500/80 tracking-widest uppercase mt-1">{subtitle}</span>
+                                {selectionProgressLabel ? (
+                                    <span className="mt-1 inline-flex w-fit rounded-full border border-cyan-500/40 bg-cyan-500/10 px-2 py-0.5 text-[10px] font-black italic tracking-[0.15em] text-cyan-200">
+                                        {selectionProgressLabel}
+                                    </span>
+                                ) : null}
                             </div>
                         </div>
 

--- a/apps/client/src/dev/visual-scenarios.ts
+++ b/apps/client/src/dev/visual-scenarios.ts
@@ -459,7 +459,7 @@ function createResultReady(args: {
 
   return {
     summary: {
-      match_id: `${args.mode.toLowerCase()}-visual-match`,
+      match_id: `${args.mode}-visual-match`,
       mode: args.mode,
       win_metric: "SCORE",
       total_rounds: args.totalRounds,

--- a/apps/client/src/features/stats/stats.test.ts
+++ b/apps/client/src/features/stats/stats.test.ts
@@ -25,6 +25,7 @@ import {
 } from "./models";
 import {
   captureRoomStatsSession,
+  createArchiveFromStorage,
   getChartRankings,
   getCurrentRating,
   getDetailedMatchHistory,
@@ -178,7 +179,7 @@ function makeResultReady(input: {
   return {
     summary: {
       match_id: input.session.match_id,
-      mode: input.session.settings.mode,
+      mode: input.session.settings.mode === "ARENA" ? "ARENA" : "BPL",
       win_metric: input.session.settings.win_metric,
       total_rounds: input.totalRounds ?? input.session.rounds.length,
       completed_rounds: input.completedRounds ?? input.session.rounds.length,
@@ -567,6 +568,85 @@ runCase("BPL detailed history shows tied rounds as 1-1 while preserving MISSCOUN
   assert.equal(detailedHistory[0]?.total_bp, 33);
   assert.equal(detailedHistory[0]?.total_ex_score, 6300);
   assert.equal(history[0]?.detail, "3-3");
+});
+
+runCase("legacy BPL3/BPL4 storage entries are normalized and shown in BPL stats", () => {
+  const matchId = "legacy-bpl4-match";
+  const rawArchive: unknown = {
+    ...createEmptyStatsArchive(),
+    matches: [
+      {
+        match_id: matchId,
+        started_at: iso(2),
+        ended_at: iso(3),
+        battle_type: "BPL4",
+        play_mode: "SP",
+        opponent_count: 1,
+        opponent_id: "opponent",
+        opponent_name: "OPPONENT",
+        is_rated: true,
+        is_complete: true,
+        match_result: "WIN",
+        match_point_total: 1,
+        rating_score: 1512,
+        rating_before: 1500,
+        rating_after: 1512,
+        rating_delta: 12,
+        invalid_reason: null,
+        final_rank: 1,
+        display_rank: 1,
+        participant_count: 2,
+        win_metric: "SCORE",
+      },
+    ],
+    match_games: [
+      {
+        match_game_id: "legacy-bpl4-game",
+        match_id: matchId,
+        played_at: iso(2),
+        game_index: 0,
+        chart_id: "SP::ANOTHER::legacy-song",
+        chart_title: "Legacy Song",
+        chart_difficulty: "ANOTHER",
+        chart_level: 12,
+        battle_type: "BPL4",
+        play_mode: "SP",
+        game_result: "WIN",
+        round_point: 1,
+        my_ex_score: 2000,
+        opponent_ex_score: 1900,
+        my_bp: 10,
+        opponent_bp: 15,
+        result_confirmed_at: iso(2),
+      },
+    ],
+    play_results: [
+      {
+        play_result_id: "legacy-bpl4-play",
+        played_at: iso(2),
+        battle_type: "BPL3",
+        play_mode: "SP",
+        chart_id: "SP::ANOTHER::legacy-song",
+        chart_title: "Legacy Song",
+        chart_difficulty: "ANOTHER",
+        chart_level: 12,
+        my_ex_score: 2000,
+        my_bp: 10,
+        source_match_id: matchId,
+      },
+    ],
+  };
+
+  const archive = createArchiveFromStorage(rawArchive);
+  const detailedHistory = getDetailedMatchHistory(archive, "BPL", "SP");
+  const history = getRecentMatchHistory(archive, "BPL", "SP");
+
+  assert.equal(archive.matches[0]?.battle_type, "BPL");
+  assert.equal(archive.match_games[0]?.battle_type, "BPL");
+  assert.equal(archive.play_results[0]?.battle_type, "BPL");
+  assert.equal(detailedHistory.length, 1);
+  assert.equal(detailedHistory[0]?.games.length, 1);
+  assert.equal(history[0]?.match_id, matchId);
 });
 
 runCase("DO-provided unrated decision blocks local rating updates", () => {

--- a/apps/client/src/features/stats/stats.test.ts
+++ b/apps/client/src/features/stats/stats.test.ts
@@ -574,6 +574,9 @@ runCase("legacy BPL3/BPL4 storage entries are normalized and shown in BPL stats"
   const matchId = "legacy-bpl4-match";
   const rawArchive: unknown = {
     ...createEmptyStatsArchive(),
+    rating_series_state: {
+      BPL4_SP: 1620,
+    },
     matches: [
       {
         match_id: matchId,
@@ -641,6 +644,7 @@ runCase("legacy BPL3/BPL4 storage entries are normalized and shown in BPL stats"
   const detailedHistory = getDetailedMatchHistory(archive, "BPL", "SP");
   const history = getRecentMatchHistory(archive, "BPL", "SP");
 
+  assert.equal(getCurrentRating(archive, "BPL", "SP"), 1620);
   assert.equal(archive.matches[0]?.battle_type, "BPL");
   assert.equal(archive.match_games[0]?.battle_type, "BPL");
   assert.equal(archive.play_results[0]?.battle_type, "BPL");

--- a/apps/client/src/features/stats/stats.ts
+++ b/apps/client/src/features/stats/stats.ts
@@ -150,7 +150,31 @@ function getArenaRankByPlayerId(results: SessionPlayerResult[], winMetric: WinMe
 }
 
 function getBattleType(settings: RoomSettings): StatsBattleType {
-  return settings.mode;
+  return settings.mode === "ARENA" ? "ARENA" : "BPL";
+}
+
+function normalizeLegacyBplBattleType(value: unknown): unknown {
+  return value === "BPL3" || value === "BPL4" ? "BPL" : value;
+}
+
+function normalizeArchiveBattleTypes(entries: unknown[]): unknown[] {
+  let changed = false;
+  const normalizedEntries = entries.map((entry) => {
+    const record = asRecord(entry);
+    if (record === null) {
+      return entry;
+    }
+    const normalizedBattleType = normalizeLegacyBplBattleType(record.battle_type);
+    if (normalizedBattleType === record.battle_type) {
+      return entry;
+    }
+    changed = true;
+    return {
+      ...record,
+      battle_type: normalizedBattleType,
+    };
+  });
+  return changed ? normalizedEntries : entries;
 }
 
 export function buildChartId(expectedKey: {
@@ -1091,7 +1115,23 @@ export function createArchiveFromStorage(rawArchive: unknown): StatsArchive {
     return createEmptyStatsArchive();
   }
 
-  return archive as unknown as StatsArchive;
+  const normalizedMatches = normalizeArchiveBattleTypes(archive.matches as unknown[]);
+  const normalizedMatchGames = normalizeArchiveBattleTypes(archive.match_games as unknown[]);
+  const normalizedPlayResults = normalizeArchiveBattleTypes(archive.play_results as unknown[]);
+  if (
+    normalizedMatches === archive.matches &&
+    normalizedMatchGames === archive.match_games &&
+    normalizedPlayResults === archive.play_results
+  ) {
+    return archive as unknown as StatsArchive;
+  }
+
+  return {
+    ...archive,
+    matches: normalizedMatches,
+    match_games: normalizedMatchGames,
+    play_results: normalizedPlayResults,
+  } as unknown as StatsArchive;
 }
 
 export function getCurrentRating(

--- a/apps/client/src/features/stats/stats.ts
+++ b/apps/client/src/features/stats/stats.ts
@@ -157,6 +157,16 @@ function normalizeLegacyBplBattleType(value: unknown): unknown {
   return value === "BPL3" || value === "BPL4" ? "BPL" : value;
 }
 
+function normalizeLegacyRatingSeriesKey(key: string): string {
+  if (key === "BPL3_SP" || key === "BPL4_SP") {
+    return "BPL_SP";
+  }
+  if (key === "BPL3_DP" || key === "BPL4_DP") {
+    return "BPL_DP";
+  }
+  return key;
+}
+
 function normalizeArchiveBattleTypes(entries: unknown[]): unknown[] {
   let changed = false;
   const normalizedEntries = entries.map((entry) => {
@@ -175,6 +185,29 @@ function normalizeArchiveBattleTypes(entries: unknown[]): unknown[] {
     };
   });
   return changed ? normalizedEntries : entries;
+}
+
+function normalizeArchiveRatingSeriesState(value: unknown): unknown {
+  const ratingSeriesState = asRecord(value);
+  if (ratingSeriesState === null) {
+    return value;
+  }
+
+  let changed = false;
+  const normalizedState: Record<string, unknown> = { ...ratingSeriesState };
+  for (const [key, keyValue] of Object.entries(ratingSeriesState)) {
+    const normalizedKey = normalizeLegacyRatingSeriesKey(key);
+    if (normalizedKey === key) {
+      continue;
+    }
+    changed = true;
+    if (!(normalizedKey in normalizedState)) {
+      normalizedState[normalizedKey] = keyValue;
+    }
+    delete normalizedState[key];
+  }
+
+  return changed ? normalizedState : value;
 }
 
 export function buildChartId(expectedKey: {
@@ -1118,10 +1151,12 @@ export function createArchiveFromStorage(rawArchive: unknown): StatsArchive {
   const normalizedMatches = normalizeArchiveBattleTypes(archive.matches as unknown[]);
   const normalizedMatchGames = normalizeArchiveBattleTypes(archive.match_games as unknown[]);
   const normalizedPlayResults = normalizeArchiveBattleTypes(archive.play_results as unknown[]);
+  const normalizedRatingSeriesState = normalizeArchiveRatingSeriesState(archive.rating_series_state);
   if (
     normalizedMatches === archive.matches &&
     normalizedMatchGames === archive.match_games &&
-    normalizedPlayResults === archive.play_results
+    normalizedPlayResults === archive.play_results &&
+    normalizedRatingSeriesState === archive.rating_series_state
   ) {
     return archive as unknown as StatsArchive;
   }
@@ -1131,6 +1166,7 @@ export function createArchiveFromStorage(rawArchive: unknown): StatsArchive {
     matches: normalizedMatches,
     match_games: normalizedMatchGames,
     play_results: normalizedPlayResults,
+    rating_series_state: normalizedRatingSeriesState,
   } as unknown as StatsArchive;
 }
 

--- a/apps/client/src/pages/LobbyPage.tsx
+++ b/apps/client/src/pages/LobbyPage.tsx
@@ -1,4 +1,6 @@
 import {
+  BPL4_ROUNDS,
+  BPL_ROUNDS,
   JOIN_CODE_CHARSET,
   JOIN_CODE_LENGTH,
   LEVEL_FILTERS,
@@ -41,8 +43,13 @@ const levelLabels: Record<RoomSettings["level_filter"], string> = {
 
 const modeLabels: Record<RoomSettings["mode"], string> = {
   ARENA: "ARENA",
-  BPL: "BPL (3 STAGE)",
+  BPL: `BPL (${BPL_ROUNDS} STAGE)`,
+  BPL4: `BPL (${BPL4_ROUNDS} STAGE)`,
 };
+
+function isBplMode(mode: RoomSettings["mode"]): boolean {
+  return mode === "BPL" || mode === "BPL4";
+}
 
 const winMetricLabels: Record<RoomSettings["win_metric"], string> = {
   SCORE: "SCORE (EX SCORE)",
@@ -394,7 +401,7 @@ export function LobbyPage() {
                   <div className="flex items-center gap-3">
                     <h3 className="text-lg font-bold transition-colors group-hover:text-cyan-400">{roomTitle(room)}</h3>
                     <span className="rounded border border-cyan-500/20 bg-cyan-500/10 px-2 py-0.5 text-[10px] font-black text-cyan-400">
-                      {room.mode === "BPL" ? "BPL" : room.mode}
+                      {room.mode === "ARENA" ? "ARENA" : room.mode === "BPL4" ? "BPL(4)" : "BPL(3)"}
                     </span>
                     {room.hasJoinCode ? <Lock size={14} className="text-amber-500/70" /> : null}
                   </div>
@@ -567,7 +574,7 @@ export function LobbyPage() {
                         setCreateDraft((current) => ({
                           ...current,
                           mode: nextMode,
-                          max_players: nextMode === "BPL" ? 2 : current.max_players,
+                          max_players: isBplMode(nextMode) ? 2 : current.max_players,
                         }));
                       }}
                     >
@@ -647,7 +654,7 @@ export function LobbyPage() {
                     ))}
                   </div>
                 </div>
-                {createDraft.mode === "BPL" ? (
+                {isBplMode(createDraft.mode) ? (
                   <div className="space-y-2">
                     <label className="flex items-center gap-2 text-xs font-bold text-gray-400">
                       <Users size={14} />

--- a/apps/client/src/pages/RoomPage.tsx
+++ b/apps/client/src/pages/RoomPage.tsx
@@ -1,9 +1,13 @@
 import {
   AUTO_REMATCH_RESULT_SECONDS,
+  BPL4_PICKING_TTL_SECONDS,
+  BPL4_ROUNDS,
+  BPL_ROUNDS,
   CHART_DIFFICULTIES,
   CHART_SEARCH_PAGE_SIZE,
   HOST_SKIP_UNLOCK_SECONDS,
   MATCH_TTL_MINUTES,
+  PICKING_TTL_SECONDS,
   ROUND_MUSIC_SELECT_SECONDS,
   ROUND_PLAY_BEGIN_AT_SECONDS,
   type ChartSearchEntry,
@@ -102,6 +106,23 @@ type ChartSearchEntryWithVersion = ChartSearchEntry & {
 const BPL_PICK_CUTIN_SECONDS = 3;
 const BPL_RESULT_PHASE_SECONDS = 10;
 const ARENA_RESULT_PHASE_SECONDS = 10;
+
+function isBplMode(mode: RoomStateSnapshot["settings"]["mode"]): boolean {
+  return mode === "BPL" || mode === "BPL4";
+}
+
+function isBplFourStageMode(mode: RoomStateSnapshot["settings"]["mode"]): boolean {
+  return mode === "BPL4";
+}
+
+function getBplStageCount(mode: RoomStateSnapshot["settings"]["mode"]): number {
+  return isBplFourStageMode(mode) ? BPL4_ROUNDS : BPL_ROUNDS;
+}
+
+function getBplStageLabel(mode: RoomStateSnapshot["settings"]["mode"]): string {
+  return `${getBplStageCount(mode)} STAGE`;
+}
+
 function getArchiveTone(status: string): string {
   if (status === "READY") {
     return "ok";
@@ -403,7 +424,7 @@ function formatRoomTitle(
     return comment;
   }
 
-  return `${mode === "BPL" ? "BPL (3 STAGE)" : "ARENA"} ${playStyle}`;
+  return `${isBplMode(mode) ? `BPL (${getBplStageLabel(mode)})` : "ARENA"} ${playStyle}`;
 }
 
 function getLobbyStartIssues(snapshot: RoomStateSnapshot): string[] {
@@ -413,7 +434,7 @@ function getLobbyStartIssues(snapshot: RoomStateSnapshot): string[] {
     issues.push("At least two players are required.");
   }
 
-  if (snapshot.settings.mode === "BPL" && snapshot.players.length !== 2) {
+  if (isBplMode(snapshot.settings.mode) && snapshot.players.length !== 2) {
     issues.push("BPL mode requires exactly two players.");
   }
 
@@ -757,8 +778,14 @@ export function RoomPage() {
   const previousRoomStateRef = useRef<RoomStateSnapshot["room_state"] | null>(null);
   const previousRoomIdRef = useRef<string | null>(null);
   const pickerModalVisibleRef = useRef(false);
-  const mySubmittedPick = snapshot?.picks.find((pick) => pick.player_id === activePlayerId) ?? null;
-  const showPickerModal = snapshot?.room_state === "PICKING" && mySubmittedPick === null;
+  const mySubmittedPicks = snapshot?.picks.filter((pick) => pick.player_id === activePlayerId) ?? [];
+  const mySubmittedPick = mySubmittedPicks[mySubmittedPicks.length - 1] ?? null;
+  const requiredPickCountPerPlayer =
+    snapshot && isBplFourStageMode(snapshot.settings.mode) ? 2 : 1;
+  const showPickerModal =
+    snapshot?.room_state === "PICKING" &&
+    activePlayerId !== null &&
+    mySubmittedPicks.length < requiredPickCountPerPlayer;
 
   async function loadChartCandidates(targetCursor: string | null, appendResults: boolean): Promise<void> {
     if (snapshot === null || snapshot.room_state !== "PICKING") {
@@ -1367,7 +1394,9 @@ export function RoomPage() {
     snapshot.auto_rematch_cancelled !== true &&
     autoRematchDueAtMs !== null;
 
-  const isBpl = snapshot.settings.mode === "BPL";
+  const isBpl = isBplMode(snapshot.settings.mode);
+  const isBplFourStage = isBplFourStageMode(snapshot.settings.mode);
+  const bplStageCount = getBplStageCount(snapshot.settings.mode);
   const leaveRoomDisabled = snapshot.room_state === "PICKING" || snapshot.room_state === "PLAYING";
   const orderedPlayers = [...snapshot.players].sort((left, right) => {
     const leftHost = left.player_id === snapshot.host_player_id || left.role === "HOST" ? 1 : 0;
@@ -1541,11 +1570,18 @@ export function RoomPage() {
   const roundPickerNameByIndex = new Map(
     picksByAcceptedOrder.map((pick, index) => [index, playersById.get(pick.player_id)?.display_name ?? pick.player_id]),
   );
-  const bplRoundPickerNames: Array<string | null> = [
-    roundPickerNameByIndex.get(0) ?? null,
-    roundPickerNameByIndex.get(1) ?? null,
-    "System Random",
+  const defaultBplPickerNames = [
+    slots[0]?.display_name ?? "HOST",
+    slots[1]?.display_name ?? "GUEST",
   ];
+  const bplRoundPickerNames: Array<string | null> = Array.from(
+    { length: bplStageCount },
+    (_, index) =>
+      roundPickerNameByIndex.get(index) ??
+      (!isBplFourStage && index === bplStageCount - 1
+        ? "SYSTEM RANDOM"
+        : defaultBplPickerNames[index % defaultBplPickerNames.length] ?? null),
+  );
   const arenaCurrentRoundPickerName =
     currentRound === null ? null : roundPickerNameByIndex.get(currentRound.round_index) ?? null;
   const roomIdLabel = snapshot.room_id;
@@ -1556,7 +1592,9 @@ export function RoomPage() {
     currentExpectedKeyCacheKey === null ? null : resolvedChartsByExpectedKey[currentExpectedKeyCacheKey] ?? null;
   const roundLevel = currentRoundDisplay?.display.level ?? null;
   const currentSongLevel = currentResolvedChart?.level ?? roundLevel;
-  const activeBplPickIndex = snapshot.room_state === "PICKING" ? Math.min(snapshot.picks.length, 2) : null;
+  const activeBplPickIndex = snapshot.room_state === "PICKING"
+    ? Math.min(snapshot.picks.length, Math.max(0, bplStageCount - 1))
+    : null;
   const displayResultPlayers = resultPlayers.length > 0
     ? resultPlayers
     : orderedPlayers.map((player) => ({
@@ -1729,7 +1767,20 @@ export function RoomPage() {
       selectedDiff={chartDifficulty ? getDifficultyId(chartDifficulty) : null}
       selectedLevel={chartLevel ? Number(chartLevel) : null}
       selectedVersion={selectedVersion}
-      timeLeft={pickingCountdown ?? 120}
+      {...(
+        snapshot && isBplMode(snapshot.settings.mode) && snapshot.room_state === "PICKING"
+          ? {
+              selectionProgressLabel:
+                `PICK ${Math.min(mySubmittedPicks.length + 1, requiredPickCountPerPlayer)} / ${requiredPickCountPerPlayer}`,
+            }
+          : {}
+      )}
+      timeLeft={
+        pickingCountdown ??
+        (snapshot && isBplFourStageMode(snapshot.settings.mode)
+          ? BPL4_PICKING_TTL_SECONDS
+          : PICKING_TTL_SECONDS)
+      }
       displayedSongs={pickerSongs}
       totalSongs={pickerSongs.length}
       hasMore={chartNextCursor !== null}
@@ -1917,7 +1968,7 @@ export function RoomPage() {
       };
     });
 
-  const bplPicks: (BplSong | null)[] = Array.from({ length: 3 }, (_, index) => {
+  const bplPicks: (BplSong | null)[] = Array.from({ length: bplStageCount }, (_, index) => {
     const roundSong = roundSongsByIndex.get(index);
     if (roundSong) {
       const revealActualSong =
@@ -1934,31 +1985,36 @@ export function RoomPage() {
       };
     }
 
-    if (index < 2) {
-      const playerPick = roundPickByIndex.get(index) ?? null;
-      if (playerPick) {
-        const parsedPickChartKey = parsePickChartKey(playerPick.pick_chart_key);
-        const resolvedPickChart = getResolvedPickChart(playerPick.pick_chart_key);
-        const resolvedPickChartVersion = getChartVersionLabel(resolvedPickChart);
+    const playerPick = roundPickByIndex.get(index) ?? null;
+    if (playerPick) {
+      const isOwnPick = activePlayerId !== null && playerPick.player_id === activePlayerId;
+      const shouldMaskPick = snapshot.room_state === "PICKING" && !isOwnPick;
+      if (shouldMaskPick) {
         return {
-          title: parsedPickChartKey
-            ? formatSongKeyTitle(
-                parsedPickChartKey.title_search_key,
-                parsedPickChartKey.play_style,
-                parsedPickChartKey.difficulty,
-              )
-            : resolvedPickChart?.title ?? "DECIDED",
-          artist: formatSongArtist(resolvedPickChart?.artist ?? null),
-          ...(resolvedPickChartVersion ? { version: resolvedPickChartVersion } : {}),
-          playStyle: parsedPickChartKey?.play_style ?? snapshot.settings.play_style,
-          level: resolvedPickChart?.level ?? "?",
-          difficulty: getDifficultyId(parsedPickChartKey?.difficulty ?? resolvedPickChart?.difficulty),
+          title: "DECIDED",
+          artist: "Track Hidden",
+          playStyle: snapshot.settings.play_style,
+          level: "?",
+          difficulty: "-",
         };
       }
-    }
-
-    if (index === 2) {
-      return { title: "?????", artist: "System Random", playStyle: snapshot.settings.play_style, level: "??" };
+      const parsedPickChartKey = parsePickChartKey(playerPick.pick_chart_key);
+      const resolvedPickChart = getResolvedPickChart(playerPick.pick_chart_key);
+      const resolvedPickChartVersion = getChartVersionLabel(resolvedPickChart);
+      return {
+        title: parsedPickChartKey
+          ? formatSongKeyTitle(
+              parsedPickChartKey.title_search_key,
+              parsedPickChartKey.play_style,
+              parsedPickChartKey.difficulty,
+            )
+          : resolvedPickChart?.title ?? "DECIDED",
+        artist: formatSongArtist(resolvedPickChart?.artist ?? null),
+        ...(resolvedPickChartVersion ? { version: resolvedPickChartVersion } : {}),
+        playStyle: parsedPickChartKey?.play_style ?? snapshot.settings.play_style,
+        level: resolvedPickChart?.level ?? "?",
+        difficulty: getDifficultyId(parsedPickChartKey?.difficulty ?? resolvedPickChart?.difficulty),
+      };
     }
 
     return null;
@@ -2451,7 +2507,7 @@ export function RoomPage() {
         playerMetrics: bplPlayerMetrics,
         metricLabel: bplMetricLabel,
         resultPlayers: bplResultPlayers,
-        resultRegulationLabel: "3 STAGES",
+        resultRegulationLabel: getBplStageLabel(snapshot.settings.mode),
         finalResultPlayers: bplFinalResultPlayers,
         finalWinningPlayerName: bplWinningPlayerName,
         isHost,

--- a/apps/worker/src/durable/room-state.test.mjs
+++ b/apps/worker/src/durable/room-state.test.mjs
@@ -24,6 +24,7 @@ function createChartMaster() {
     buildChart("chart-1", "chart-one", "Chart One", 11),
     buildChart("chart-2", "chart-two", "Chart Two", 8),
     buildChart("chart-3", "chart-three", "Chart Three", 10),
+    buildChart("chart-4", "chart-four", "Chart Four", 9),
     buildChart("chart-bit", "chart-bit", "Chart Bit", 10, { inf_unlock_type: "bit" }),
     buildChart("chart-djp", "chart-djp", "Chart Djp", 10, { inf_unlock_type: "djp" }),
     buildChart("chart-pack-2", "chart-pack-2", "Chart Pack 2", 10, { inf_unlock_type: "pack", inf_pack_id: 2 }),
@@ -154,12 +155,18 @@ function prepareMatch(state, input = {}) {
   const startAt = input.startAt ?? "2026-03-08T00:01:00.000Z";
   const hostPick = input.hostPick ?? "chart-1";
   const guestPick = input.guestPick ?? "chart-2";
+  const hostSecondPick = input.hostSecondPick ?? "chart-3";
+  const guestSecondPick = input.guestSecondPick ?? "chart-4";
 
   assert.equal(state.setPlayerReady("host", true).ok, true);
   assert.equal(state.setPlayerReady("guest", true).ok, true);
   assert.deepEqual(state.startMatch("host", new Date(startAt)), { ok: true });
   assert.equal(state.submitPick("host", hostPick, new Date("2026-03-08T00:01:10.000Z")).ok, true);
   assert.equal(state.submitPick("guest", guestPick, new Date("2026-03-08T00:01:11.000Z")).ok, true);
+  if (state.toSnapshot().settings.mode === "BPL4") {
+    assert.equal(state.submitPick("host", hostSecondPick, new Date("2026-03-08T00:01:12.000Z")).ok, true);
+    assert.equal(state.submitPick("guest", guestSecondPick, new Date("2026-03-08T00:01:13.000Z")).ok, true);
+  }
   assert.equal(state.getRoomState(), "PLAYING");
 }
 
@@ -388,6 +395,28 @@ test("RESULT -> LOBBY clears ready and match transient state without auto-start"
   assert.equal(typeof secondStartSnapshot.current_match_id, "string");
   assert.notEqual(secondStartSnapshot.current_match_id, "room-1");
   assert.notEqual(secondStartSnapshot.current_match_id, firstMatchId);
+});
+
+test("BPL(3) keeps PICKING TTL at 120 seconds", () => {
+  const state = createState({ mode: "BPL", max_players: 2 });
+  assert.equal(state.setPlayerReady("host", true).ok, true);
+  assert.equal(state.setPlayerReady("guest", true).ok, true);
+  assert.deepEqual(state.startMatch("host", new Date("2026-03-08T00:01:00.000Z")), { ok: true });
+
+  const snapshot = state.toSnapshot();
+  assert.equal(snapshot.room_state, "PICKING");
+  assert.equal(snapshot.timers.picking_deadline, "2026-03-08T00:03:00.000Z");
+});
+
+test("BPL4 extends PICKING TTL to 180 seconds", () => {
+  const state = createState({ mode: "BPL4", max_players: 2 });
+  assert.equal(state.setPlayerReady("host", true).ok, true);
+  assert.equal(state.setPlayerReady("guest", true).ok, true);
+  assert.deepEqual(state.startMatch("host", new Date("2026-03-08T00:01:00.000Z")), { ok: true });
+
+  const snapshot = state.toSnapshot();
+  assert.equal(snapshot.room_state, "PICKING");
+  assert.equal(snapshot.timers.picking_deadline, "2026-03-08T00:04:00.000Z");
 });
 
 test("PRIVATE auto_rematch starts next match from RESULT after countdown", () => {
@@ -669,7 +698,7 @@ test("mismatched observed_key poisons the match even if the player later submits
   assert.equal(summary.rated_block_reason, "mismatch_observed_key");
 });
 
-test("BPL always plays 3 stages before entering RESULT", () => {
+test("BPL(3) always plays 3 stages before entering RESULT", () => {
   const state = createState({ mode: "BPL", max_players: 2 });
   prepareMatch(state);
 
@@ -687,33 +716,84 @@ test("BPL always plays 3 stages before entering RESULT", () => {
   assert.deepEqual(summary.winner_player_ids, ["host"]);
 });
 
-test("BPL random third stage level stays within first two picks range", () => {
+test("BPL(3) freezes two picks plus one random stage", () => {
   const state = createState({ mode: "BPL", max_players: 2 });
-  prepareMatch(state, { hostPick: "chart-1", guestPick: "chart-2" });
+  prepareMatch(state, {
+    hostPick: "chart-1",
+    guestPick: "chart-2",
+  });
 
   const snapshot = state.toSnapshot();
+  const titles = snapshot.frozen_rounds.map((round) => round.display.title);
   assert.equal(snapshot.frozen_rounds.length, 3);
+  assert.deepEqual(titles.slice(0, 2), ["Chart One", "Chart Two"]);
+  assert.equal(new Set(titles).size, 3);
+  assert.equal(["Chart Three", "Chart Four"].includes(titles[2] ?? ""), true);
+});
 
-  const firstLevel = snapshot.frozen_rounds[0]?.display.level;
-  const secondLevel = snapshot.frozen_rounds[1]?.display.level;
-  const randomLevel = snapshot.frozen_rounds[2]?.display.level;
+test("BPL4 always plays 4 stages before entering RESULT", () => {
+  const state = createState({ mode: "BPL4", max_players: 2 });
+  prepareMatch(state);
 
-  assert.equal(typeof firstLevel, "number");
-  assert.equal(typeof secondLevel, "number");
-  assert.equal(typeof randomLevel, "number");
+  playCurrentRound(state, 0, 2200, 2100, "2026-03-08T00:02");
+  playCurrentRound(state, 1, 2300, 2000, "2026-03-08T00:03");
+  assert.equal(state.getRoomState(), "PLAYING");
+  assert.equal(state.toSnapshot().current_round?.round_index, 2);
 
-  const minLevel = Math.min(firstLevel, secondLevel);
-  const maxLevel = Math.max(firstLevel, secondLevel);
-  assert.ok(randomLevel >= minLevel && randomLevel <= maxLevel);
+  playCurrentRound(state, 2, 2400, 2300, "2026-03-08T00:04");
+  assert.equal(state.getRoomState(), "PLAYING");
+  assert.equal(state.toSnapshot().current_round?.round_index, 3);
+  playCurrentRound(state, 3, 2500, 2400, "2026-03-08T00:05");
+
+  const summary = getResultSummary(state);
+  assert.equal(state.getRoomState(), "RESULT");
+  assert.equal(summary.is_rated, true);
+  assert.equal(summary.rated_block_reason, null);
+  assert.deepEqual(summary.winner_player_ids, ["host"]);
+});
+
+test("BPL4 freezes four stages from player picks in accepted order", () => {
+  const state = createState({ mode: "BPL4", max_players: 2 });
+  prepareMatch(state, {
+    hostPick: "chart-1",
+    guestPick: "chart-2",
+    hostSecondPick: "chart-3",
+    guestSecondPick: "chart-4",
+  });
+
+  const snapshot = state.toSnapshot();
+  assert.equal(snapshot.frozen_rounds.length, 4);
+  assert.deepEqual(
+    snapshot.frozen_rounds.map((round) => round.display.title),
+    ["Chart One", "Chart Two", "Chart Three", "Chart Four"],
+  );
+});
+
+test("BPL4 allows two picks per player and rejects a third pick", () => {
+  const state = createState({ mode: "BPL4", max_players: 2 });
+  assert.equal(state.setPlayerReady("host", true).ok, true);
+  assert.equal(state.setPlayerReady("guest", true).ok, true);
+  assert.deepEqual(state.startMatch("host", new Date("2026-03-08T00:01:00.000Z")), { ok: true });
+
+  assert.equal(state.submitPick("host", "chart-1", new Date("2026-03-08T00:01:10.000Z")).ok, true);
+  assert.equal(state.submitPick("guest", "chart-2", new Date("2026-03-08T00:01:11.000Z")).ok, true);
+  assert.equal(state.submitPick("host", "chart-3", new Date("2026-03-08T00:01:12.000Z")).ok, true);
+  assert.deepEqual(
+    state.submitPick("host", "chart-4", new Date("2026-03-08T00:01:13.000Z")),
+    { ok: false, reason: "PLAYER_ALREADY_PICKED" },
+  );
+  assert.equal(state.submitPick("guest", "chart-4", new Date("2026-03-08T00:01:14.000Z")).ok, true);
+  assert.equal(state.getRoomState(), "PLAYING");
 });
 
 test("conflicting final result blocks rating", () => {
-  const state = createState({ mode: "BPL", max_players: 2 });
+  const state = createState({ mode: "BPL4", max_players: 2 });
   prepareMatch(state);
 
   playCurrentRound(state, 0, 2200, 2100, "2026-03-08T00:02");
   playCurrentRound(state, 1, 2000, 2300, "2026-03-08T00:03");
   playCurrentRound(state, 2, 2100, 2100, "2026-03-08T00:04");
+  playCurrentRound(state, 3, 2200, 2200, "2026-03-08T00:05");
 
   const summary = getResultSummary(state);
   assert.equal(summary.is_rated, false);

--- a/apps/worker/src/durable/room-state.ts
+++ b/apps/worker/src/durable/room-state.ts
@@ -1,5 +1,7 @@
 import {
   AUTO_REMATCH_RESULT_SECONDS,
+  BPL4_ROUNDS,
+  BPL4_PICKING_TTL_SECONDS,
   BPL_ROUNDS,
   HOST_SKIP_UNLOCK_SECONDS,
   MATCH_TTL_MINUTES,
@@ -374,8 +376,9 @@ function computeReadyCheckDeadline(openedAt: Date): Date {
   return new Date(openedAt.getTime() + READY_CHECK_TTL_MINUTES * 60_000);
 }
 
-function computePickingDeadline(startedAt: Date): Date {
-  return new Date(startedAt.getTime() + PICKING_TTL_SECONDS * 1_000);
+function computePickingDeadline(startedAt: Date, mode: RoomSettings["mode"]): Date {
+  const pickingTtlSeconds = mode === "BPL4" ? BPL4_PICKING_TTL_SECONDS : PICKING_TTL_SECONDS;
+  return new Date(startedAt.getTime() + pickingTtlSeconds * 1_000);
 }
 
 function computeRejoinUntil(now: Date): Date {
@@ -459,14 +462,6 @@ function computeMatchSongUnlockFilter(players: InternalPlayer[]): MatchSongUnloc
 
 function canNewPlayerJoin(roomState: RoomState): roomState is "LOBBY" {
   return roomState === "LOBBY";
-}
-
-function expectedKeyId(expectedKey: ExpectedKey): string {
-  if (typeof expectedKey.chart_id === "number" && Number.isInteger(expectedKey.chart_id) && expectedKey.chart_id > 0) {
-    return `chart_id::${expectedKey.chart_id}`;
-  }
-
-  return `${expectedKey.play_style}::${expectedKey.difficulty}::${expectedKey.title_search_key}`;
 }
 
 function cloneExpectedKey(expectedKey: ExpectedKey): ExpectedKey {
@@ -826,7 +821,7 @@ export class RoomLobbyState {
       return { ok: false, reason: "NOT_ALL_PLAYERS_READY" };
     }
 
-    if (this.settings.mode === "BPL" && this.players.size !== 2) {
+    if (this.isBplMode() && this.players.size !== 2) {
       return { ok: false, reason: "BPL_REQUIRES_TWO_PLAYERS" };
     }
 
@@ -915,7 +910,8 @@ export class RoomLobbyState {
       return { ok: false, reason: "PLAYER_NOT_FOUND" };
     }
 
-    if (this.picks.some((pick) => pick.player_id === playerId)) {
+    const playerPickCount = this.picks.filter((pick) => pick.player_id === playerId).length;
+    if (playerPickCount >= this.getRequiredPickCountForPlayer(playerId)) {
       return { ok: false, reason: "PLAYER_ALREADY_PICKED" };
     }
 
@@ -960,7 +956,7 @@ export class RoomLobbyState {
       },
     };
 
-    if (this.picks.length < this.matchPlayerIds.length) {
+    if (this.picks.length < this.getRequiredPickCount()) {
       return result;
     }
 
@@ -1263,12 +1259,17 @@ export class RoomLobbyState {
     }
 
     const usedChartKeys = new Set(this.picks.map((pick) => pick.pick_chart_key));
-    const missingPlayerIds = this.matchPlayerIds.filter(
-      (playerId) => !this.picks.some((pick) => pick.player_id === playerId),
-    );
+    const missingPickPlayerIds: string[] = [];
+    for (const playerId of this.matchPlayerIds) {
+      const currentPickCount = this.picks.filter((pick) => pick.player_id === playerId).length;
+      const requiredPickCountForPlayer = this.getRequiredPickCountForPlayer(playerId);
+      for (let pickIndex = currentPickCount; pickIndex < requiredPickCountForPlayer; pickIndex += 1) {
+        missingPickPlayerIds.push(playerId);
+      }
+    }
     const acceptedPicks: PickingTimeoutResult["accepted_picks"] = [];
 
-    for (const [index, playerId] of missingPlayerIds.entries()) {
+    for (const [index, playerId] of missingPickPlayerIds.entries()) {
       const acceptedAt = new Date(now.getTime() + index);
       const autoPick = this.chartMaster.pickRandomUnusedChart({
         play_style: this.settings.play_style,
@@ -1986,13 +1987,13 @@ export class RoomLobbyState {
       return { ok: false, reason: "START_REQUIRES_MIN_PLAYERS" };
     }
 
-    if (this.settings.mode === "BPL" && participants.length !== 2) {
+    if (this.isBplMode() && participants.length !== 2) {
       return { ok: false, reason: "BPL_REQUIRES_TWO_PLAYERS" };
     }
 
     this.roomState = "PICKING";
     this.readyCheckDeadline = null;
-    this.pickingDeadline = computePickingDeadline(now);
+    this.pickingDeadline = computePickingDeadline(now, this.settings.mode);
     this.matchDeadline = computeMatchDeadline(now);
     this.resultDeadline = null;
     this.closedAt = null;
@@ -2086,7 +2087,7 @@ export class RoomLobbyState {
       return { ok: false, reason: "INSUFFICIENT_PLAYERS" };
     }
 
-    if (this.settings.mode === "BPL" && participantIds.length !== 2) {
+    if (this.isBplMode() && participantIds.length !== 2) {
       return { ok: false, reason: "INSUFFICIENT_PLAYERS" };
     }
 
@@ -2186,6 +2187,55 @@ export class RoomLobbyState {
     };
   }
 
+  private isBplMode(): boolean {
+    return this.settings.mode === "BPL" || this.settings.mode === "BPL4";
+  }
+
+  private isBplFourStageMode(): boolean {
+    return this.settings.mode === "BPL4";
+  }
+
+  private getBplRoundCount(): number {
+    return this.isBplFourStageMode() ? BPL4_ROUNDS : BPL_ROUNDS;
+  }
+
+  private getRequiredPickCount(): number {
+    if (this.settings.mode === "ARENA") {
+      return this.matchPlayerIds.length;
+    }
+
+    if (!this.isBplMode()) {
+      return this.matchPlayerIds.length;
+    }
+
+    return this.isBplFourStageMode() ? this.getBplRoundCount() : this.matchPlayerIds.length;
+  }
+
+  private getRequiredPickCountForPlayer(playerId: string): number {
+    if (!this.matchPlayerIds.includes(playerId)) {
+      return 0;
+    }
+
+    if (!this.isBplMode()) {
+      return 1;
+    }
+
+    if (!this.isBplFourStageMode()) {
+      return 1;
+    }
+
+    const participantCount = this.matchPlayerIds.length;
+    if (participantCount <= 0) {
+      return 0;
+    }
+
+    const playerIndex = this.matchPlayerIds.indexOf(playerId);
+    const roundCount = this.getBplRoundCount();
+    const basePickCount = Math.floor(roundCount / participantCount);
+    const extraPickCount = roundCount % participantCount;
+    return basePickCount + (playerIndex >= 0 && playerIndex < extraPickCount ? 1 : 0);
+  }
+
   private buildFrozenRounds(): FrozenRound[] {
     const picksByAcceptedOrder = [...this.picks].sort(
       (left, right) => left.accepted_at.getTime() - right.accepted_at.getTime(),
@@ -2204,8 +2254,25 @@ export class RoomLobbyState {
       }));
     }
 
-    if (picksByAcceptedOrder.length < 2) {
+    if (!this.isBplMode()) {
       return [];
+    }
+
+    if (picksByAcceptedOrder.length < this.getRequiredPickCount()) {
+      return [];
+    }
+
+    if (this.isBplFourStageMode()) {
+      return picksByAcceptedOrder.slice(0, this.getBplRoundCount()).map((pick, index) => ({
+        round_index: index,
+        expected_key: cloneExpectedKey(pick.expected_key),
+        display: {
+          title: pick.display.title,
+          level: pick.display.level,
+        },
+        started_at: null,
+        soft_ttl_seconds: ROUND_SOFT_TTL_SECONDS,
+      }));
     }
 
     const rounds: FrozenRound[] = picksByAcceptedOrder.slice(0, 2).map((pick, index) => ({
@@ -2219,18 +2286,22 @@ export class RoomLobbyState {
       soft_ttl_seconds: ROUND_SOFT_TTL_SECONDS,
     }));
 
-    const randomRound = this.buildMasterRandomRound(rounds.length, rounds);
+    const usedChartKeys = new Set(picksByAcceptedOrder.slice(0, 2).map((pick) => pick.pick_chart_key));
+    const randomRound = this.buildMasterRandomRound(rounds.length, rounds, usedChartKeys);
     if (randomRound === null) {
       return [];
     }
 
     rounds.push(randomRound);
 
-    return rounds.slice(0, BPL_ROUNDS);
+    return rounds.slice(0, this.getBplRoundCount());
   }
 
-  private buildMasterRandomRound(roundIndex: number, existingRounds: FrozenRound[]): FrozenRound | null {
-    const usedKeys = new Set(existingRounds.map((round) => expectedKeyId(round.expected_key)));
+  private buildMasterRandomRound(
+    roundIndex: number,
+    existingRounds: FrozenRound[],
+    usedChartKeys: Set<string>,
+  ): FrozenRound | null {
     const pickedLevels = existingRounds
       .map((round) => round.display.level)
       .filter((level): level is number => typeof level === "number");
@@ -2242,14 +2313,14 @@ export class RoomLobbyState {
     const randomChart = this.chartMaster.pickRandomUnusedChart({
       play_style: this.settings.play_style,
       level_filter: this.settings.level_filter,
-      used_chart_keys: usedKeys,
+      used_chart_keys: usedChartKeys,
       ...(this.matchSongUnlockFilter === null
         ? {}
         : { unlock_filter: this.matchSongUnlockFilter }),
       preferred_level_min: levelMin,
       preferred_level_max: levelMax,
       enforce_level_range: true,
-      seed: `${this.roomId}:random:${roundIndex}:${Array.from(usedKeys).sort().join("|")}`,
+      seed: `${this.roomId}:random:${roundIndex}:${Array.from(usedChartKeys).sort().join("|")}`,
     });
     if (randomChart === null) {
       return null;
@@ -2328,7 +2399,7 @@ export class RoomLobbyState {
   }
 
   private getRoundLeadInSeconds(roundIndex: number): number {
-    if (this.settings.mode === "BPL") {
+    if (this.isBplMode()) {
       return roundIndex === 0 ? BPL_PICK_CUTIN_DELAY_SECONDS : BPL_RESULT_PHASE_DELAY_SECONDS;
     }
 
@@ -2353,7 +2424,7 @@ export class RoomLobbyState {
   }
 
   private shouldEnterResultAfterRound(roundIndex: number): boolean {
-    if (this.settings.mode !== "BPL") {
+    if (!this.isBplMode()) {
       return false;
     }
 
@@ -2565,7 +2636,7 @@ export class RoomLobbyState {
       return {
         summary: {
           match_id: matchId,
-          mode: this.settings.mode,
+          mode: this.settings.mode === "ARENA" ? "ARENA" : "BPL",
           win_metric: this.settings.win_metric,
           total_rounds: this.frozenRounds.length,
           completed_rounds: completedRounds,
@@ -2652,7 +2723,7 @@ export class RoomLobbyState {
     return {
       summary: {
         match_id: matchId,
-        mode: this.settings.mode,
+        mode: "BPL",
         win_metric: this.settings.win_metric,
         total_rounds: this.frozenRounds.length,
         completed_rounds: completedRounds,

--- a/docs/design/01_fsm.md
+++ b/docs/design/01_fsm.md
@@ -53,7 +53,8 @@
 
 ## 4. タイマー（固定値 / DOが管理）
 - `ready_check_ttl = 20min`（LOBBY開始または `RESULT -> LOBBY` 復帰から。超過で解散）
-- `picking_ttl = 120s`（PICKING開始から。超過で未pick者をランダム補完して凍結）
+- `picking_ttl = 120s`（ARENA / BPL(3) の PICKING開始から。超過で未pick者をランダム補完して凍結）
+- `bpl4_picking_ttl = 180s`（BPL4 の PICKING開始から。超過で未pick者をランダム補完して凍結）
 - `round_soft_ttl = 5min`（`count_go` 以降。超過で未確定者をTIMEOUT確定）
 - `host_skip_unlock_seconds = 240s`（`SKIP_HOST_ASSIGN` 用の予約値。現行v1では操作を受理しない）
 - `match_ttl = 30min`（`START_MATCH` 成功時、すなわち `PICKING` 開始時から固定）
@@ -63,7 +64,7 @@
 - `visibility`: `PUBLIC | PRIVATE`
 - `join_code`: string|null
 - `auto_rematch`: boolean（`PRIVATE` のみ有効）
-- `mode`: `ARENA | BPL`
+- `mode`: `ARENA | BPL | BPL4`
 - `win_metric`: `SCORE | MISSCOUNT`
 - `play_style`: `SP | DP`
 - `level_filter`: `ANY | LV8_10 | LV10 | LV11 | LV12`
@@ -115,7 +116,9 @@
 
 ## 8. PICKING（指名・凍結）
 ### 8.1 指名ルール
-- 各プレイヤーは 1譜面指名（`pick_chart_key`）
+- ARENA: 各プレイヤーは 1譜面指名（`pick_chart_key`）
+- BPL: 各プレイヤーは 1譜面指名（2人固定）
+- BPL4: 各プレイヤーは 2譜面指名（2人固定）
 - 指名は DO の受信時刻（DOが付与）で先着順
 - 同一譜面重複は許可しない
   - 重複検出時、後着の枠だけ DO が同フィルタで「未使用譜面」を抽選し差し替え
@@ -124,8 +127,10 @@
 
 ### 8.2 凍結リスト構築
 - ARENA: 参加人数 = ラウンド数（各自1譜面）
-- BPL: 3 STAGE固定
-  - 2人想定: `P1指名 + P2指名 + ランダム1`（同フィルタ・未使用、かつ P1/P2 の選曲レベル最小〜最大の範囲で抽選）
+- BPL(3 STAGE): 2人固定
+  - `P1指名 + P2指名 + Masterランダム1譜面`
+- BPL4(4 STAGE): 2人固定
+  - `P1指名 + P2指名 + P1指名 + P2指名`
 - 凍結時に各ラウンドへ `expected_key` を確定して埋める
   - `expected_key = (play_style, difficulty, title_search_key, chart_id?)`
   - `chart_id` が確定できる場合は優先し、欠落時は従来キーで後方互換運用する
@@ -205,11 +210,12 @@
 - 同点は同順位、順位飛ばしあり（競技標準）
   - 例: 2人同率1位 → 2,2,0,0
 
-### 10.3 BPL（3 STAGE固定）
+### 10.3 BPL / BPL4
 - 各ラウンド勝者が1勝
-- 3ラウンドを必ず実施し、総勝ち数で勝敗を決定
+- BPL: 3ラウンドを実施し、総勝ち数で勝敗を決定
+- BPL4: 4ラウンドを実施し、総勝ち数で勝敗を決定
 - 同点（SCORE同値 / MISSCOUNT同値）は「勝ち数加算なし」
-- 3ラウンド終了時に同勝ち数なら総合引き分け
+- 既定ラウンド終了時に同勝ち数なら総合引き分け
 
 ### 10.4 再戦復帰
 - ホスト操作で `RESULT -> LOBBY` に戻せる

--- a/docs/design/03_data_model.md
+++ b/docs/design/03_data_model.md
@@ -41,7 +41,7 @@
 - `event_seq: int`
 
 ### 2.2 RoomSettings（Ph1）
-- `mode: ARENA|BPL`
+- `mode: ARENA|BPL|BPL4`
 - `auto_rematch: bool`（`PRIVATE` のみ有効）
 - `win_metric: SCORE|MISSCOUNT`
 - `play_style: SP|DP`
@@ -187,11 +187,12 @@ type LobbyRoomSummary = {
 - rank3+: 0
 - 同点同順位、順位飛ばしあり
 
-### 5.4 BPL（3 round）
-- 3ラウンド固定
+### 5.4 BPL / BPL4
+- BPL: 3ラウンド固定（2人が1曲ずつ選曲 + Masterランダム1曲）
+- BPL4: 4ラウンド固定（2人が2曲ずつ選曲）
 - 各ラウンド勝者が1勝
 - 同点は勝ち数加算なし
-- 3ラウンド終了時の総勝ち数で勝敗を決め、同勝ち数なら総合引き分け
+- 既定ラウンド終了時の総勝ち数で勝敗を決め、同勝ち数なら総合引き分け
 
 ## 6. タイトル同定（Ph1 v1）
 

--- a/docs/design/07_constants.md
+++ b/docs/design/07_constants.md
@@ -14,7 +14,9 @@ Ph1で固定するタイマー値、制約値、表示/運用上の定数を整�
 - `START_MIN_PLAYERS = 2`
   - `players < 2` の間はホスト `START_MATCH` 不可
 - `PICKING_TTL_SECONDS = 120`
-  - PICKING開始から120秒で未pickをランダム補完
+  - ARENA / BPL(3) の PICKING 制限時間
+- `BPL4_PICKING_TTL_SECONDS = 180`
+  - BPL4 の PICKING 制限時間
 
 ## 1.2 ラウンド進行
 - `ROUND_SOFT_TTL_SECONDS = 300`
@@ -105,9 +107,11 @@ Ph1で固定するタイマー値、制約値、表示/運用上の定数を整�
 - `ARENA_POINT_RANK_3 = 0`
 - `ARENA_POINT_RANK_4 = 0`
 
-## 4.5 BPL
+## 4.5 BPL / BPL4
 - `BPL_ROUNDS = 3`
-  - 3 STAGE固定
+  - BPL（3 STAGE）
+- `BPL4_ROUNDS = 4`
+  - BPL4（4 STAGE）
 
 ---
 

--- a/docs/design/08_repo_structure.md
+++ b/docs/design/08_repo_structure.md
@@ -307,7 +307,7 @@ apps/worker/src/durable/
 ### result-rating.ts
 
 * rated 可否判定
-* ARENA 配点 / BPL 3 round 集計
+* ARENA 配点 / BPL・BPL4 集計
 * RESULT_READY 用のレーティング情報生成
 
 ### ws-codec.ts

--- a/packages/shared/src/constants/scoring.ts
+++ b/packages/shared/src/constants/scoring.ts
@@ -14,3 +14,4 @@ export const ARENA_POINT_RANK_3 = 0;
 export const ARENA_POINT_RANK_4 = 0;
 
 export const BPL_ROUNDS = 3;
+export const BPL4_ROUNDS = 4;

--- a/packages/shared/src/constants/timers.ts
+++ b/packages/shared/src/constants/timers.ts
@@ -1,6 +1,7 @@
 export const READY_CHECK_TTL_MINUTES = 20;
 export const START_MIN_PLAYERS = 2;
 export const PICKING_TTL_SECONDS = 120;
+export const BPL4_PICKING_TTL_SECONDS = 180;
 
 export const ROUND_SOFT_TTL_SECONDS = 300;
 export const HOST_SKIP_UNLOCK_SECONDS = 240;

--- a/packages/shared/src/enums/gameplay.ts
+++ b/packages/shared/src/enums/gameplay.ts
@@ -1,4 +1,4 @@
-export const MODES = ["ARENA", "BPL"] as const;
+export const MODES = ["ARENA", "BPL", "BPL4"] as const;
 
 export type Mode = (typeof MODES)[number];
 

--- a/tasks/codex-issue-116-bpl-4stage.md
+++ b/tasks/codex-issue-116-bpl-4stage.md
@@ -1,0 +1,59 @@
+# codex-issue-116-bpl-4stage
+
+## Purpose
+- 既存 BPL（3 STAGE）に加えて、2人が2曲ずつ選曲する BPL 4 STAGE モードを追加する。
+- Room の進行、集計、クライアント表示を 4 STAGE 前提で一貫させる。
+
+## Non-goals
+- ARENA モードの進行仕様変更。
+- 監視ソース I/O（watcher/parser）仕様変更。
+- Cloudflare のデプロイ設定、依存関係更新。
+
+## Changes
+- 規範 design doc の BPL 仕様を 4 STAGE 追加に合わせて更新する。
+- worker の BPL round 構築/進行/集計を 4 STAGE へ対応し、既存 3 STAGE 回帰を防ぐ。
+- client のモード表示・ステージ枠・履歴/結果表示を 4 STAGE と整合させる。
+- 必要最小限のテストを更新し、BPL 4 STAGE の成立を検証する。
+
+## Impact
+- Users: BPL で 4 曲（各プレイヤー2曲）の対戦が可能になる。
+- Data: BPL の round 配列長と関連表示データが 4 STAGE 前提になる。
+- Compatibility: BPL 進行契約が変更されるため、design doc と実装を同時に整合させる。
+- Cloudflare: Durable Object の room 進行ロジックのみ変更（route/KV 契約は変更しない）。
+
+## Target Files / Layers
+- Files:
+  - `docs/design/01_fsm.md`
+  - `docs/design/03_data_model.md`
+  - `docs/design/07_constants.md`
+  - `packages/worker/src/room-state.ts`
+  - `packages/worker/test/*bpl*`（必要最小限）
+  - `apps/client/src/pages/RoomPage.tsx`
+  - `apps/client/src/components/RoomBPL.tsx`（必要な場合のみ）
+- Layers:
+  - docs / worker / client（必要なら shared）
+
+## Test Focus
+- QUALITY section 1: 対象パッケージの build/lint/test 実行。
+- QUALITY section 2: 目的外 diff・encoding/LF ノイズが無いこと。
+- QUALITY section 3: BPL の round 進行、終了判定、host 権限、idempotency 影響なしを確認。
+- QUALITY section 4: 監視ソース仕様に変更なし（not required）。
+- QUALITY section 5: BPL 4 STAGE の最小 E2E 相当（room flow）を確認。
+
+## Rollback Plan
+- worker/client の BPL 4 STAGE 変更コミットを revert し、3 STAGE の既存挙動へ戻す。
+- docs を同時に revert して仕様と実装の不一致を解消する。
+
+## Commit Split Plan
+1. docs: BPL 4 STAGE 契約更新（FSM/Data model/Constants）
+2. worker: BPL 4 STAGE round 構築・進行・集計と関連テスト更新
+3. client: BPL 4 STAGE 表示・文言・履歴/結果整合
+4. tests/chore: 必要最小限の検証調整（分離が必要な場合のみ）
+
+## Checklist
+- [x] Design doc alignment confirmed (if required)
+- [x] Impact scope identified
+- [x] Implementation completed
+- [x] Tests completed
+- [x] Regression checks completed
+- [x] Documentation updates completed (if required)


### PR DESCRIPTION
## 概要
- BPL4モードを追加し、仕様書・shared定数・worker進行をBPL(3)/BPL(4)両対応へ更新
- BPL-PICKINGのUI/導線を調整（4STAGE対応、選曲進捗表示、相手選曲マスキング、制限時間反映）
- 統計でBPL(3)/BPL(4)をBPLとして統合表示できるようにストレージ読込時の正規化を追加
- BPL-PICKING-MATCH表示の小文字化を廃止し、元のケースを保持

## コミット計画対応
1. docs(design): BPL4仕様契約更新
2. feat(worker): BPL4進行・TTL・ラウンド/選曲対応
3. feat(client): BPL4 UIフローと統計正規化
4. test(chore): 統計回帰テスト追加とQUALITY更新

## 検証
- npm run test:worker
- npm run test:client-stats
- npm run typecheck
- npm run lint
- npm run build:client

Closes #116