### PR TITLE
Issue #124: PUBLICルーム向けSNS共有/joinページ/deep link導線を実装

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2.5.1",
+    "@tauri-apps/plugin-deep-link": "^2.0.0",
     "@tauri-apps/plugin-updater": "^2.5.1",
     "lucide-react": "^0.446.0",
     "react": "^19.1.0",

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@tauri-apps/api": "^2.5.1",
     "@tauri-apps/plugin-deep-link": "^2.0.0",
+    "@tauri-apps/plugin-opener": "^2.5.3",
     "@tauri-apps/plugin-updater": "^2.5.1",
     "lucide-react": "^0.446.0",
     "react": "^19.1.0",

--- a/apps/client/src-tauri/Cargo.lock
+++ b/apps/client/src-tauri/Cargo.lock
@@ -1966,6 +1966,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-deep-link",
+ "tauri-plugin-opener",
  "tauri-plugin-single-instance",
  "tauri-plugin-tts",
  "tauri-plugin-updater",
@@ -2006,6 +2007,25 @@ checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -2653,6 +2673,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "dunce",
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2754,6 +2786,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -4301,6 +4339,28 @@ dependencies = [
  "url",
  "windows-registry",
  "windows-result 0.3.4",
+]
+
+[[package]]
+name = "tauri-plugin-opener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc624469b06f59f5a29f874bbc61a2ed737c0f9c23ef09855a292c389c42e83f"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "open",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "url",
+ "windows 0.61.3",
+ "zbus",
 ]
 
 [[package]]

--- a/apps/client/src-tauri/Cargo.lock
+++ b/apps/client/src-tauri/Cargo.lock
@@ -580,6 +580,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +708,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -889,6 +915,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1584,6 +1619,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1745,7 +1786,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -1924,6 +1965,8 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-deep-link",
+ "tauri-plugin-single-instance",
  "tauri-plugin-tts",
  "tauri-plugin-updater",
  "unicode-normalization",
@@ -2614,6 +2657,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "ordered-stream"
@@ -3434,6 +3487,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4220,6 +4283,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94deb2e2e4641514ac496db2cddcfc850d6fc9d51ea17b82292a0490bd20ba5b"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "windows-registry",
+ "windows-result 0.3.4",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc61e4822b8f74d68278e09161d3e3fdd1b14b9eb781e24edccaabf10c420e8c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin-deep-link",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-plugin-tts"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4468,6 +4568,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -5329,7 +5438,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5486,6 +5595,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]

--- a/apps/client/src-tauri/Cargo.toml
+++ b/apps/client/src-tauri/Cargo.toml
@@ -14,6 +14,8 @@ rfd = "0.15.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", features = [] }
+tauri-plugin-deep-link = "2"
+tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 tauri-plugin-tts = "0.1.2"
 tauri-plugin-updater = "2.5.1"
 unicode-normalization = "0.1"

--- a/apps/client/src-tauri/Cargo.toml
+++ b/apps/client/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", features = [] }
 tauri-plugin-deep-link = "2"
+tauri-plugin-opener = "2"
 tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 tauri-plugin-tts = "0.1.2"
 tauri-plugin-updater = "2.5.1"

--- a/apps/client/src-tauri/capabilities/default.json
+++ b/apps/client/src-tauri/capabilities/default.json
@@ -3,5 +3,5 @@
   "identifier": "main-capability",
   "description": "Capability for the main window",
   "windows": ["main"],
-  "permissions": ["core:default", "tts:default", "updater:default", "deep-link:default"]
+  "permissions": ["core:default", "tts:default", "updater:default", "deep-link:default", "opener:default"]
 }

--- a/apps/client/src-tauri/capabilities/default.json
+++ b/apps/client/src-tauri/capabilities/default.json
@@ -3,5 +3,5 @@
   "identifier": "main-capability",
   "description": "Capability for the main window",
   "windows": ["main"],
-  "permissions": ["core:default", "tts:default", "updater:default"]
+  "permissions": ["core:default", "tts:default", "updater:default", "deep-link:default"]
 }

--- a/apps/client/src-tauri/src/lib.rs
+++ b/apps/client/src-tauri/src/lib.rs
@@ -24,6 +24,16 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_tts::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        .setup(|app| {
+            #[cfg(any(target_os = "linux", all(debug_assertions, windows)))]
+            {
+                use tauri_plugin_deep_link::DeepLinkExt;
+
+                app.deep_link().register_all()?;
+            }
+
+            Ok(())
+        })
         .manage(SourceWatcherManager::default())
         .invoke_handler(tauri::generate_handler![
             get_source_watcher_state,

--- a/apps/client/src-tauri/src/lib.rs
+++ b/apps/client/src-tauri/src/lib.rs
@@ -21,6 +21,7 @@ pub fn run() {
 
     builder
         .plugin(tauri_plugin_deep_link::init())
+        .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_tts::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(SourceWatcherManager::default())

--- a/apps/client/src-tauri/src/lib.rs
+++ b/apps/client/src-tauri/src/lib.rs
@@ -12,7 +12,15 @@ use watchers::SourceWatcherManager;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let mut builder = tauri::Builder::default();
+
+    #[cfg(desktop)]
+    {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|_app, _argv, _cwd| {}));
+    }
+
+    builder
+        .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_tts::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(SourceWatcherManager::default())

--- a/apps/client/src-tauri/tauri.conf.json
+++ b/apps/client/src-tauri/tauri.conf.json
@@ -33,6 +33,11 @@
     ]
   },
   "plugins": {
+    "deep-link": {
+      "desktop": {
+        "schemes": ["infinitas-arena"]
+      }
+    },
     "updater": {
       "endpoints": [],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDRBNEFEREU1NjQwMkNBNEYKUldSUHlnSms1ZDFLU2xHSTAxcVZpblRWWHdoWTNzdWlYY0JMRzFSeXNqUjJIYklIcUhjWEppYWgK",

--- a/apps/client/src/app/App.tsx
+++ b/apps/client/src/app/App.tsx
@@ -14,11 +14,41 @@ import { initializeE2EObservability } from "../services/e2e-observability";
 import { startE2EScenarioRunner } from "../services/e2e-scenario-runner";
 import { runtimeConfig } from "../runtime/runtime-config";
 import { statsArchiveService } from "../services/stats-archive";
+import { logClientShareAnalytics } from "../services/share-analytics";
+import { getCurrentDeepLinkUrls, listenToDeepLinkUrls } from "../services/tauri-bridge";
 import { voiceAnnouncerService } from "../services/voice-announcer";
 import { lobbyStore } from "../stores/lobby-store";
 import { roomStore, useRoomStore } from "../stores/room-store";
 import { sourceStore, useSourceStore } from "../stores/source-store";
 import { isRoomEntryReady, settingsStore, useSettingsStore } from "../stores/settings-store";
+
+function parseJoinRoomRefFromDeepLink(rawUrl: string): string | null {
+  try {
+    const parsed = new URL(rawUrl);
+    if (parsed.protocol !== "infinitas-arena:") {
+      return null;
+    }
+    if (parsed.hostname !== "join" && parsed.pathname !== "/join") {
+      return null;
+    }
+
+    const roomRef = parsed.searchParams.get("r")?.trim();
+    return roomRef && roomRef.length > 0 ? roomRef : null;
+  } catch {
+    return null;
+  }
+}
+
+function pickRoomRefFromDeepLinkUrls(urls: string[]): string | null {
+  for (const url of urls) {
+    const roomRef = parseJoinRoomRefFromDeepLink(url);
+    if (roomRef !== null) {
+      return roomRef;
+    }
+  }
+
+  return null;
+}
 
 export function App() {
   const savedSettings = useSettingsStore((state) => state.saved);
@@ -29,6 +59,10 @@ export function App() {
   const sourceUnresolvedDialog = useSourceStore((state) => state.activeUnresolvedDialog);
   const [activeView, setActiveView] = useState<AppView>("lobby");
   const activeViewRef = useRef<AppView>(activeView);
+  const roomSnapshotRef = useRef(roomSnapshot);
+  const roomConnectionStatusRef = useRef(roomConnectionStatus);
+  const pendingDeepLinkRoomIdRef = useRef<string | null>(null);
+  const [pendingDeepLinkRoomId, setPendingDeepLinkRoomId] = useState<string | null>(null);
   const [mockScenario] = useState(() =>
     runtimeConfig.mockScenarioId ? getVisualScenario(runtimeConfig.mockScenarioId) : null,
   );
@@ -46,6 +80,11 @@ export function App() {
   useEffect(() => {
     activeViewRef.current = activeView;
   }, [activeView]);
+
+  useEffect(() => {
+    roomSnapshotRef.current = roomSnapshot;
+    roomConnectionStatusRef.current = roomConnectionStatus;
+  }, [roomConnectionStatus, roomSnapshot]);
 
   useEffect(() => {
     if (roomSnapshot !== null && activeView !== "room") {
@@ -154,6 +193,89 @@ export function App() {
   ]);
 
   useEffect(() => {
+    if (mockScenarioRequested) {
+      return;
+    }
+
+    let disposed = false;
+    let stopListening: (() => void) | null = null;
+
+    const handleDeepLinkUrls = (urls: string[], trigger: "startup" | "runtime"): void => {
+      const roomRef = pickRoomRefFromDeepLinkUrls(urls);
+      if (roomRef === null) {
+        return;
+      }
+
+      const hasActiveRoom =
+        roomSnapshotRef.current !== null ||
+        roomConnectionStatusRef.current === "CONNECTING" ||
+        roomConnectionStatusRef.current === "JOINING" ||
+        roomConnectionStatusRef.current === "CONNECTED";
+      if (hasActiveRoom) {
+        logClientShareAnalytics("join_page_deep_link_ignored", {
+          trigger,
+          roomId: roomRef,
+          reason: "active_room",
+          roomState: roomSnapshotRef.current?.room_state ?? null,
+          connectionStatus: roomConnectionStatusRef.current,
+        });
+        return;
+      }
+
+      pendingDeepLinkRoomIdRef.current = roomRef;
+      setPendingDeepLinkRoomId(roomRef);
+      logClientShareAnalytics("join_page_deep_link_received", {
+        trigger,
+        roomId: roomRef,
+      });
+      startTransition(() => {
+        setActiveView("lobby");
+      });
+    };
+
+    void (async () => {
+      try {
+        const startUrls = await getCurrentDeepLinkUrls();
+        handleDeepLinkUrls(startUrls, "startup");
+        stopListening = await listenToDeepLinkUrls((urls) => {
+          handleDeepLinkUrls(urls, "runtime");
+        });
+        if (disposed && stopListening !== null) {
+          stopListening();
+          stopListening = null;
+        }
+      } catch {
+        // no-op: deep-link plugin may be unavailable in non-desktop contexts.
+      }
+    })();
+
+    return () => {
+      disposed = true;
+      if (stopListening !== null) {
+        stopListening();
+        stopListening = null;
+      }
+    };
+  }, [mockScenarioRequested]);
+
+  useEffect(() => {
+    if (roomSnapshot === null || roomConnectionStatus !== "CONNECTED") {
+      return;
+    }
+
+    if (pendingDeepLinkRoomIdRef.current !== roomSnapshot.room_id) {
+      return;
+    }
+
+    logClientShareAnalytics("join_page_join_succeeded", {
+      roomId: roomSnapshot.room_id,
+      roomState: roomSnapshot.room_state,
+    });
+    pendingDeepLinkRoomIdRef.current = null;
+    setPendingDeepLinkRoomId(null);
+  }, [roomConnectionStatus, roomSnapshot]);
+
+  useEffect(() => {
     void initializeE2EObservability();
     const stopRunner = startE2EScenarioRunner(() => activeViewRef.current);
     return () => {
@@ -230,7 +352,14 @@ export function App() {
       {activeView !== "room" ? <AppSidebar activeView={activeView} hasRoom={roomSnapshot !== null} onNavigate={navigate} /> : null}
 
       <section className={activeView === "room" ? "relative min-w-0 flex-1 overflow-hidden" : "custom-scrollbar relative min-w-0 flex-1 overflow-y-auto p-8"}>
-        {activeView === "lobby" ? <LobbyPage /> : null}
+        {activeView === "lobby" ? (
+          <LobbyPage
+            pendingJoinRoomId={pendingDeepLinkRoomId}
+            onConsumePendingJoinRoomId={() => {
+              setPendingDeepLinkRoomId(null);
+            }}
+          />
+        ) : null}
         {activeView === "settings" ? (
           <SettingsPage
             roomJoined={roomSnapshot !== null}

--- a/apps/client/src/components/RoomArena.tsx
+++ b/apps/client/src/components/RoomArena.tsx
@@ -84,6 +84,7 @@ export interface RoomArenaControlledState {
     pickingCountdownSeconds?: number | null;
     logs?: RoomArenaLogEntry[];
     matchInfoItems?: RoomArenaMatchInfoItem[];
+    publicSharePanel?: ReactNode;
     playTime: number;
     playingPhase: 'MUSIC_SELECT' | 'PLAY_START' | 'IN_PLAY';
     playingCountdownSeconds?: number | null;
@@ -284,6 +285,7 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
         { label: 'Mode', value: 'ARENA' },
         { label: 'Scoring', value: 'EX SCORE' },
     ];
+    const publicSharePanel = controlled?.publicSharePanel ?? null;
 
     const allMockPlayers = controlled?.allPlayers ?? [
         { id: '1', name: 'PLAYER_ONE (HOST)', isReady: true, isHost: true },
@@ -1140,7 +1142,13 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
                     </div>
                 </section>
 
-                <section className="pt-6 border-t border-white/5">
+                {publicSharePanel ? (
+                    <section className="pt-6 border-t border-white/5">
+                        {publicSharePanel}
+                    </section>
+                ) : null}
+
+                <section className={publicSharePanel ? "pt-6" : "pt-6 border-t border-white/5"}>
                     <h3 className="text-[10px] font-black text-gray-500 uppercase tracking-widest mb-4 flex items-center gap-2">
                         <Info size={14} /> Match Info
                     </h3>

--- a/apps/client/src/pages/LobbyPage.tsx
+++ b/apps/client/src/pages/LobbyPage.tsx
@@ -14,7 +14,7 @@ import {
   type RoomSettings,
 } from "@infinitas/shared";
 import { AlertCircle, Eye, EyeOff, Key, Lock, MessageSquare, Plus, RefreshCcw, Search, Trophy, Users, X } from "lucide-react";
-import { useMemo, useRef, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { createRoom } from "../services/worker-api-client";
 import { lobbyStore, useLobbyStore } from "../stores/lobby-store";
@@ -104,7 +104,15 @@ function ModalPortal({ children }: { children: ReactNode }) {
   return createPortal(children, document.body);
 }
 
-export function LobbyPage() {
+interface LobbyPageProps {
+  pendingJoinRoomId?: string | null;
+  onConsumePendingJoinRoomId?: () => void;
+}
+
+export function LobbyPage({
+  pendingJoinRoomId = null,
+  onConsumePendingJoinRoomId,
+}: LobbyPageProps) {
   const savedSettings = useSettingsStore((state) => state.saved);
   const rooms = useLobbyStore((state) => state.rooms);
   const loading = useLobbyStore((state) => state.loading);
@@ -139,6 +147,20 @@ export function LobbyPage() {
   const manualJoinCodeError = validateJoinCode(manualJoinCode);
   const createJoinCodeError = validateJoinCode(createDraft.join_code ?? "");
   const createBusy = busyAction === "create";
+
+  useEffect(() => {
+    const trimmedRoomId = pendingJoinRoomId?.trim() ?? "";
+    if (trimmedRoomId.length === 0) {
+      return;
+    }
+
+    setShowManualJoinCode(false);
+    setShowManualJoin(true);
+    setManualRoomId(trimmedRoomId);
+    setManualJoinCode("");
+    setLocalMessage(null);
+    onConsumePendingJoinRoomId?.();
+  }, [onConsumePendingJoinRoomId, pendingJoinRoomId]);
 
   function closeManualJoinModal(): void {
     setShowManualJoinCode(false);

--- a/apps/client/src/pages/RoomPage.tsx
+++ b/apps/client/src/pages/RoomPage.tsx
@@ -63,6 +63,7 @@ import {
   setRoomPresentationSeOverride,
   useVoicePlaybackStore,
 } from "../services/voice-announcer";
+import { openExternalUrl } from "../services/tauri-bridge";
 import { roomStore, useRoomStore, type RoomConnectionStatus } from "../stores/room-store";
 import { isVoicePlaybackEnabled, useSettingsStore } from "../stores/settings-store";
 import { formatDateTime, stringifyJson } from "../utils/format";
@@ -112,6 +113,7 @@ const BPL_PICK_CUTIN_SECONDS = 3;
 const BPL_RESULT_PHASE_SECONDS = 10;
 const ARENA_RESULT_PHASE_SECONDS = 10;
 const DEFAULT_JOIN_PAGE_URL = "https://tts1374.github.io/infinitas_arena/join";
+const X_SHARE_HASHTAGS = ["INFINITAS_ARENA"] as const;
 
 function isBplMode(mode: RoomStateSnapshot["settings"]["mode"]): boolean {
   return mode === "BPL" || mode === "BPL4";
@@ -453,6 +455,7 @@ function buildXShareText(
   if (joinCode !== null && joinCode.trim().length > 0) {
     lines.push(`join code: ${joinCode.trim()}`);
   }
+  lines.push(X_SHARE_HASHTAGS.map((tag) => `#${tag}`).join(" "));
 
   return lines.join("\n");
 }
@@ -1656,6 +1659,7 @@ export function RoomPage() {
   const shareJoinCode =
     includeJoinCodeInXShare && joinCodeLabel.trim().length > 0 ? joinCodeLabel.trim() : null;
   const xShareText = buildXShareText(shareRoomName, shareJoinPageUrl, shareJoinCode);
+  const xShareHashtagCsv = X_SHARE_HASHTAGS.join(",");
   const publicSharePanel: ReactNode = canShowSharePanel ? (
     <div className="rounded-2xl border border-cyan-400/30 bg-[#10151d]/95 p-4 shadow-[0_14px_36px_rgba(0,0,0,0.55)] backdrop-blur-sm">
       <div className="mb-3 flex items-center justify-between">
@@ -1668,7 +1672,19 @@ export function RoomPage() {
         </span>
       </div>
       <p className="text-sm font-semibold text-white">{shareRoomName}</p>
-      <p className="mt-1 break-all text-xs text-cyan-100/80">{shareJoinPageUrl}</p>
+      <div className="mt-2 flex items-start gap-2 rounded-xl border border-white/10 bg-black/20 px-3 py-2">
+        <p className="min-w-0 flex-1 break-all text-xs leading-4 text-cyan-100/80 max-h-8 overflow-hidden">
+          {shareJoinPageUrl}
+        </p>
+        <button
+          type="button"
+          onClick={handleCopyShareUrl}
+          className="inline-flex shrink-0 items-center justify-center gap-1 rounded-lg border border-white/20 bg-black/25 px-2 py-1 text-[10px] font-black uppercase tracking-[0.15em] text-gray-100 transition-all hover:border-white/35 hover:bg-white/10"
+        >
+          {copiedShareUrl ? <Check size={12} /> : <Copy size={12} />}
+          {copiedShareUrl ? "Copied" : "Copy"}
+        </button>
+      </div>
       <label className="mt-3 flex cursor-pointer items-center justify-between gap-3 rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-xs text-gray-200">
         <span className="font-semibold">X本文に join_code を含める</span>
         <button
@@ -1685,22 +1701,14 @@ export function RoomPage() {
           {includeJoinCodeInXShare ? "ON" : "OFF"}
         </button>
       </label>
-      <div className="mt-3 grid grid-cols-2 gap-2">
+      <div className="mt-3">
         <button
           type="button"
           onClick={handleShareToX}
-          className="inline-flex items-center justify-center gap-2 rounded-xl bg-cyan-500 px-3 py-2 text-xs font-black uppercase tracking-[0.2em] text-black transition-all hover:bg-cyan-400"
+          className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-cyan-500 px-3 py-2 text-xs font-black uppercase tracking-[0.2em] text-black transition-all hover:bg-cyan-400"
         >
           <ExternalLink size={14} />
           X共有
-        </button>
-        <button
-          type="button"
-          onClick={handleCopyShareUrl}
-          className="inline-flex items-center justify-center gap-2 rounded-xl border border-white/20 bg-black/25 px-3 py-2 text-xs font-black uppercase tracking-[0.2em] text-gray-100 transition-all hover:border-white/35 hover:bg-white/10"
-        >
-          {copiedShareUrl ? <Check size={14} /> : <Copy size={14} />}
-          {copiedShareUrl ? "Copied" : "URLコピー"}
         </button>
       </div>
     </div>
@@ -1833,7 +1841,7 @@ export function RoomPage() {
     handleCopy(shareJoinPageUrl, setCopiedShareUrl);
   }
 
-  function handleShareToX(): void {
+  async function handleShareToX(): Promise<void> {
     if (!shareJoinPageUrl) {
       return;
     }
@@ -1846,7 +1854,19 @@ export function RoomPage() {
     });
     const intentUrl = new URL("https://x.com/intent/tweet");
     intentUrl.searchParams.set("text", xShareText);
-    window.open(intentUrl.toString(), "_blank", "noopener,noreferrer");
+    if (xShareHashtagCsv.length > 0) {
+      intentUrl.searchParams.set("hashtags", xShareHashtagCsv);
+    }
+
+    try {
+      await openExternalUrl(intentUrl.toString());
+    } catch (error) {
+      logClientShareAnalytics("share_url_generated", {
+        roomId: roomIdLabel,
+        source: "x_intent_failed",
+        reason: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   function submitManualResult(): void {

--- a/apps/client/src/pages/RoomPage.tsx
+++ b/apps/client/src/pages/RoomPage.tsx
@@ -1656,6 +1656,55 @@ export function RoomPage() {
   const shareJoinCode =
     includeJoinCodeInXShare && joinCodeLabel.trim().length > 0 ? joinCodeLabel.trim() : null;
   const xShareText = buildXShareText(shareRoomName, shareJoinPageUrl, shareJoinCode);
+  const publicSharePanel: ReactNode = canShowSharePanel ? (
+    <div className="rounded-2xl border border-cyan-400/30 bg-[#10151d]/95 p-4 shadow-[0_14px_36px_rgba(0,0,0,0.55)] backdrop-blur-sm">
+      <div className="mb-3 flex items-center justify-between">
+        <p className="inline-flex items-center gap-2 text-[10px] font-black uppercase tracking-[0.24em] text-cyan-200">
+          <Share2 size={12} />
+          Public Share
+        </p>
+        <span className="rounded-full border border-cyan-400/35 bg-cyan-400/10 px-2 py-0.5 text-[10px] font-bold text-cyan-100">
+          Host only
+        </span>
+      </div>
+      <p className="text-sm font-semibold text-white">{shareRoomName}</p>
+      <p className="mt-1 break-all text-xs text-cyan-100/80">{shareJoinPageUrl}</p>
+      <label className="mt-3 flex cursor-pointer items-center justify-between gap-3 rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-xs text-gray-200">
+        <span className="font-semibold">X本文に join_code を含める</span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={includeJoinCodeInXShare}
+          onClick={() => setIncludeJoinCodeInXShare((current) => !current)}
+          className={`rounded-lg border px-2 py-1 text-[10px] font-black uppercase tracking-[0.2em] transition-all ${
+            includeJoinCodeInXShare
+              ? "border-cyan-400 bg-cyan-400/15 text-cyan-100"
+              : "border-white/15 bg-black/30 text-gray-400 hover:border-white/30"
+          }`}
+        >
+          {includeJoinCodeInXShare ? "ON" : "OFF"}
+        </button>
+      </label>
+      <div className="mt-3 grid grid-cols-2 gap-2">
+        <button
+          type="button"
+          onClick={handleShareToX}
+          className="inline-flex items-center justify-center gap-2 rounded-xl bg-cyan-500 px-3 py-2 text-xs font-black uppercase tracking-[0.2em] text-black transition-all hover:bg-cyan-400"
+        >
+          <ExternalLink size={14} />
+          X共有
+        </button>
+        <button
+          type="button"
+          onClick={handleCopyShareUrl}
+          className="inline-flex items-center justify-center gap-2 rounded-xl border border-white/20 bg-black/25 px-3 py-2 text-xs font-black uppercase tracking-[0.2em] text-gray-100 transition-all hover:border-white/35 hover:bg-white/10"
+        >
+          {copiedShareUrl ? <Check size={14} /> : <Copy size={14} />}
+          {copiedShareUrl ? "Copied" : "URLコピー"}
+        </button>
+      </div>
+    </div>
+  ) : null;
   const currentExpectedKey = currentRound?.expected_key ?? null;
   const currentExpectedKeyCacheKey = getExpectedKeyCacheKey(currentExpectedKey);
   const currentResolvedChart =
@@ -2684,6 +2733,7 @@ export function RoomPage() {
       pickingCountdownSeconds: pickingCountdown ?? 0,
       logs: arenaLobbyLogs,
       matchInfoItems: arenaMatchInfoItems,
+      publicSharePanel,
       playTime: playElapsedSeconds,
       playingPhase: mockPlayingPhase,
       playingCountdownSeconds: playingCountdown?.remainingSeconds ?? null,
@@ -2722,58 +2772,6 @@ export function RoomPage() {
   return (
     <section id="visual-capture-root" className="flex h-full min-h-0 w-full flex-col text-white font-sans">
       {roomSurface}
-
-      {canShowSharePanel ? (
-        <div className="pointer-events-none fixed left-4 top-4 z-[146] w-[min(360px,calc(100vw-2rem))]">
-          <div className="pointer-events-auto rounded-2xl border border-cyan-400/30 bg-[#10151d]/95 p-4 shadow-[0_14px_36px_rgba(0,0,0,0.55)] backdrop-blur-sm">
-            <div className="mb-3 flex items-center justify-between">
-              <p className="inline-flex items-center gap-2 text-[10px] font-black uppercase tracking-[0.24em] text-cyan-200">
-                <Share2 size={12} />
-                Public Share
-              </p>
-              <span className="rounded-full border border-cyan-400/35 bg-cyan-400/10 px-2 py-0.5 text-[10px] font-bold text-cyan-100">
-                Host only
-              </span>
-            </div>
-            <p className="text-sm font-semibold text-white">{shareRoomName}</p>
-            <p className="mt-1 break-all text-xs text-cyan-100/80">{shareJoinPageUrl}</p>
-            <label className="mt-3 flex cursor-pointer items-center justify-between gap-3 rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-xs text-gray-200">
-              <span className="font-semibold">X本文に join_code を含める</span>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={includeJoinCodeInXShare}
-                onClick={() => setIncludeJoinCodeInXShare((current) => !current)}
-                className={`rounded-lg border px-2 py-1 text-[10px] font-black uppercase tracking-[0.2em] transition-all ${
-                  includeJoinCodeInXShare
-                    ? "border-cyan-400 bg-cyan-400/15 text-cyan-100"
-                    : "border-white/15 bg-black/30 text-gray-400 hover:border-white/30"
-                }`}
-              >
-                {includeJoinCodeInXShare ? "ON" : "OFF"}
-              </button>
-            </label>
-            <div className="mt-3 grid grid-cols-2 gap-2">
-              <button
-                type="button"
-                onClick={handleShareToX}
-                className="inline-flex items-center justify-center gap-2 rounded-xl bg-cyan-500 px-3 py-2 text-xs font-black uppercase tracking-[0.2em] text-black transition-all hover:bg-cyan-400"
-              >
-                <ExternalLink size={14} />
-                X共有
-              </button>
-              <button
-                type="button"
-                onClick={handleCopyShareUrl}
-                className="inline-flex items-center justify-center gap-2 rounded-xl border border-white/20 bg-black/25 px-3 py-2 text-xs font-black uppercase tracking-[0.2em] text-gray-100 transition-all hover:border-white/35 hover:bg-white/10"
-              >
-                {copiedShareUrl ? <Check size={14} /> : <Copy size={14} />}
-                {copiedShareUrl ? "Copied" : "URLコピー"}
-              </button>
-            </div>
-          </div>
-        </div>
-      ) : null}
 
       {autoRematchPanelVisible ? (
         <div className="pointer-events-none fixed bottom-4 left-0 right-0 z-[145] px-4 md:left-auto md:right-4 md:w-[min(460px,calc(100vw-2rem))]">

--- a/apps/client/src/pages/RoomPage.tsx
+++ b/apps/client/src/pages/RoomPage.tsx
@@ -18,7 +18,11 @@ import {
 } from "@infinitas/shared";
 import {
   AlertTriangle,
+  Check,
+  Copy,
   Database,
+  ExternalLink,
+  Share2,
   ShieldAlert,
   Volume2,
 } from "lucide-react";
@@ -50,6 +54,7 @@ import {
 } from "../components/SongSearchModalView";
 import { runtimeConfig } from "../runtime/runtime-config";
 import { useLocalResultArchiveStore } from "../services/result-archive";
+import { logClientShareAnalytics } from "../services/share-analytics";
 import { listCharts, listRoomCharts } from "../services/worker-api-client";
 import {
   clearRoomPresentationSeOverride,
@@ -106,6 +111,7 @@ type ChartSearchEntryWithVersion = ChartSearchEntry & {
 const BPL_PICK_CUTIN_SECONDS = 3;
 const BPL_RESULT_PHASE_SECONDS = 10;
 const ARENA_RESULT_PHASE_SECONDS = 10;
+const DEFAULT_JOIN_PAGE_URL = "https://tts1374.github.io/infinitas_arena/join";
 
 function isBplMode(mode: RoomStateSnapshot["settings"]["mode"]): boolean {
   return mode === "BPL" || mode === "BPL4";
@@ -425,6 +431,30 @@ function formatRoomTitle(
   }
 
   return `${isBplMode(mode) ? `BPL (${getBplStageLabel(mode)})` : "ARENA"} ${playStyle}`;
+}
+
+function buildJoinPageUrl(baseUrl: string, roomId: string): string {
+  try {
+    const resolved = new URL(baseUrl, window.location.origin);
+    resolved.searchParams.set("r", roomId);
+    return resolved.toString();
+  } catch {
+    const encodedRoomId = encodeURIComponent(roomId);
+    return `${DEFAULT_JOIN_PAGE_URL}?r=${encodedRoomId}`;
+  }
+}
+
+function buildXShareText(
+  roomName: string,
+  joinPageUrl: string,
+  joinCode: string | null,
+): string {
+  const lines = [`INFINITAS Arena: ${roomName}`, joinPageUrl];
+  if (joinCode !== null && joinCode.trim().length > 0) {
+    lines.push(`join code: ${joinCode.trim()}`);
+  }
+
+  return lines.join("\n");
 }
 
 function getLobbyStartIssues(snapshot: RoomStateSnapshot): string[] {
@@ -747,6 +777,10 @@ export function RoomPage() {
   const voiceDetail = useVoicePlaybackStore((state) => state.detail);
   const voiceLastUpdatedAt = useVoicePlaybackStore((state) => state.lastUpdatedAt);
   const voicePendingCues = useVoicePlaybackStore((state) => state.pendingCues);
+  const joinPageBaseUrl =
+    import.meta.env.VITE_JOIN_PAGE_URL?.trim().length > 0
+      ? import.meta.env.VITE_JOIN_PAGE_URL.trim()
+      : DEFAULT_JOIN_PAGE_URL;
 
   const [metricValue, setMetricValue] = useState("0");
   const [chartDifficulty, setChartDifficulty] = useState<(typeof CHART_DIFFICULTIES)[number] | "">("");
@@ -760,6 +794,8 @@ export function RoomPage() {
   const [clockNowMs, setClockNowMs] = useState(() => Date.now());
   const [copiedRoomId, setCopiedRoomId] = useState(false);
   const [copiedJoinCode, setCopiedJoinCode] = useState(false);
+  const [copiedShareUrl, setCopiedShareUrl] = useState(false);
+  const [includeJoinCodeInXShare, setIncludeJoinCodeInXShare] = useState(false);
   const [showHostLeaveConfirm, setShowHostLeaveConfirm] = useState(false);
   const [showRoomAudioMenu, setShowRoomAudioMenu] = useState(false);
   const [roomPresentationSeEnabled, setRoomPresentationSeEnabled] = useState(savedSettings.enablePresentationSe);
@@ -777,6 +813,7 @@ export function RoomPage() {
   const skipLobbySoundDiffRef = useRef(true);
   const previousRoomStateRef = useRef<RoomStateSnapshot["room_state"] | null>(null);
   const previousRoomIdRef = useRef<string | null>(null);
+  const initialShareClosedByStateRef = useRef(false);
   const pickerModalVisibleRef = useRef(false);
   const mySubmittedPicks = snapshot?.picks.filter((pick) => pick.player_id === activePlayerId) ?? [];
   const mySubmittedPick = mySubmittedPicks[mySubmittedPicks.length - 1] ?? null;
@@ -1168,11 +1205,24 @@ export function RoomPage() {
     setPendingOwnPickCutIn(null);
     setOwnPickCutInChart(null);
     setShowRoomAudioMenu(false);
+    setCopiedShareUrl(false);
+    setIncludeJoinCodeInXShare(false);
+    initialShareClosedByStateRef.current = false;
     if (cutInTimeoutRef.current !== null) {
       window.clearTimeout(cutInTimeoutRef.current);
       cutInTimeoutRef.current = null;
     }
   }, [snapshot?.room_id]);
+
+  useEffect(() => {
+    if (snapshot === null) {
+      return;
+    }
+
+    if (snapshot.room_state !== "LOBBY") {
+      initialShareClosedByStateRef.current = true;
+    }
+  }, [snapshot?.room_state]);
 
   useEffect(() => {
     if (snapshot === null) {
@@ -1586,6 +1636,26 @@ export function RoomPage() {
     currentRound === null ? null : roundPickerNameByIndex.get(currentRound.round_index) ?? null;
   const roomIdLabel = snapshot.room_id;
   const joinCodeLabel = snapshot.settings.join_code ?? "";
+  const shareRoomName = formatRoomTitle(
+    snapshot.settings.mode,
+    snapshot.settings.play_style,
+    snapshot.settings.room_comment,
+  );
+  const shareJoinPageUrl = buildJoinPageUrl(joinPageBaseUrl, roomIdLabel);
+  const isInitialLobbyShareWindow =
+    snapshot.room_state === "LOBBY" &&
+    !initialShareClosedByStateRef.current &&
+    snapshot.current_round === null &&
+    snapshot.picks.length === 0 &&
+    snapshot.frozen_rounds.length === 0 &&
+    !snapshot.result_ready;
+  const canShowSharePanel =
+    isHost &&
+    snapshot.settings.visibility === "PUBLIC" &&
+    isInitialLobbyShareWindow;
+  const shareJoinCode =
+    includeJoinCodeInXShare && joinCodeLabel.trim().length > 0 ? joinCodeLabel.trim() : null;
+  const xShareText = buildXShareText(shareRoomName, shareJoinPageUrl, shareJoinCode);
   const currentExpectedKey = currentRound?.expected_key ?? null;
   const currentExpectedKeyCacheKey = getExpectedKeyCacheKey(currentExpectedKey);
   const currentResolvedChart =
@@ -1699,6 +1769,35 @@ export function RoomPage() {
       setCopied(true);
       window.setTimeout(() => setCopied(false), 2_000);
     });
+  }
+
+  function handleCopyShareUrl(): void {
+    if (!shareJoinPageUrl) {
+      return;
+    }
+
+    logClientShareAnalytics("share_url_generated", {
+      roomId: roomIdLabel,
+      source: "copy",
+      includeJoinCodeInX: includeJoinCodeInXShare,
+    });
+    handleCopy(shareJoinPageUrl, setCopiedShareUrl);
+  }
+
+  function handleShareToX(): void {
+    if (!shareJoinPageUrl) {
+      return;
+    }
+
+    logClientShareAnalytics("share_url_generated", {
+      roomId: roomIdLabel,
+      source: "x_intent",
+      includeJoinCodeInX: includeJoinCodeInXShare,
+      hasJoinCode: joinCodeLabel.trim().length > 0,
+    });
+    const intentUrl = new URL("https://x.com/intent/tweet");
+    intentUrl.searchParams.set("text", xShareText);
+    window.open(intentUrl.toString(), "_blank", "noopener,noreferrer");
   }
 
   function submitManualResult(): void {
@@ -2623,6 +2722,58 @@ export function RoomPage() {
   return (
     <section id="visual-capture-root" className="flex h-full min-h-0 w-full flex-col text-white font-sans">
       {roomSurface}
+
+      {canShowSharePanel ? (
+        <div className="pointer-events-none fixed left-4 top-4 z-[146] w-[min(360px,calc(100vw-2rem))]">
+          <div className="pointer-events-auto rounded-2xl border border-cyan-400/30 bg-[#10151d]/95 p-4 shadow-[0_14px_36px_rgba(0,0,0,0.55)] backdrop-blur-sm">
+            <div className="mb-3 flex items-center justify-between">
+              <p className="inline-flex items-center gap-2 text-[10px] font-black uppercase tracking-[0.24em] text-cyan-200">
+                <Share2 size={12} />
+                Public Share
+              </p>
+              <span className="rounded-full border border-cyan-400/35 bg-cyan-400/10 px-2 py-0.5 text-[10px] font-bold text-cyan-100">
+                Host only
+              </span>
+            </div>
+            <p className="text-sm font-semibold text-white">{shareRoomName}</p>
+            <p className="mt-1 break-all text-xs text-cyan-100/80">{shareJoinPageUrl}</p>
+            <label className="mt-3 flex cursor-pointer items-center justify-between gap-3 rounded-xl border border-white/10 bg-black/20 px-3 py-2 text-xs text-gray-200">
+              <span className="font-semibold">X本文に join_code を含める</span>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={includeJoinCodeInXShare}
+                onClick={() => setIncludeJoinCodeInXShare((current) => !current)}
+                className={`rounded-lg border px-2 py-1 text-[10px] font-black uppercase tracking-[0.2em] transition-all ${
+                  includeJoinCodeInXShare
+                    ? "border-cyan-400 bg-cyan-400/15 text-cyan-100"
+                    : "border-white/15 bg-black/30 text-gray-400 hover:border-white/30"
+                }`}
+              >
+                {includeJoinCodeInXShare ? "ON" : "OFF"}
+              </button>
+            </label>
+            <div className="mt-3 grid grid-cols-2 gap-2">
+              <button
+                type="button"
+                onClick={handleShareToX}
+                className="inline-flex items-center justify-center gap-2 rounded-xl bg-cyan-500 px-3 py-2 text-xs font-black uppercase tracking-[0.2em] text-black transition-all hover:bg-cyan-400"
+              >
+                <ExternalLink size={14} />
+                X共有
+              </button>
+              <button
+                type="button"
+                onClick={handleCopyShareUrl}
+                className="inline-flex items-center justify-center gap-2 rounded-xl border border-white/20 bg-black/25 px-3 py-2 text-xs font-black uppercase tracking-[0.2em] text-gray-100 transition-all hover:border-white/35 hover:bg-white/10"
+              >
+                {copiedShareUrl ? <Check size={14} /> : <Copy size={14} />}
+                {copiedShareUrl ? "Copied" : "URLコピー"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
 
       {autoRematchPanelVisible ? (
         <div className="pointer-events-none fixed bottom-4 left-0 right-0 z-[145] px-4 md:left-auto md:right-4 md:w-[min(460px,calc(100vw-2rem))]">

--- a/apps/client/src/pages/RoomPage.tsx
+++ b/apps/client/src/pages/RoomPage.tsx
@@ -112,7 +112,7 @@ type ChartSearchEntryWithVersion = ChartSearchEntry & {
 const BPL_PICK_CUTIN_SECONDS = 3;
 const BPL_RESULT_PHASE_SECONDS = 10;
 const ARENA_RESULT_PHASE_SECONDS = 10;
-const DEFAULT_JOIN_PAGE_URL = "https://tts1374.github.io/infinitas_arena/join";
+const DEFAULT_JOIN_PAGE_URL = "https://tts1374.github.io/infinitas_arena/join/";
 const X_SHARE_HASHTAGS = ["INFINITAS_ARENA"] as const;
 
 function isBplMode(mode: RoomStateSnapshot["settings"]["mode"]): boolean {
@@ -438,6 +438,9 @@ function formatRoomTitle(
 function buildJoinPageUrl(baseUrl: string, roomId: string): string {
   try {
     const resolved = new URL(baseUrl, window.location.origin);
+    if (!resolved.pathname.endsWith("/")) {
+      resolved.pathname = `${resolved.pathname}/`;
+    }
     resolved.searchParams.set("r", roomId);
     return resolved.toString();
   } catch {

--- a/apps/client/src/pages/RoomPage.tsx
+++ b/apps/client/src/pages/RoomPage.tsx
@@ -451,13 +451,14 @@ function buildXShareText(
   joinPageUrl: string,
   joinCode: string | null,
 ): string {
-  const lines = [`INFINITAS Arena: ${roomName}`, joinPageUrl];
+  const parts = [`【INFINITAS Arena】${roomName}`];
   if (joinCode !== null && joinCode.trim().length > 0) {
-    lines.push(`join code: ${joinCode.trim()}`);
+    parts.push(`join code:${joinCode.trim()}`);
   }
-  lines.push(X_SHARE_HASHTAGS.map((tag) => `#${tag}`).join(" "));
+  parts.push(X_SHARE_HASHTAGS.map((tag) => `#${tag}`).join(" "));
+  parts.push(joinPageUrl);
 
-  return lines.join("\n");
+  return parts.join(" ");
 }
 
 function getLobbyStartIssues(snapshot: RoomStateSnapshot): string[] {
@@ -1659,7 +1660,6 @@ export function RoomPage() {
   const shareJoinCode =
     includeJoinCodeInXShare && joinCodeLabel.trim().length > 0 ? joinCodeLabel.trim() : null;
   const xShareText = buildXShareText(shareRoomName, shareJoinPageUrl, shareJoinCode);
-  const xShareHashtagCsv = X_SHARE_HASHTAGS.join(",");
   const publicSharePanel: ReactNode = canShowSharePanel ? (
     <div className="rounded-2xl border border-cyan-400/30 bg-[#10151d]/95 p-4 shadow-[0_14px_36px_rgba(0,0,0,0.55)] backdrop-blur-sm">
       <div className="mb-3 flex items-center justify-between">
@@ -1854,9 +1854,6 @@ export function RoomPage() {
     });
     const intentUrl = new URL("https://x.com/intent/tweet");
     intentUrl.searchParams.set("text", xShareText);
-    if (xShareHashtagCsv.length > 0) {
-      intentUrl.searchParams.set("hashtags", xShareHashtagCsv);
-    }
 
     try {
       await openExternalUrl(intentUrl.toString());

--- a/apps/client/src/services/share-analytics.ts
+++ b/apps/client/src/services/share-analytics.ts
@@ -1,0 +1,17 @@
+type ClientShareAnalyticsEvent =
+  | "share_url_generated"
+  | "join_page_deep_link_received"
+  | "join_page_deep_link_ignored"
+  | "join_page_join_succeeded";
+
+export function logClientShareAnalytics(
+  event: ClientShareAnalyticsEvent,
+  payload: Record<string, unknown>,
+): void {
+  console.info("[share-analytics]", {
+    ts: new Date().toISOString(),
+    platform: "client",
+    event,
+    ...payload,
+  });
+}

--- a/apps/client/src/services/tauri-bridge.ts
+++ b/apps/client/src/services/tauri-bridge.ts
@@ -267,6 +267,18 @@ export async function listenToDeepLinkUrls(
   });
 }
 
+export async function openExternalUrl(url: string): Promise<void> {
+  if (isTauriRuntime()) {
+    const { openUrl } = await import("@tauri-apps/plugin-opener");
+    await openUrl(url);
+    return;
+  }
+
+  if (typeof window !== "undefined") {
+    window.open(url, "_blank", "noopener,noreferrer");
+  }
+}
+
 function createUnavailableState(): SourceWatcherStatePayload {
   return {
     status: "UNAVAILABLE",

--- a/apps/client/src/services/tauri-bridge.ts
+++ b/apps/client/src/services/tauri-bridge.ts
@@ -244,6 +244,29 @@ export async function writeE2eBinaryFile(
   return invoke<WriteE2eFileResponse>("write_e2e_binary_file", { request });
 }
 
+export async function getCurrentDeepLinkUrls(): Promise<string[]> {
+  if (!isTauriRuntime()) {
+    return [];
+  }
+
+  const { getCurrent } = await import("@tauri-apps/plugin-deep-link");
+  const urls = await getCurrent();
+  return Array.isArray(urls) ? urls.filter((url): url is string => typeof url === "string") : [];
+}
+
+export async function listenToDeepLinkUrls(
+  handler: (urls: string[]) => void,
+): Promise<() => void> {
+  if (!isTauriRuntime()) {
+    return () => {};
+  }
+
+  const { onOpenUrl } = await import("@tauri-apps/plugin-deep-link");
+  return onOpenUrl((urls) => {
+    handler(urls.filter((url): url is string => typeof url === "string"));
+  });
+}
+
 function createUnavailableState(): SourceWatcherStatePayload {
   return {
     status: "UNAVAILABLE",

--- a/apps/web/src/lib/config.ts
+++ b/apps/web/src/lib/config.ts
@@ -30,7 +30,7 @@ export const WEB_LINKS = Object.freeze({
 export const WEB_RUNTIME = Object.freeze({
   basePath,
   deepLinkScheme: envOrDefault(import.meta.env.VITE_DEEP_LINK_SCHEME, "infinitas-arena://join"),
-  joinApiEndpoint: import.meta.env.VITE_JOIN_API_ENDPOINT?.trim() ?? "",
+  joinApiEndpoint: envOrDefault(import.meta.env.VITE_JOIN_API_ENDPOINT, "/api/join"),
 });
 
 export const JOIN_DEMO_QUERY = "demo-open";

--- a/apps/web/src/lib/join-room.ts
+++ b/apps/web/src/lib/join-room.ts
@@ -40,57 +40,12 @@ const toStatus = (value: string | undefined): RecruitmentStatus => {
   }
 };
 
-const inferMockStatus = (roomRef: string): RecruitmentStatus => {
-  const normalized = roomRef.toLowerCase();
-  if (normalized.includes("full")) {
-    return "full";
-  }
-  if (normalized.includes("closed")) {
-    return "closed";
-  }
-  if (normalized.includes("expired") || normalized.includes("invalid")) {
-    return "expired";
-  }
-  return "recruiting";
-};
-
-const buildMockSummary = (roomRef: string): JoinRoomSummary => {
-  const status = inferMockStatus(roomRef);
-
-  if (status === "full") {
-    return {
-      roomName: "INFINITAS ARENA 4P Room",
-      status,
-      isShareable: false,
-      downloadUrl: WEB_LINKS.download,
-    };
-  }
-
-  if (status === "closed") {
-    return {
-      roomName: "BPL Friendly Match Room",
-      status,
-      isShareable: false,
-      downloadUrl: WEB_LINKS.download,
-    };
-  }
-
-  if (status === "expired") {
-    return {
-      roomName: "期限切れまたは無効な招待URL",
-      status,
-      isShareable: false,
-      downloadUrl: WEB_LINKS.download,
-    };
-  }
-
-  return {
-    roomName: "INFINITAS ARENA Public Lobby",
-    status: "recruiting",
-    isShareable: true,
-    downloadUrl: WEB_LINKS.download,
-  };
-};
+const buildExpiredSummary = (): JoinRoomSummary => ({
+  roomName: "期限切れまたは無効な招待URL",
+  status: "expired",
+  isShareable: false,
+  downloadUrl: WEB_LINKS.download,
+});
 
 const resolveEndpoint = (roomRef: string): string | null => {
   if (!WEB_RUNTIME.joinApiEndpoint) {
@@ -128,16 +83,15 @@ export const fetchJoinRoomSummary = async (
 ): Promise<JoinRoomSummary> => {
   const trimmedRef = roomRef.trim();
   if (!trimmedRef) {
-    return buildMockSummary("expired");
+    return buildExpiredSummary();
   }
 
   const endpoint = resolveEndpoint(trimmedRef);
   if (!endpoint) {
-    return buildMockSummary(trimmedRef);
+    return buildExpiredSummary();
   }
 
   try {
-    // TODO(issue-125): Replace mock fallback with strict error handling after Worker API contract is finalized.
     const requestInit: RequestInit = {
       method: "GET",
       headers: {
@@ -157,6 +111,6 @@ export const fetchJoinRoomSummary = async (
     const payload = (await response.json()) as JoinRoomApiResponse;
     return parseApiSummary(payload);
   } catch {
-    return buildMockSummary(trimmedRef);
+    return buildExpiredSummary();
   }
 };

--- a/apps/web/src/lib/share-analytics.ts
+++ b/apps/web/src/lib/share-analytics.ts
@@ -1,0 +1,19 @@
+type WebShareAnalyticsEvent = "join_page_viewed" | "deep_link_attempted";
+
+interface WebShareAnalyticsPayload {
+  roomRef: string;
+  [key: string]: unknown;
+}
+
+export function logWebShareAnalytics(
+  event: WebShareAnalyticsEvent,
+  payload: WebShareAnalyticsPayload,
+): void {
+  const record = {
+    ts: new Date().toISOString(),
+    event,
+    platform: "web",
+    ...payload,
+  };
+  console.info("[share-analytics]", record);
+}

--- a/apps/web/src/pages/Join.tsx
+++ b/apps/web/src/pages/Join.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { attemptOpenDeepLink, buildJoinDeepLink } from "../lib/deeplink";
 import { WEB_LINKS, WEB_RUNTIME } from "../lib/config";
 import { fetchJoinRoomSummary, type JoinRoomSummary, type RecruitmentStatus } from "../lib/join-room";
+import { logWebShareAnalytics } from "../lib/share-analytics";
 
 type DeepLinkUiState = "idle" | "trying" | "launched" | "fallback";
 
@@ -56,14 +57,25 @@ export const JoinPage: FC = () => {
 
   const statusMeta = statusMetaMap[summary.status];
 
-  const openInApp = useCallback(async (): Promise<void> => {
+  const openInApp = useCallback(async (trigger: "auto" | "manual"): Promise<void> => {
     if (!roomRef) {
       setDeepLinkState("fallback");
       return;
     }
 
+    logWebShareAnalytics("deep_link_attempted", {
+      roomRef,
+      trigger,
+      phase: "start",
+    });
     setDeepLinkState("trying");
     const result = await attemptOpenDeepLink(buildJoinDeepLink(roomRef));
+    logWebShareAnalytics("deep_link_attempted", {
+      roomRef,
+      trigger,
+      phase: "end",
+      result,
+    });
     setDeepLinkState(result);
   }, [roomRef]);
 
@@ -88,6 +100,13 @@ export const JoinPage: FC = () => {
   }, [roomRef]);
 
   useEffect(() => {
+    logWebShareAnalytics("join_page_viewed", {
+      roomRef,
+      pathname: window.location.pathname,
+    });
+  }, [roomRef]);
+
+  useEffect(() => {
     if (!roomRef) {
       return;
     }
@@ -98,7 +117,7 @@ export const JoinPage: FC = () => {
     }
 
     window.sessionStorage.setItem(sessionKey, "1");
-    void openInApp();
+    void openInApp("auto");
   }, [openInApp, roomRef]);
 
   const deepLinkMessage = (() => {
@@ -174,7 +193,7 @@ export const JoinPage: FC = () => {
             <button
               type="button"
               onClick={() => {
-                void openInApp();
+                void openInApp("manual");
               }}
               disabled={deepLinkState === "trying"}
               className="inline-flex items-center justify-center gap-2 rounded-xl bg-cyan-500 px-6 py-3 font-bold text-black transition-colors hover:bg-cyan-400 disabled:cursor-not-allowed disabled:bg-cyan-700/50 disabled:text-gray-300"
@@ -196,7 +215,7 @@ export const JoinPage: FC = () => {
             <button
               type="button"
               onClick={() => {
-                void openInApp();
+                void openInApp("manual");
               }}
               disabled={deepLinkState === "trying"}
               className="inline-flex items-center justify-center gap-2 rounded-xl border border-cyan-500/30 bg-cyan-500/10 px-6 py-3 font-semibold text-cyan-100 transition-colors hover:bg-cyan-500/20 disabled:cursor-not-allowed disabled:opacity-50"

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "test": "tsx --test src/durable/room-state.test.mjs src/durable/room-object.test.mjs src/durable/contract-guards.test.mjs src/master/chart-master.test.mjs",
+    "test": "tsx --test src/durable/room-state.test.mjs src/durable/room-object.test.mjs src/durable/contract-guards.test.mjs src/master/chart-master.test.mjs src/routes/join.test.mjs",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "devDependencies": {

--- a/apps/worker/src/durable/room-object.test.mjs
+++ b/apps/worker/src/durable/room-object.test.mjs
@@ -297,3 +297,78 @@ test("SOURCE_STATUS_SET changed update persists and syncs alarm", async () => {
   assert.equal(persistCalls, 2);
   assert.equal(syncAlarmCalls, 1);
 });
+
+test("internal join-status returns recruiting for PUBLIC LOBBY room", async () => {
+  const roomObject = await createRoomObject();
+  const response = await roomObject.fetch(new Request("https://room.internal/join-status", { method: "GET" }));
+  assert.equal(response.status, 200);
+
+  const payload = await response.json();
+  assert.equal(payload.room_name, "room object test");
+  assert.equal(payload.recruitment_status, "recruiting");
+  assert.equal(payload.shareable, true);
+});
+
+test("internal join-status returns full when lobby is at capacity", async () => {
+  const roomObject = await createRoomObject();
+  roomObject.roomState.settings.max_players = 2;
+  const hostSocket = new TestSocket();
+  const guestSocket = new TestSocket();
+  await joinPlayer(roomObject, hostSocket, "host", "msg-1");
+  await joinPlayer(roomObject, guestSocket, "guest", "msg-2");
+
+  const response = await roomObject.fetch(new Request("https://room.internal/join-status", { method: "GET" }));
+  assert.equal(response.status, 200);
+
+  const payload = await response.json();
+  assert.equal(payload.recruitment_status, "full");
+  assert.equal(payload.shareable, false);
+});
+
+test("internal join-status returns closed after match has started", async () => {
+  const roomObject = await createRoomObject();
+  const now = new Date("2026-03-08T00:00:00.000Z");
+  const hostSocket = new TestSocket();
+  const guestSocket = new TestSocket();
+
+  await joinPlayer(roomObject, hostSocket, "host", "msg-1");
+  await joinPlayer(roomObject, guestSocket, "guest", "msg-2");
+  roomObject.roomState.setPlayerReady("host", true);
+  roomObject.roomState.setPlayerReady("guest", true);
+  const startResult = roomObject.roomState.startMatch("host", now);
+  assert.equal(startResult.ok, true);
+
+  const response = await roomObject.fetch(new Request("https://room.internal/join-status", { method: "GET" }));
+  assert.equal(response.status, 200);
+
+  const payload = await response.json();
+  assert.equal(payload.recruitment_status, "closed");
+  assert.equal(payload.shareable, false);
+});
+
+test("internal join-status remains closed after returning to LOBBY once match started", async () => {
+  const roomObject = await createRoomObject();
+  const now = new Date("2026-03-08T00:00:00.000Z");
+  const hostSocket = new TestSocket();
+  const guestSocket = new TestSocket();
+
+  await joinPlayer(roomObject, hostSocket, "host", "msg-1");
+  await joinPlayer(roomObject, guestSocket, "guest", "msg-2");
+  roomObject.roomState.setPlayerReady("host", true);
+  roomObject.roomState.setPlayerReady("guest", true);
+  const startResult = roomObject.roomState.startMatch("host", now);
+  assert.equal(startResult.ok, true);
+  await roomObject.persistRoomRecord();
+
+  roomObject.roomState.enterResult(new Date("2026-03-08T00:05:00.000Z"));
+  const returnResult = roomObject.roomState.returnToLobby("host", new Date("2026-03-08T00:06:00.000Z"));
+  assert.equal(returnResult.ok, true);
+  await roomObject.persistRoomRecord();
+
+  const response = await roomObject.fetch(new Request("https://room.internal/join-status", { method: "GET" }));
+  assert.equal(response.status, 200);
+
+  const payload = await response.json();
+  assert.equal(payload.recruitment_status, "closed");
+  assert.equal(payload.shareable, false);
+});

--- a/apps/worker/src/durable/room-object.test.mjs
+++ b/apps/worker/src/durable/room-object.test.mjs
@@ -346,9 +346,9 @@ test("internal join-status returns closed after match has started", async () => 
   assert.equal(payload.shareable, false);
 });
 
-test("internal join-status remains closed after returning to LOBBY once match started", async () => {
+test("internal join-status returns recruiting after host recreates room via RETURN_TO_LOBBY", async () => {
   const roomObject = await createRoomObject();
-  const now = new Date("2026-03-08T00:00:00.000Z");
+  const now = new Date();
   const hostSocket = new TestSocket();
   const guestSocket = new TestSocket();
 
@@ -360,15 +360,25 @@ test("internal join-status remains closed after returning to LOBBY once match st
   assert.equal(startResult.ok, true);
   await roomObject.persistRoomRecord();
 
-  roomObject.roomState.enterResult(new Date("2026-03-08T00:05:00.000Z"));
-  const returnResult = roomObject.roomState.returnToLobby("host", new Date("2026-03-08T00:06:00.000Z"));
-  assert.equal(returnResult.ok, true);
-  await roomObject.persistRoomRecord();
+  roomObject.roomState.enterResult(new Date(now.getTime() + 1_000));
+  await roomObject.webSocketMessage(
+    hostSocket,
+    JSON.stringify({
+      type: "RETURN_TO_LOBBY",
+      client_msg_id: "msg-3",
+      room_id: "room-1",
+      player_id: "host",
+      payload: {
+        request_id: "return-1",
+      },
+    }),
+  );
+  assert.equal(roomObject.roomState.getRoomState(), "LOBBY");
 
   const response = await roomObject.fetch(new Request("https://room.internal/join-status", { method: "GET" }));
   assert.equal(response.status, 200);
 
   const payload = await response.json();
-  assert.equal(payload.recruitment_status, "closed");
-  assert.equal(payload.shareable, false);
+  assert.equal(payload.recruitment_status, "recruiting");
+  assert.equal(payload.shareable, true);
 });

--- a/apps/worker/src/durable/room-object.ts
+++ b/apps/worker/src/durable/room-object.ts
@@ -1821,6 +1821,8 @@ export class RoomDurableObject {
       return;
     }
 
+    // Host-initiated room recreation reopens recruitment for the same shared URL.
+    this.shareRecruitmentClosed = false;
     this.rememberRequest(session.playerId, message.type, payload.request_id);
     await this.persistRoomRecord();
     await this.syncAlarm();

--- a/apps/worker/src/durable/room-object.ts
+++ b/apps/worker/src/durable/room-object.ts
@@ -105,6 +105,7 @@ interface RoomDurableRecord {
   processed_request_keys: string[];
   seen_client_message_ids?: SeenClientMessageIdsRecord;
   next_event_seq: number;
+  share_recruitment_closed?: boolean;
 }
 
 type RoomDoLogLevel = "INFO" | "WARN" | "ERROR";
@@ -157,6 +158,15 @@ type ClientEnvelopeLogContext = {
   player_id: string;
   client_msg_id: string;
 };
+
+type InternalJoinRecruitmentStatus = "recruiting" | "full" | "closed";
+
+interface InternalJoinStatusPayload {
+  room_name: string;
+  recruitment_status: InternalJoinRecruitmentStatus;
+  shareable: boolean;
+  updated_at: string;
+}
 
 function summarizeExpectedKey(expectedKey: ExpectedKey): JsonObject {
   return {
@@ -692,6 +702,7 @@ export class RoomDurableObject {
   private readonly minSupportedClientVersion: ParsedClientVersion;
   private processedRequestKeys: string[] = [];
   private nextEventSeq = 0;
+  private shareRecruitmentClosed = false;
   private readonly readyPromise: Promise<void>;
 
   constructor(
@@ -712,6 +723,8 @@ export class RoomDurableObject {
           this.seenClientMessageIds.set(playerId, messageIds);
         }
         this.nextEventSeq = record.next_event_seq;
+        this.shareRecruitmentClosed =
+          record.share_recruitment_closed === true || this.roomState.getRoomState() !== "LOBBY";
       }
 
       this.rebuildSessionsFromWebSockets();
@@ -831,6 +844,12 @@ export class RoomDurableObject {
     if (url.pathname === "/internal/init" && request.method === "POST") {
       return this.handleInternalInitialize(request);
     }
+    if (url.pathname === "/join-status") {
+      if (request.method !== "GET") {
+        return jsonResponse(405, { error: "Method not allowed." });
+      }
+      return this.handleInternalJoinStatus();
+    }
     if (url.pathname === "/charts") {
       if (request.method !== "GET") {
         return jsonResponse(405, { error: "Method not allowed." });
@@ -935,6 +954,41 @@ export class RoomDurableObject {
     });
 
     return jsonResponse(200, response);
+  }
+
+  private buildInternalJoinStatus(snapshot: RoomStateSnapshot): InternalJoinStatusPayload | null {
+    if (snapshot.settings.visibility !== "PUBLIC") {
+      return null;
+    }
+
+    const currentPlayers = snapshot.players.length;
+    const maxPlayers = snapshot.settings.max_players;
+    const isFull = currentPlayers >= maxPlayers;
+    const inRecruitingLobby = snapshot.room_state === "LOBBY";
+    const recruitmentClosed = this.shareRecruitmentClosed || !inRecruitingLobby;
+    const recruitmentStatus: InternalJoinRecruitmentStatus =
+      recruitmentClosed ? "closed" : isFull ? "full" : "recruiting";
+
+    return {
+      room_name: this.deriveLobbyRoomName(snapshot),
+      recruitment_status: recruitmentStatus,
+      shareable: recruitmentStatus === "recruiting",
+      updated_at: new Date().toISOString(),
+    };
+  }
+
+  private handleInternalJoinStatus(): Response {
+    if (!this.roomState.isInitialized()) {
+      return jsonResponse(404, { error: "ROOM_STATE_LOST" });
+    }
+
+    const snapshot = this.roomState.toSnapshot();
+    const payload = this.buildInternalJoinStatus(snapshot);
+    if (payload === null) {
+      return jsonResponse(404, { error: "NOT_PUBLIC_ROOM" });
+    }
+
+    return jsonResponse(200, payload);
   }
 
   async webSocketMessage(
@@ -2638,12 +2692,16 @@ export class RoomDurableObject {
       // CLOSED means the room lifecycle ended, so message-level dedupe history is discarded.
       this.clearSeenClientMessageIds();
     }
+    if (!this.shareRecruitmentClosed && this.roomState.getRoomState() !== "LOBBY") {
+      this.shareRecruitmentClosed = true;
+    }
 
     const record: RoomDurableRecord = {
       room_state: this.roomState.toPersistenceRecord(),
       processed_request_keys: [...this.processedRequestKeys],
       seen_client_message_ids: serializeSeenClientMessageIds(this.seenClientMessageIds),
       next_event_seq: this.nextEventSeq,
+      share_recruitment_closed: this.shareRecruitmentClosed,
     };
     await this.state.storage.put(ROOM_RECORD_STORAGE_KEY, record);
   }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,6 +1,7 @@
 import { handleGetCharts } from "./routes/charts";
 import { handleGetChartAliasResolve } from "./routes/chart-aliases";
 import { handlePostFeedback } from "./routes/feedback";
+import { handleGetJoin } from "./routes/join";
 import { handleGetLobby } from "./routes/lobby";
 import { handleGetRoomCharts, handlePostRooms, handleRoomWebSocket, matchRoomChartsPath, matchRoomWebSocketPath } from "./routes/rooms";
 import { handleGetSongPacks } from "./routes/song-packs";
@@ -12,6 +13,7 @@ import { methodNotAllowed, noContent, notFound, withCors } from "./utils/http";
 const CHARTS_ALLOWED_METHODS = ["GET"];
 const CHART_ALIAS_RESOLVE_ALLOWED_METHODS = ["GET"];
 const ROOMS_ALLOWED_METHODS = ["POST"];
+const JOIN_ALLOWED_METHODS = ["GET"];
 const LOBBY_ALLOWED_METHODS = ["GET"];
 const FEEDBACK_ALLOWED_METHODS = ["POST"];
 const SONG_PACKS_ALLOWED_METHODS = ["GET"];
@@ -49,6 +51,17 @@ export default {
       }
 
       return withCors(methodNotAllowed([...ROOMS_ALLOWED_METHODS, "OPTIONS"]), request, ROOMS_ALLOWED_METHODS);
+    }
+
+    if (url.pathname === "/api/join") {
+      if (request.method === "OPTIONS") {
+        return withCors(noContent(), request, JOIN_ALLOWED_METHODS);
+      }
+      if (request.method === "GET") {
+        return withCors(await handleGetJoin(request, env), request, JOIN_ALLOWED_METHODS);
+      }
+
+      return withCors(methodNotAllowed([...JOIN_ALLOWED_METHODS, "OPTIONS"]), request, JOIN_ALLOWED_METHODS);
     }
 
     if (url.pathname === "/api/lobby") {

--- a/apps/worker/src/routes/join.test.mjs
+++ b/apps/worker/src/routes/join.test.mjs
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { handleGetJoin } from "./join.ts";
+
+function createEnv({ responseFactory, appDownloadUrl } = {}) {
+  return {
+    ROOM_DO: {
+      idFromName(name) {
+        return { toString: () => name };
+      },
+      get() {
+        return {
+          fetch: async () =>
+            responseFactory
+              ? responseFactory()
+              : new Response(
+                  JSON.stringify({
+                    room_name: "Public Room",
+                    recruitment_status: "recruiting",
+                    shareable: true,
+                    updated_at: "2026-03-25T00:00:00.000Z",
+                  }),
+                  { status: 200 },
+                ),
+        };
+      },
+    },
+    LOBBY_DIRECTORY_DO: {
+      idFromName(name) {
+        return { toString: () => name };
+      },
+      get() {
+        return {
+          fetch: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+        };
+      },
+    },
+    FEEDBACK_KV: {
+      get: async () => null,
+      put: async () => {},
+    },
+    APP_DOWNLOAD_URL: appDownloadUrl,
+    REPO_OWNER_GITHUB: "tts1374",
+    REPO_NAME_GITHUB: "infinitas_arena",
+    APP_ENV: "test",
+    MIN_SUPPORTED_CLIENT_VERSION: "1.0.2",
+    ISSUE_TOKEN: "",
+    DISCORD_WEBHOOK_URL: "",
+  };
+}
+
+test("handleGetJoin returns expired payload when r query is missing", async () => {
+  const response = await handleGetJoin(
+    new Request("https://example.com/api/join"),
+    createEnv({ appDownloadUrl: "https://example.com/download" }),
+  );
+  assert.equal(response.status, 200);
+
+  const payload = await response.json();
+  assert.equal(payload.recruitment_status, "expired");
+  assert.equal(payload.shareable, false);
+  assert.equal(payload.download_url, "https://example.com/download");
+});
+
+test("handleGetJoin returns room payload when DO join-status is available", async () => {
+  const response = await handleGetJoin(
+    new Request("https://example.com/api/join?r=room-1"),
+    createEnv(),
+  );
+  assert.equal(response.status, 200);
+
+  const payload = await response.json();
+  assert.equal(payload.room_name, "Public Room");
+  assert.equal(payload.recruitment_status, "recruiting");
+  assert.equal(payload.shareable, true);
+});
+
+test("handleGetJoin falls back to expired payload when DO returns not found", async () => {
+  const response = await handleGetJoin(
+    new Request("https://example.com/api/join?r=room-unknown"),
+    createEnv({
+      responseFactory: () => new Response(JSON.stringify({ error: "ROOM_STATE_LOST" }), { status: 404 }),
+    }),
+  );
+  assert.equal(response.status, 200);
+
+  const payload = await response.json();
+  assert.equal(payload.recruitment_status, "expired");
+  assert.equal(payload.shareable, false);
+});

--- a/apps/worker/src/routes/join.ts
+++ b/apps/worker/src/routes/join.ts
@@ -1,0 +1,14 @@
+import { buildExpiredJoinStatus, fetchJoinRoomStatus } from "../services/join-status";
+import type { WorkerEnv } from "../types/env";
+import { ok } from "../utils/http";
+
+export async function handleGetJoin(request: Request, env: WorkerEnv): Promise<Response> {
+  const roomRef = new URL(request.url).searchParams.get("r")?.trim() ?? "";
+
+  try {
+    const response = await fetchJoinRoomStatus(env, roomRef);
+    return ok(response);
+  } catch {
+    return ok(buildExpiredJoinStatus(env));
+  }
+}

--- a/apps/worker/src/services/join-status.ts
+++ b/apps/worker/src/services/join-status.ts
@@ -1,0 +1,98 @@
+import type { JoinRoomStatusResponse, RecruitmentStatus } from "../types/api";
+import type { WorkerEnv } from "../types/env";
+
+const INTERNAL_JOIN_STATUS_URL = "https://room.internal/join-status";
+const JSON_CONTENT_TYPE = "application/json; charset=utf-8";
+const DEFAULT_ROOM_NAME = "期限切れまたは無効な招待URL";
+const DEFAULT_DOWNLOAD_URL = "https://github.com/tts1374/infinitas_arena/releases/latest";
+
+interface InternalJoinStatusResponse {
+  room_name?: string;
+  recruitment_status?: string;
+  shareable?: boolean;
+  updated_at?: string;
+}
+
+const VALID_STATUSES: RecruitmentStatus[] = ["recruiting", "full", "closed", "expired"];
+
+function resolveDownloadUrl(env: WorkerEnv): string {
+  const candidate = env.APP_DOWNLOAD_URL?.trim();
+  return candidate && candidate.length > 0 ? candidate : DEFAULT_DOWNLOAD_URL;
+}
+
+function resolveStatus(value: string | undefined): RecruitmentStatus {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized && VALID_STATUSES.includes(normalized as RecruitmentStatus)) {
+    return normalized as RecruitmentStatus;
+  }
+
+  return "expired";
+}
+
+function normalizeIso8601(value: string | undefined): string {
+  if (typeof value !== "string") {
+    return new Date().toISOString();
+  }
+
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : new Date().toISOString();
+}
+
+export function buildExpiredJoinStatus(env: WorkerEnv): JoinRoomStatusResponse {
+  return {
+    room_name: DEFAULT_ROOM_NAME,
+    recruitment_status: "expired",
+    shareable: false,
+    download_url: resolveDownloadUrl(env),
+    updated_at: new Date().toISOString(),
+  };
+}
+
+function parseInternalJoinStatus(
+  env: WorkerEnv,
+  payload: InternalJoinStatusResponse,
+): JoinRoomStatusResponse {
+  const roomName = payload.room_name?.trim() || DEFAULT_ROOM_NAME;
+  const status = resolveStatus(payload.recruitment_status);
+  const shareable = payload.shareable === true && status === "recruiting";
+
+  return {
+    room_name: roomName,
+    recruitment_status: status,
+    shareable,
+    download_url: resolveDownloadUrl(env),
+    updated_at: normalizeIso8601(payload.updated_at),
+  };
+}
+
+export async function fetchJoinRoomStatus(
+  env: WorkerEnv,
+  roomRef: string,
+): Promise<JoinRoomStatusResponse> {
+  const normalizedRoomRef = roomRef.trim();
+  if (normalizedRoomRef.length === 0) {
+    return buildExpiredJoinStatus(env);
+  }
+
+  const roomDoId = env.ROOM_DO.idFromName(normalizedRoomRef);
+  const roomDoStub = env.ROOM_DO.get(roomDoId);
+  const response = await roomDoStub.fetch(
+    new Request(INTERNAL_JOIN_STATUS_URL, {
+      method: "GET",
+      headers: {
+        "content-type": JSON_CONTENT_TYPE,
+        "x-room-id": normalizedRoomRef,
+      },
+    }),
+  );
+
+  if (response.status === 404) {
+    return buildExpiredJoinStatus(env);
+  }
+  if (!response.ok) {
+    throw new Error(`Failed to fetch join status (${response.status}).`);
+  }
+
+  const payload = (await response.json()) as InternalJoinStatusResponse;
+  return parseInternalJoinStatus(env, payload);
+}

--- a/apps/worker/src/types/api.ts
+++ b/apps/worker/src/types/api.ts
@@ -21,3 +21,13 @@ export interface ChartSearchResponse {
   charts: ChartSearchEntry[];
   next_cursor: string | null;
 }
+
+export type RecruitmentStatus = "recruiting" | "full" | "closed" | "expired";
+
+export interface JoinRoomStatusResponse {
+  room_name: string;
+  recruitment_status: RecruitmentStatus;
+  shareable: boolean;
+  download_url: string;
+  updated_at: ISO8601String;
+}

--- a/apps/worker/src/types/env.ts
+++ b/apps/worker/src/types/env.ts
@@ -29,6 +29,7 @@ export interface WorkerEnv {
   ROOM_DO: RoomDurableObjectNamespace;
   LOBBY_DIRECTORY_DO: LobbyDirectoryDurableObjectNamespace;
   FEEDBACK_KV: WorkerKVNamespace;
+  APP_DOWNLOAD_URL?: string;
   REPO_OWNER_GITHUB: string;
   REPO_NAME_GITHUB: string;
   APP_ENV: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       "version": "1.1.1",
       "dependencies": {
         "@tauri-apps/api": "^2.5.1",
+        "@tauri-apps/plugin-deep-link": "^2.0.0",
         "@tauri-apps/plugin-updater": "^2.5.1",
         "lucide-react": "^0.446.0",
         "react": "^19.1.0",
@@ -2434,6 +2435,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-deep-link": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-deep-link/-/plugin-deep-link-2.4.7.tgz",
+      "integrity": "sha512-K0FQlLM6BoV7Ws2xfkh+Tnwi5VZVdkI4Vw/3AGLSf0Xvu2y86AMBzd9w/SpzKhw9ai2B6ES8di/OoGDCExkOzg==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@tauri-apps/plugin-updater": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       "dependencies": {
         "@tauri-apps/api": "^2.5.1",
         "@tauri-apps/plugin-deep-link": "^2.0.0",
+        "@tauri-apps/plugin-opener": "^2.5.3",
         "@tauri-apps/plugin-updater": "^2.5.1",
         "lucide-react": "^0.446.0",
         "react": "^19.1.0",
@@ -2444,6 +2445,15 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-opener": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.3.tgz",
+      "integrity": "sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/plugin-updater": {

--- a/tasks/issue-124-public-share.md
+++ b/tasks/issue-124-public-share.md
@@ -1,0 +1,71 @@
+# issue-124-public-share
+
+## Purpose
+- Implement Issue #124 scope for PUBLIC room sharing: SNS share entry, join page -> deep link flow, join URL validity checks, and minimum analytics logging.
+
+## Non-goals
+- URL-only room entry (join_code-less auto-join).
+- Exposing `join_code` in shared URL, join page, or deep link payload.
+- PRIVATE room sharing behavior changes.
+- FSM/protocol redesign outside the required API/flow additions.
+
+## Changes
+- Add Worker join-status API for join page (`r` param) with share-validity evaluation.
+- Replace web join-page mock fallback with strict API-backed summary + minimal analytics events.
+- Add client share UI for PUBLIC host in initial `LOBBY` only, with optional join_code insertion into X text (default OFF) and copy URL action.
+- Add deep-link receiving on Tauri app side and route to Lobby join flow with prefilled room id while keeping join_code manual input.
+- Reject/ignore deep-link-based room move when already in an active room.
+- Add tests for new Worker API and client/web flow helpers.
+
+## Impact
+- Users: PUBLIC room hosts can share recruit links to SNS; participants can open join page and transition to app join flow safely.
+- Data: No schema migration; adds read-only join status API response and lightweight event logging.
+- Compatibility: Existing WS room protocol remains unchanged; join entry remains join_code-gated.
+- Cloudflare: Worker route additions only; no new DO/KV bindings.
+
+## Target Files / Layers
+- Files:
+  - `apps/worker/src/index.ts`
+  - `apps/worker/src/routes/*` (new join status route)
+  - `apps/worker/src/durable/room-object.ts` (internal join status fetch endpoint)
+  - `apps/worker/src/types/*` (API type additions)
+  - `apps/web/src/lib/join-room.ts`
+  - `apps/web/src/pages/Join.tsx`
+  - `apps/client/src/pages/RoomPage.tsx`
+  - `apps/client/src/pages/LobbyPage.tsx`
+  - `apps/client/src/services/tauri-bridge.ts`
+  - `apps/client/src/app/App.tsx`
+  - `apps/client/src-tauri/src/lib.rs`
+  - `apps/client/src-tauri/Cargo.toml`
+  - `apps/client/src-tauri/tauri.conf.json`
+  - related tests for worker/client/web
+- Layers:
+  - worker
+  - web
+  - client
+  - tauri (desktop)
+
+## Test Focus
+- Worker: route tests for join-status response mapping (`recruiting/full/closed/expired`) and URL invalid conditions.
+- Web: join page summary fetch path and deep-link auto/manual retry behavior.
+- Client: share visibility gating (PUBLIC + host + initial LOBBY), text generation, and deep-link room-id prefill behavior.
+- Tauri/client integration: deep-link event propagation guard when already joined.
+- Universal checks: build/lint/test and diff/encoding validation.
+
+## Rollback Plan
+- Revert this task's commits to remove join-status route, web API hookup, and client deep-link/share additions.
+- Fallback behavior returns to existing lobby/manual join flow and static join page.
+
+## Commit Split Plan
+1. Worker join-status API and tests.
+2. Web join-page API integration and analytics hooks.
+3. Client share UI + deep-link receive handling and tests.
+
+## Checklist
+- [x] Design doc alignment confirmed (if required)
+- [x] Impact scope identified
+- [x] Implementation completed
+- [x] Tests completed
+- [x] Regression checks completed
+- [x] Documentation updates completed (not required for this local contract-preserving change)
+- [x] BASE_SHA recorded: `317b16cdba203fb73320ffd770ae02f4939fd71a`

--- a/tasks/issue-124-share-recreate-status.md
+++ b/tasks/issue-124-share-recreate-status.md
@@ -1,0 +1,53 @@
+# Issue 124 Follow-up: Recreated Room Share Status
+
+Mode decision: Plan Mode  
+Reason: Durable Object recruitment status behavior changes across RESULT -> LOBBY transition.
+
+## Objective
+
+- Ensure join-page recruitment status can return from `closed` to `recruiting` when host explicitly recreates the room via `RETURN_TO_LOBBY`.
+
+## Non-objective
+
+- No WebSocket schema changes.
+- No join URL format changes.
+- No UI redesign changes.
+
+## Scope
+
+- Worker DO only.
+
+Target files:
+- `apps/worker/src/durable/room-object.ts`
+- `apps/worker/src/durable/room-object.test.mjs`
+
+## Invariants / Risk Notes
+
+- Keep Worker route thin; status decision remains inside DO.
+- Keep `recruitment_status=closed` while match is active (`PICKING/PLAYING/RESULT`).
+- Only reset persistent share-closed flag on explicit host `RETURN_TO_LOBBY` success.
+
+## Implementation Plan
+
+- [ ] Add explicit reset path for `shareRecruitmentClosed` after successful `RETURN_TO_LOBBY`.
+- [ ] Update/adjust join-status regression test for recreate behavior.
+- [ ] Run worker tests and typecheck.
+
+## Validation
+
+Required:
+- [ ] `npm --workspace @infinitas/worker run test`
+- [ ] `npm --workspace @infinitas/worker run typecheck`
+- [ ] Diff review: only intended files changed
+
+Not required:
+- Source I/O checks: not touched
+- E2E checks: not required for this localized DO join-status fix
+
+## Rollback
+
+- Revert this follow-up commit to restore sticky-closed behavior.
+
+## Commit Plan
+
+1. `fix(worker): reopen join recruitment after explicit room recreate`


### PR DESCRIPTION
## 目的
- PUBLICルームの募集導線として、SNS共有 -> joinページ -> deep link -> アプリ参加画面（join_code入力）を実装する。
- URL自体を参加資格にせず、join_codeはURL/joinページ/deep linkに含めない方針を維持する。

## 変更点
- Worker
  - /api/join?r=... を追加し、joinページ向け状態APIを実装。
  - Room DO 内部に /join-status を追加。
  - 募集状態を ecruiting/full/closed/expired で返却。
  - 一度LOBBYを離れた後は共有募集を再開しないよう share_recruitment_closed を永続化。
  - ルート/API/DOのテストを追加。
- Web
  - joinページのモック推論を廃止し、Worker APIレスポンスに完全依存。
  - joinページ閲覧・deep link試行の最小分析ログを追加（consoleベース）。
- Client/Tauri
  - PUBLIC + ホスト + 初回LOBBY時のみ共有UIを表示。
  - X共有文面に join_code を含めるかのトグルを追加（初期値OFF）。
  - joinページURLコピー導線を追加。
  - Tauri deep-link plugin を導入し infinitas-arena://join?r=... を受信。
  - 受信時はLobbyの手動参加導線へ room_id をプリセット。
  - 既にルーム参加中（LOBBY含む）の deep link は無視。
  - deep link受信/無視/参加成功の最小分析ログを追加（consoleベース）。

## 非変更点
- URLだけで即参加する仕様は未実装。
- join_code の URL/joinページ/deep link 露出は未実装。
- PRIVATEルームの共有仕様は変更なし。
- 既存WS message schema/type/payload の契約変更なし。

## 影響範囲
- ユーザー: PUBLIC募集時の共有導線が追加。
- データ: 既存永続データの互換性破壊なし（DO recordに share_recruitment_closed を追加）。
- 互換性: join参加は従来どおりjoin_code必須フローを維持。
- Cloudflare: Worker/DOのルート追加のみ。新規リソース追加なし。

## テスト内容
- 
pm --workspace @infinitas/worker run test
- 
pm --workspace @infinitas/worker run typecheck
- 
pm --workspace @infinitas/web run typecheck
- 
pm --workspace @infinitas/client run typecheck
- 
pm run typecheck
- 
pm run lint
- 
pm --workspace @infinitas/web run build
- 
pm --workspace @infinitas/client run build
- cargo check (pps/client/src-tauri)

## 回帰確認項目
- PUBLIC初回LOBBYでのみ共有UIが表示されること。
- MATCH開始後/満員/募集終了で /api/join が shareable=false になること。
- deep link経由でも参加時にjoin_code入力が必要であること。
- 既参加中クライアントがdeep linkを受けても遷移しないこと。

## ロールバック方針
- 本PRをrevertすることで、join-status API / web連携 / client deep link導線を一括で元に戻せる。

## 互換性影響
- 破壊的変更なし。

## Cloudflare resources影響
- なし。

Closes #124