### PR TITLE
feat(spectate): add read-only observer flow and UI regression tests

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "dev": "vite --host 0.0.0.0 --port 1430",
     "build": "vite build",
     "preview": "vite preview --host 0.0.0.0 --port 4130",
-    "typecheck": "tsc --noEmit -p tsconfig.json"
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run"
   },
   "dependencies": {
     "lucide-react": "^0.446.0",
@@ -15,13 +16,16 @@
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.1.5",
     "@types/react-dom": "^19.1.5",
     "@vitejs/plugin-react": "^5.0.4",
     "autoprefixer": "^10.4.19",
+    "happy-dom": "^20.8.9",
     "postcss": "^8.4.39",
     "tailwindcss": "^3.4.4",
     "typescript": "^5.8.2",
-    "vite": "^7.1.7"
+    "vite": "^7.1.7",
+    "vitest": "^4.1.2"
   }
 }

--- a/apps/web/spectate/index.html
+++ b/apps/web/spectate/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="INFINITAS Arena の観戦ページ。read-only でスコア進行を確認できます。"
+    />
+    <title>INFINITAS Arena | Spectate</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/spectate-main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/src/lib/config.ts
+++ b/apps/web/src/lib/config.ts
@@ -7,6 +7,21 @@ const withTrailingSlash = (path: string): string => (path.endsWith("/") ? path :
 
 const basePath = withTrailingSlash(import.meta.env.BASE_URL || "/");
 
+const resolveJoinApiEndpointFallback = (): string => {
+  if (typeof window === "undefined") {
+    return "/api/join";
+  }
+
+  const hostname = window.location.hostname.trim().toLowerCase();
+  const isLocalhost = hostname === "localhost" || hostname === "127.0.0.1";
+  if (!isLocalhost) {
+    return "/api/join";
+  }
+
+  // In local web-dev (`localhost:1430`), worker APIs are usually served by `wrangler dev` on 8787.
+  return "http://127.0.0.1:8787/api/join";
+};
+
 export const WEB_LINKS = Object.freeze({
   download: envOrDefault(
     import.meta.env.VITE_DOWNLOAD_URL,
@@ -30,7 +45,7 @@ export const WEB_LINKS = Object.freeze({
 export const WEB_RUNTIME = Object.freeze({
   basePath,
   deepLinkScheme: envOrDefault(import.meta.env.VITE_DEEP_LINK_SCHEME, "infinitas-arena://join"),
-  joinApiEndpoint: envOrDefault(import.meta.env.VITE_JOIN_API_ENDPOINT, "/api/join"),
+  joinApiEndpoint: envOrDefault(import.meta.env.VITE_JOIN_API_ENDPOINT, resolveJoinApiEndpointFallback()),
 });
 
 export const JOIN_DEMO_QUERY = "demo-open";

--- a/apps/web/src/lib/join-room.ts
+++ b/apps/web/src/lib/join-room.ts
@@ -1,6 +1,6 @@
 import { WEB_LINKS, WEB_RUNTIME } from "./config";
 
-export type RecruitmentStatus = "recruiting" | "full" | "closed" | "expired";
+export type RecruitmentStatus = "recruiting" | "full" | "closed" | "expired" | "unavailable";
 
 export interface JoinRoomSummary {
   roomName: string;
@@ -43,6 +43,13 @@ const toStatus = (value: string | undefined): RecruitmentStatus => {
 const buildExpiredSummary = (): JoinRoomSummary => ({
   roomName: "期限切れまたは無効な招待URL",
   status: "expired",
+  isShareable: false,
+  downloadUrl: WEB_LINKS.download,
+});
+
+const buildUnavailableSummary = (): JoinRoomSummary => ({
+  roomName: "ルーム情報を取得できませんでした",
+  status: "unavailable",
   isShareable: false,
   downloadUrl: WEB_LINKS.download,
 });
@@ -111,6 +118,6 @@ export const fetchJoinRoomSummary = async (
     const payload = (await response.json()) as JoinRoomApiResponse;
     return parseApiSummary(payload);
   } catch {
-    return buildExpiredSummary();
+    return buildUnavailableSummary();
   }
 };

--- a/apps/web/src/pages/Join.tsx
+++ b/apps/web/src/pages/Join.tsx
@@ -1,4 +1,4 @@
-import { AppWindow, Download, LoaderCircle, RefreshCw, TriangleAlert } from "lucide-react";
+import { AppWindow, Download, Eye, LoaderCircle, RefreshCw, TriangleAlert } from "lucide-react";
 import type { FC } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { attemptOpenDeepLink, buildJoinDeepLink } from "../lib/deeplink";
@@ -31,9 +31,14 @@ const statusMetaMap: Record<RecruitmentStatus, StatusMeta> = {
     description: "このルームの募集は終了しました。",
   },
   expired: {
-    label: "期限切れ / 無効URL",
+    label: "無効リンク",
     badgeClass: "bg-rose-500/20 text-rose-300 border-rose-400/30",
-    description: "リンクが無効、または共有期限を過ぎています。",
+    description: "このリンクは使えません。新しい招待リンクを受け取ってください。",
+  },
+  unavailable: {
+    label: "接続できません",
+    badgeClass: "bg-orange-500/20 text-orange-200 border-orange-400/30",
+    description: "ルーム情報を取得できませんでした。",
   },
 };
 
@@ -54,6 +59,10 @@ export const JoinPage: FC = () => {
   const [summary, setSummary] = useState<JoinRoomSummary>(fallbackSummary);
   const [isLoading, setIsLoading] = useState<boolean>(Boolean(roomRef));
   const [deepLinkState, setDeepLinkState] = useState<DeepLinkUiState>("idle");
+  const spectateUrl = useMemo(
+    () => `${WEB_RUNTIME.basePath}spectate/?r=${encodeURIComponent(roomRef)}`,
+    [roomRef],
+  );
 
   const statusMeta = statusMetaMap[summary.status];
 
@@ -154,11 +163,8 @@ export const JoinPage: FC = () => {
       <main className="mx-auto max-w-4xl space-y-8">
         <header className="rounded-3xl border border-white/10 bg-[#15151A] p-8 shadow-[0_20px_40px_rgba(0,0,0,0.35)]">
           <p className="mb-3 text-sm uppercase tracking-widest text-cyan-300">INFINITAS Arena Join</p>
-          <h1 className="mb-4 text-3xl font-black md:text-4xl">参加導線ページ</h1>
-          <p className="text-sm leading-relaxed text-gray-300 md:text-base">
-            X などで共有されたリンクから、アプリ起動とダウンロード導線へ接続するページです。URL自体を参加券にはせず、
-            ルーム状態を確認したうえでアプリ参加へ進みます。
-          </p>
+          <h1 className="mb-4 text-3xl font-black md:text-4xl">参加ページ</h1>
+          <p className="text-sm leading-relaxed text-gray-300 md:text-base">ルーム状態を確認して、アプリ参加またはブラウザ観戦へ進みます。</p>
         </header>
 
         <section className="rounded-3xl border border-cyan-500/20 bg-[#101018] p-8 shadow-[0_0_35px_rgba(6,182,212,0.12)]">
@@ -221,15 +227,29 @@ export const JoinPage: FC = () => {
               className="inline-flex items-center justify-center gap-2 rounded-xl border border-cyan-500/30 bg-cyan-500/10 px-6 py-3 font-semibold text-cyan-100 transition-colors hover:bg-cyan-500/20 disabled:cursor-not-allowed disabled:opacity-50"
             >
               <RefreshCw size={16} />
-              手動で再試行
+              再試行
             </button>
+
+            <a
+              href={spectateUrl}
+              className="inline-flex items-center justify-center gap-2 rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-6 py-3 font-semibold text-emerald-100 transition-colors hover:bg-emerald-500/20"
+            >
+              <Eye size={16} />
+              ブラウザ観戦
+            </a>
           </div>
 
           <p className="mt-4 text-sm text-gray-300">{deepLinkMessage}</p>
           {summary.status === "expired" ? (
             <p className="mt-3 inline-flex items-center gap-2 rounded-lg border border-rose-400/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">
               <TriangleAlert size={16} />
-              期限切れまたは無効URLです。新しい招待リンクを受け取ってください。
+              このリンクは使えません。新しい招待リンクを受け取ってください。
+            </p>
+          ) : null}
+          {summary.status === "unavailable" ? (
+            <p className="mt-3 inline-flex items-center gap-2 rounded-lg border border-orange-400/40 bg-orange-500/10 px-3 py-2 text-sm text-orange-100">
+              <TriangleAlert size={16} />
+              APIへ接続できません。`wrangler dev` と `VITE_JOIN_API_ENDPOINT` を確認してください。
             </p>
           ) : null}
         </section>
@@ -237,9 +257,9 @@ export const JoinPage: FC = () => {
         <section className="rounded-3xl border border-white/10 bg-[#15151A] p-8">
           <h2 className="mb-4 text-2xl font-bold">参加手順</h2>
           <ol className="space-y-3 text-sm leading-relaxed text-gray-300">
-            <li>1. 「アプリで開く」を押して、`infinitas-arena://join?r=...` の deep link 起動を試します。</li>
-            <li>2. アプリ未導入の場合は「ダウンロード」から Windows 版をインストールします。</li>
-            <li>3. アプリ起動後にルーム参加を続行し、募集状態に従って入室してください。</li>
+            <li>1. 「アプリで開く」で参加します。</li>
+            <li>2. アプリ未導入なら「ダウンロード」からインストールします。</li>
+            <li>3. 観戦したい場合は「ブラウザ観戦」を選びます。</li>
           </ol>
         </section>
 

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -5,7 +5,7 @@ import { HeroSection } from "../components/sections/HeroSection";
 import { HowToSection } from "../components/sections/HowToSection";
 import { IntegrationSection } from "../components/sections/IntegrationSection";
 import { NotesSection } from "../components/sections/NotesSection";
-import { WEB_LINKS } from "../lib/config";
+import { WEB_LINKS, WEB_RUNTIME } from "../lib/config";
 
 export const LandingPage: FC = () => {
   const scrollToHowTo = (): void => {
@@ -33,6 +33,9 @@ export const LandingPage: FC = () => {
           </a>
           <a href={WEB_LINKS.knownIssues} target="_blank" rel="noreferrer" className="hover:text-cyan-300">
             既知の制約
+          </a>
+          <a href={`${WEB_RUNTIME.basePath}spectate/`} className="hover:text-cyan-300">
+            観戦ページ
           </a>
         </div>
       </footer>

--- a/apps/web/src/pages/Spectate.test.tsx
+++ b/apps/web/src/pages/Spectate.test.tsx
@@ -299,6 +299,53 @@ describe("SpectatePage", () => {
     });
   });
 
+  it("ignores stale close events from a previous socket after reconnect", async () => {
+    render(<SpectatePage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "CONNECT TO MATCH" }));
+    const firstSocket = MockWebSocket.instances.at(0);
+    if (firstSocket === undefined) {
+      throw new Error("First WebSocket was not created.");
+    }
+
+    await act(async () => {
+      firstSocket.open();
+      firstSocket.emitServerMessage("ROOM_JOIN_REJECTED", {
+        reason: "ROOM_FULL",
+      });
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "CONNECT TO MATCH" }));
+
+    const secondSocket = MockWebSocket.instances.at(1);
+    if (secondSocket === undefined) {
+      throw new Error("Second WebSocket was not created.");
+    }
+
+    await act(async () => {
+      secondSocket.open();
+      secondSocket.emitServerMessage("ROOM_JOIN_ACCEPTED", {
+        room_state_snapshot: createSnapshot({
+          currentRoundIndex: 0,
+          confirmedMetrics: {},
+          frozenRoundCount: 2,
+        }),
+        session_role: "SPECTATOR",
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Spectator Connect")).toBeNull();
+    });
+
+    await act(async () => {
+      firstSocket.close(1006, "late close from previous socket");
+    });
+
+    expect(screen.queryByText("Spectator Connect")).toBeNull();
+    expect(screen.getByRole("button", { name: "Disconnect" })).toBeDefined();
+  });
+
   it("matches snapshot for connected layout", async () => {
     const snapshot = createSnapshot({
       currentRoundIndex: 0,

--- a/apps/web/src/pages/Spectate.test.tsx
+++ b/apps/web/src/pages/Spectate.test.tsx
@@ -1,0 +1,333 @@
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { RoomStateSnapshot, ServerMessageType } from "@infinitas/shared";
+import { SpectatePage } from "./Spectate";
+
+const ROOM_ID = "room-test-001";
+const WS_URL = `ws://127.0.0.1:8787/api/rooms/${ROOM_ID}/ws`;
+
+type WebSocketListener = (event: unknown) => void;
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readonly url: string;
+  readyState = MockWebSocket.CONNECTING;
+  sentPayloads: string[] = [];
+  private readonly listeners: Record<string, WebSocketListener[]> = {
+    open: [],
+    message: [],
+    close: [],
+    error: [],
+  };
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: WebSocketListener): void {
+    const list = this.listeners[type];
+    if (list === undefined) {
+      return;
+    }
+    list.push(listener);
+  }
+
+  send(payload: string): void {
+    this.sentPayloads.push(payload);
+  }
+
+  close(code = 1000, reason = ""): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.emit("close", { code, reason, wasClean: true });
+  }
+
+  open(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.emit("open", {});
+  }
+
+  emitServerMessage(type: ServerMessageType, payload: unknown): void {
+    this.emit("message", {
+      data: JSON.stringify({
+        type,
+        payload,
+      }),
+    });
+  }
+
+  private emit(type: string, event: unknown): void {
+    const list = this.listeners[type];
+    if (list === undefined) {
+      return;
+    }
+    for (const listener of list) {
+      listener(event);
+    }
+  }
+}
+
+function createSnapshot(options: {
+  currentRoundIndex: number | null;
+  confirmedMetrics?: Record<string, number>;
+  frozenRoundCount?: number;
+  mode?: "ARENA" | "BPL";
+}): RoomStateSnapshot {
+  const frozenRoundCount = options.frozenRoundCount ?? 2;
+  const mode = options.mode ?? "ARENA";
+  const frozenRounds = Array.from({ length: frozenRoundCount }, (_, index) => ({
+    round_index: index,
+    expected_key: {
+      play_style: "SP" as const,
+      difficulty: "ANOTHER",
+      title_search_key: `song-${index}`,
+    },
+    display: {
+      title: `Song ${index}`,
+      level: 10 + index,
+    },
+    started_at: "2026-04-05T12:00:00.000Z",
+    soft_ttl_seconds: 300,
+  }));
+
+  const confirmed = Object.entries(options.confirmedMetrics ?? {}).map(([playerId, metricValue]) => ({
+    player_id: playerId,
+    status: "PLAYED" as const,
+    metric_value: metricValue,
+    reason: null,
+    submitted_by: "SELF" as const,
+    submitted_at: "2026-04-05T12:01:00.000Z",
+    source_meta: null,
+  }));
+
+  const currentRound =
+    options.currentRoundIndex === null
+      ? null
+      : {
+          round_index: options.currentRoundIndex,
+          expected_key: frozenRounds[options.currentRoundIndex]?.expected_key ?? {
+            play_style: "SP" as const,
+            difficulty: "ANOTHER",
+            title_search_key: "song-fallback",
+          },
+          round_started_at: "2026-04-05T12:00:00.000Z",
+          soft_ttl_seconds: 300,
+          confirmed,
+        };
+
+  return {
+    room_id: ROOM_ID,
+    room_state: "PLAYING",
+    settings: {
+      visibility: "PRIVATE",
+      join_code: "ABCD1234",
+      mode,
+      win_metric: "SCORE",
+      play_style: "SP",
+      level_filter: "ANY",
+      room_comment: "",
+      max_players: 2,
+    },
+    host_player_id: "p1",
+    players: [
+      {
+        player_id: "p1",
+        display_name: "PLAYER1",
+        source: "inf-notebook",
+        connected: true,
+        ready: true,
+        role: "HOST",
+      },
+      {
+        player_id: "p2",
+        display_name: "PLAYER2",
+        source: "reflux",
+        connected: true,
+        ready: true,
+        role: "GUEST",
+      },
+    ],
+    picks: [],
+    frozen_rounds: frozenRounds,
+    current_round: currentRound,
+    timers: {
+      ready_check_deadline: null,
+      picking_deadline: null,
+      match_deadline: null,
+      result_deadline: null,
+    },
+    result_ready: false,
+    created_at: "2026-04-05T11:59:00.000Z",
+    closed_at: null,
+    close_reason: null,
+  };
+}
+
+async function connectAndJoin(snapshot: RoomStateSnapshot): Promise<MockWebSocket> {
+  render(<SpectatePage />);
+
+  const connectButton = screen.getByRole("button", { name: "CONNECT TO MATCH" });
+  fireEvent.click(connectButton);
+
+  const ws = MockWebSocket.instances.at(-1);
+  if (ws === undefined) {
+    throw new Error("WebSocket was not created.");
+  }
+
+  expect(ws.url).toBe(WS_URL);
+
+  await act(async () => {
+    ws.open();
+  });
+
+  await act(async () => {
+    ws.emitServerMessage("ROOM_JOIN_ACCEPTED", {
+      room_state_snapshot: snapshot,
+      session_role: "SPECTATOR",
+    });
+  });
+
+  await waitFor(() => {
+    expect(screen.queryByText("Spectator Connect")).toBeNull();
+  });
+
+  return ws;
+}
+
+describe("SpectatePage", () => {
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue("00000000-0000-4000-8000-000000000000");
+    Object.defineProperty(globalThis, "WebSocket", {
+      configurable: true,
+      writable: true,
+      value: MockWebSocket,
+    });
+    window.history.replaceState({}, "", `/spectate/?r=${ROOM_ID}`);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("shows '次曲準備中' on round 0 when next frozen round does not exist", async () => {
+    const snapshot = createSnapshot({
+      currentRoundIndex: 0,
+      confirmedMetrics: {},
+      frozenRoundCount: 1,
+    });
+
+    await connectAndJoin(snapshot);
+
+    expect(screen.getByText("LIVE Next Preview")).toBeDefined();
+    expect(screen.getByText("次曲準備中")).toBeDefined();
+  });
+
+  it("keeps previous result while previewing live next round during sticky state", async () => {
+    const round0Snapshot = createSnapshot({
+      currentRoundIndex: 0,
+      confirmedMetrics: {
+        p1: 2900,
+        p2: 2750,
+      },
+      frozenRoundCount: 2,
+    });
+    const ws = await connectAndJoin(round0Snapshot);
+
+    const round1StartedSnapshot = createSnapshot({
+      currentRoundIndex: 1,
+      confirmedMetrics: {},
+      frozenRoundCount: 2,
+    });
+
+    await act(async () => {
+      ws.emitServerMessage("ROOM_UPDATED", {
+        room_state_snapshot: round1StartedSnapshot,
+      });
+    });
+
+    expect(screen.getByText("Song 0")).toBeDefined();
+    expect(screen.getByText("Song 1")).toBeDefined();
+    expect(screen.getByText("上段は直前ラウンド結果を保持中です（次曲の提出開始まで）。")).toBeDefined();
+  });
+
+  it("releases sticky state after first confirmation in the live round", async () => {
+    const round0Snapshot = createSnapshot({
+      currentRoundIndex: 0,
+      confirmedMetrics: {
+        p1: 2900,
+        p2: 2750,
+      },
+      frozenRoundCount: 2,
+    });
+    const ws = await connectAndJoin(round0Snapshot);
+
+    await act(async () => {
+      ws.emitServerMessage("ROOM_UPDATED", {
+        room_state_snapshot: createSnapshot({
+          currentRoundIndex: 1,
+          confirmedMetrics: {},
+          frozenRoundCount: 2,
+        }),
+      });
+    });
+
+    expect(screen.getByText("上段は直前ラウンド結果を保持中です（次曲の提出開始まで）。")).toBeDefined();
+
+    await act(async () => {
+      ws.emitServerMessage("PLAYER_ROUND_CONFIRMED", {
+        round_index: 1,
+        player_id: "p1",
+        status: "PLAYED",
+        metric_value: 3000,
+        reason: null,
+        submitted_at: "2026-04-05T12:03:00.000Z",
+        submitted_by: "SELF",
+        source_meta: null,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("上段は直前ラウンド結果を保持中です（次曲の提出開始まで）。")).toBeNull();
+    });
+  });
+
+  it("matches snapshot for connected layout", async () => {
+    const snapshot = createSnapshot({
+      currentRoundIndex: 0,
+      confirmedMetrics: {
+        p1: 2888,
+      },
+      frozenRoundCount: 2,
+    });
+
+    const { asFragment } = render(<SpectatePage />);
+    fireEvent.click(screen.getByRole("button", { name: "CONNECT TO MATCH" }));
+
+    const ws = MockWebSocket.instances.at(-1);
+    if (ws === undefined) {
+      throw new Error("WebSocket was not created.");
+    }
+
+    await act(async () => {
+      ws.open();
+      ws.emitServerMessage("ROOM_JOIN_ACCEPTED", {
+        room_state_snapshot: snapshot,
+        session_role: "SPECTATOR",
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Spectator Connect")).toBeNull();
+    });
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/apps/web/src/pages/Spectate.tsx
+++ b/apps/web/src/pages/Spectate.tsx
@@ -1,0 +1,843 @@
+import {
+  isServerMessageType,
+  type ClientMessage,
+  type CurrentRoundConfirmedPlayer,
+  type ResultReadyPayload,
+  type RoomStateSnapshot,
+  type ServerMessage,
+  type ServerMessagePayloadMap,
+} from "@infinitas/shared";
+import type { FC, FormEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { WEB_RUNTIME } from "../lib/config";
+
+const SPECTATOR_CLIENT_VERSION = "1.2.0";
+const MAX_RESULT_HISTORY = 20;
+
+type SpectateConnectionState = "idle" | "connecting" | "joined" | "error" | "closed";
+type SpectateThemeMode = "ARENA" | "BPL";
+
+type ResultPlayer = ResultReadyPayload["per_player"]["players"][number];
+type ArenaResultPlayer = Extract<ResultPlayer, { total_points: number }>;
+type BplResultPlayer = Extract<ResultPlayer, { round_wins: number }>;
+
+interface FinalResultHistoryItem {
+  payload: ResultReadyPayload;
+  receivedAtIso: string;
+}
+
+interface CurrentArenaRow {
+  playerId: string;
+  name: string;
+  metricValue: number | null;
+  rank: number | null;
+  point: number | null;
+}
+
+interface CurrentBplRow {
+  playerId: string;
+  name: string;
+  metricValue: number | null;
+  isWinner: boolean;
+  point: number | null;
+}
+
+interface ArenaHistoryRow {
+  playerId: string;
+  name: string;
+  rank: number;
+  point: number;
+}
+
+interface BplHistoryRow {
+  playerId: string;
+  name: string;
+  isWinner: boolean;
+  point: number;
+}
+
+interface MatchHistoryCard {
+  matchId: string;
+  mode: SpectateThemeMode;
+  playedAt: string;
+  keyLabel: string;
+  arenaRows: ArenaHistoryRow[];
+  bplRows: BplHistoryRow[];
+}
+
+const readRoomRef = (): string => {
+  const raw = new URLSearchParams(window.location.search).get("r");
+  return raw?.trim() ?? "";
+};
+
+const formatDateTime = (iso: string): string => {
+  const parsed = Date.parse(iso);
+  if (!Number.isFinite(parsed)) {
+    return iso;
+  }
+
+  return new Intl.DateTimeFormat("ja-JP", {
+    dateStyle: "medium",
+    timeStyle: "medium",
+  }).format(new Date(parsed));
+};
+
+const buildSpectateWebSocketUrl = (roomRef: string): string => {
+  const joinApiUrl = new URL(WEB_RUNTIME.joinApiEndpoint, window.location.origin);
+  const wsUrl = new URL(`/api/rooms/${encodeURIComponent(roomRef)}/ws`, joinApiUrl.origin);
+  wsUrl.protocol = wsUrl.protocol === "https:" ? "wss:" : "ws:";
+  return wsUrl.toString();
+};
+
+const metricComparator = (winMetric: RoomStateSnapshot["settings"]["win_metric"] | null): ((left: number, right: number) => number) => {
+  if (winMetric === "MISSCOUNT") {
+    return (left, right) => left - right;
+  }
+  return (left, right) => right - left;
+};
+
+const rankByPoint = <TRow extends { point: number }>(rows: TRow[]): (TRow & { rank: number })[] => {
+  const sorted = [...rows].sort((left, right) => right.point - left.point);
+  let previousPoint: number | null = null;
+  let previousRank = 0;
+  return sorted.map((row, index) => {
+    const rank = previousPoint !== null && row.point === previousPoint ? previousRank : index + 1;
+    previousPoint = row.point;
+    previousRank = rank;
+    return {
+      ...row,
+      rank,
+    };
+  });
+};
+
+const toThemeMode = (mode: string | null | undefined): SpectateThemeMode => (mode === "ARENA" ? "ARENA" : "BPL");
+
+const isArenaResultPlayer = (player: ResultPlayer): player is ArenaResultPlayer => "total_points" in player;
+const isBplResultPlayer = (player: ResultPlayer): player is BplResultPlayer => "round_wins" in player;
+
+const buildMatchHistoryCard = (item: FinalResultHistoryItem): MatchHistoryCard => {
+  const summaryMode = toThemeMode(item.payload.summary.mode);
+  const representativeRound = item.payload.per_round.rounds.find((round) => round.played) ?? item.payload.per_round.rounds[0];
+  const keyLabel =
+    representativeRound === undefined
+      ? "-"
+      : `${representativeRound.expected_key.play_style} / ${representativeRound.expected_key.difficulty}`;
+
+  const arenaPlayers = item.payload.per_player.players.filter(isArenaResultPlayer);
+  const arenaRows = rankByPoint(
+    arenaPlayers.map((player) => ({
+      playerId: player.player_id,
+      name: player.display_name,
+      point: player.total_points,
+    })),
+  ).map((row) => ({
+    playerId: row.playerId,
+    name: row.name,
+    rank: row.rank,
+    point: row.point,
+  }));
+
+  const winnerSet = new Set(item.payload.summary.winner_player_ids);
+  const bplPlayers = item.payload.per_player.players.filter(isBplResultPlayer);
+  const bplRows = bplPlayers
+    .map((player) => ({
+      playerId: player.player_id,
+      name: player.display_name,
+      isWinner: winnerSet.has(player.player_id),
+      point: player.round_wins,
+    }))
+    .sort((left, right) => {
+      if (left.isWinner === right.isWinner) {
+        return right.point - left.point;
+      }
+      return left.isWinner ? -1 : 1;
+    });
+
+  return {
+    matchId: item.payload.summary.match_id,
+    mode: summaryMode,
+    playedAt: formatDateTime(item.receivedAtIso),
+    keyLabel,
+    arenaRows,
+    bplRows,
+  };
+};
+
+export const SpectatePage: FC = () => {
+  const initialRoomRef = useMemo(readRoomRef, []);
+  const [roomRefInput, setRoomRefInput] = useState(initialRoomRef);
+  const roomRef = roomRefInput.trim();
+  const spectatorId = useMemo(() => `spectator-${crypto.randomUUID()}`, []);
+  const socketRef = useRef<WebSocket | null>(null);
+  const snapshotRef = useRef<RoomStateSnapshot | null>(null);
+
+  const [joinCode, setJoinCode] = useState("");
+  const [connectionState, setConnectionState] = useState<SpectateConnectionState>("idle");
+  const [connectionMessage, setConnectionMessage] = useState("Room ID / Join Code を入力して接続してください");
+  const [snapshot, setSnapshot] = useState<RoomStateSnapshot | null>(null);
+  const [stickySnapshot, setStickySnapshot] = useState<RoomStateSnapshot | null>(null);
+  const [finalResults, setFinalResults] = useState<FinalResultHistoryItem[]>([]);
+  const [activeRoomRef, setActiveRoomRef] = useState<string | null>(null);
+
+  const isConnected = connectionState === "joined";
+
+  const closeSocket = useCallback((code: number, reason: string): void => {
+    const socket = socketRef.current;
+    socketRef.current = null;
+    if (socket !== null && (socket.readyState === WebSocket.CONNECTING || socket.readyState === WebSocket.OPEN)) {
+      socket.close(code, reason);
+    }
+  }, []);
+
+  const sendClientMessage = useCallback((message: ClientMessage): void => {
+    const socket = socketRef.current;
+    if (socket === null || socket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    socket.send(JSON.stringify(message));
+  }, []);
+
+  const upsertFinalResult = useCallback((payload: ResultReadyPayload): void => {
+    const receivedAtIso = new Date().toISOString();
+    setFinalResults((previous) => {
+      const existingIndex = previous.findIndex((item) => item.payload.summary.match_id === payload.summary.match_id);
+      const nextItem: FinalResultHistoryItem = { payload, receivedAtIso };
+      if (existingIndex < 0) {
+        return [nextItem, ...previous].slice(0, MAX_RESULT_HISTORY);
+      }
+
+      const withoutExisting = previous.filter((_, index) => index !== existingIndex);
+      return [nextItem, ...withoutExisting].slice(0, MAX_RESULT_HISTORY);
+    });
+  }, []);
+
+  const applyIncomingSnapshot = useCallback((nextSnapshot: RoomStateSnapshot): void => {
+    const previousSnapshot = snapshotRef.current;
+    const previousRoundIndex = previousSnapshot?.current_round?.round_index ?? null;
+    const nextRoundIndex = nextSnapshot.current_round?.round_index ?? null;
+    const previousHadConfirmed = (previousSnapshot?.current_round?.confirmed.length ?? 0) > 0;
+    const roundAdvanced =
+      previousRoundIndex !== null &&
+      nextRoundIndex !== null &&
+      nextRoundIndex > previousRoundIndex;
+    const movedToResult =
+      previousRoundIndex !== null &&
+      nextRoundIndex === null &&
+      nextSnapshot.room_state === "RESULT";
+    if ((roundAdvanced || movedToResult) && previousHadConfirmed && previousSnapshot !== null) {
+      setStickySnapshot(previousSnapshot);
+    }
+
+    snapshotRef.current = nextSnapshot;
+    setSnapshot(nextSnapshot);
+  }, []);
+
+  const disconnect = useCallback((): void => {
+    closeSocket(1000, "Manual disconnect.");
+    setConnectionState("idle");
+    setConnectionMessage("切断しました。再接続できます。");
+    snapshotRef.current = null;
+    setSnapshot(null);
+    setStickySnapshot(null);
+  }, [closeSocket]);
+
+  const connect = useCallback(
+    (event: FormEvent<HTMLFormElement>): void => {
+      event.preventDefault();
+      if (roomRef.length === 0) {
+        setConnectionState("error");
+        setConnectionMessage("Room ID を入力してください");
+        return;
+      }
+
+      closeSocket(1000, "Reconnect requested.");
+      if (activeRoomRef !== null && activeRoomRef !== roomRef) {
+        setFinalResults([]);
+      }
+      setActiveRoomRef(roomRef);
+      snapshotRef.current = null;
+      setSnapshot(null);
+      setStickySnapshot(null);
+      setConnectionState("connecting");
+      setConnectionMessage("接続中...");
+
+      const wsUrl = buildSpectateWebSocketUrl(roomRef);
+      const socket = new WebSocket(wsUrl);
+      socketRef.current = socket;
+
+      socket.addEventListener("open", () => {
+        setConnectionMessage("観戦参加を送信中...");
+        sendClientMessage({
+          type: "ROOM_JOIN",
+          client_msg_id: crypto.randomUUID(),
+          room_id: roomRef,
+          player_id: spectatorId,
+          payload: {
+            session_kind: "SPECTATOR",
+            client_version: SPECTATOR_CLIENT_VERSION,
+            ...(joinCode.trim().length > 0 ? { join_code: joinCode.trim() } : {}),
+          },
+        });
+      });
+
+      socket.addEventListener("message", (messageEvent) => {
+        if (typeof messageEvent.data !== "string") {
+          return;
+        }
+
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(messageEvent.data);
+        } catch {
+          setConnectionState("error");
+          setConnectionMessage("受信データの解析に失敗しました");
+          return;
+        }
+
+        if (
+          typeof parsed !== "object" ||
+          parsed === null ||
+          typeof (parsed as { type?: unknown }).type !== "string" ||
+          !isServerMessageType((parsed as { type: string }).type)
+        ) {
+          return;
+        }
+
+        const message = parsed as ServerMessage;
+        switch (message.type) {
+          case "ROOM_JOIN_ACCEPTED": {
+            const payload = message.payload as ServerMessagePayloadMap["ROOM_JOIN_ACCEPTED"];
+            applyIncomingSnapshot(payload.room_state_snapshot);
+            setConnectionState("joined");
+            setConnectionMessage("CONNECTED");
+            return;
+          }
+          case "ROOM_UPDATED":
+          case "STATE_SNAPSHOT": {
+            const payload = message.payload as ServerMessagePayloadMap["ROOM_UPDATED"] | ServerMessagePayloadMap["STATE_SNAPSHOT"];
+            applyIncomingSnapshot(payload.room_state_snapshot);
+            return;
+          }
+          case "PLAYER_ROUND_CONFIRMED": {
+            const payload = message.payload as ServerMessagePayloadMap["PLAYER_ROUND_CONFIRMED"];
+            const current = snapshotRef.current;
+            if (current === null || current.current_round === null || current.current_round.round_index !== payload.round_index) {
+              return;
+            }
+
+            const nextConfirmed = [...current.current_round.confirmed];
+            const nextPlayer: CurrentRoundConfirmedPlayer = {
+              player_id: payload.player_id,
+              status: payload.status,
+              metric_value: payload.metric_value,
+              reason: payload.reason ?? "OTHER",
+              submitted_by: payload.submitted_by,
+              submitted_at: payload.submitted_at,
+              source_meta: payload.source_meta,
+            };
+            const existingIndex = nextConfirmed.findIndex((item) => item.player_id === payload.player_id);
+            if (existingIndex >= 0) {
+              nextConfirmed[existingIndex] = nextPlayer;
+            } else {
+              nextConfirmed.push(nextPlayer);
+            }
+
+            const nextSnapshot: RoomStateSnapshot = {
+              ...current,
+              current_round: {
+                ...current.current_round,
+                confirmed: nextConfirmed,
+              },
+            };
+            snapshotRef.current = nextSnapshot;
+            setSnapshot(nextSnapshot);
+            return;
+          }
+          case "RESULT_READY": {
+            const payload = message.payload as ServerMessagePayloadMap["RESULT_READY"];
+            upsertFinalResult(payload);
+            return;
+          }
+          case "ROOM_JOIN_REJECTED": {
+            const payload = message.payload as ServerMessagePayloadMap["ROOM_JOIN_REJECTED"];
+            setConnectionState("error");
+            setConnectionMessage(`接続拒否: ${payload.reason}`);
+            return;
+          }
+          case "ERROR": {
+            const payload = message.payload as ServerMessagePayloadMap["ERROR"];
+            setConnectionState("error");
+            setConnectionMessage(`${payload.code}: ${payload.message}`);
+            return;
+          }
+          case "ROOM_CLOSED": {
+            const payload = message.payload as ServerMessagePayloadMap["ROOM_CLOSED"];
+            setConnectionState("closed");
+            setConnectionMessage(`ROOM CLOSED: ${payload.close_reason}`);
+            return;
+          }
+          default:
+            return;
+        }
+      });
+
+      socket.addEventListener("error", () => {
+        setConnectionState("error");
+        setConnectionMessage("接続エラー");
+      });
+
+      socket.addEventListener("close", (closeEvent) => {
+        socketRef.current = null;
+        setConnectionState("closed");
+        setConnectionMessage(`切断 (${closeEvent.code})`);
+      });
+    },
+    [activeRoomRef, applyIncomingSnapshot, closeSocket, joinCode, roomRef, sendClientMessage, spectatorId, upsertFinalResult],
+  );
+
+  useEffect(
+    () => () => {
+      closeSocket(1000, "Spectate page unmounted.");
+    },
+    [closeSocket],
+  );
+
+  useEffect(() => {
+    if (stickySnapshot === null || snapshot === null) {
+      return;
+    }
+
+    const stickyRoundIndex = stickySnapshot.current_round?.round_index ?? null;
+    const liveRoundIndex = snapshot.current_round?.round_index ?? null;
+    const liveHasProgress = (snapshot.current_round?.confirmed.length ?? 0) > 0;
+    const movedAwayFromSticky = stickyRoundIndex !== liveRoundIndex;
+
+    if (movedAwayFromSticky && liveHasProgress) {
+      setStickySnapshot(null);
+      return;
+    }
+
+    if (snapshot.room_state === "LOBBY" && snapshot.current_round === null) {
+      setStickySnapshot(null);
+    }
+  }, [snapshot, stickySnapshot]);
+
+  const latestResult = finalResults[0]?.payload ?? null;
+  const resultDisplaySnapshot = stickySnapshot ?? snapshot;
+  const livePreviewSnapshot = snapshot;
+  const themeMode = toThemeMode(snapshot?.settings.mode ?? resultDisplaySnapshot?.settings.mode ?? latestResult?.summary.mode);
+  const isArenaTheme = themeMode === "ARENA";
+  const connectedBackgroundClass = isArenaTheme ? "bg-[#1a1a2e]" : "bg-[#1e1a1a]";
+  const headingAccentClass = isArenaTheme ? "text-cyan-400" : "text-amber-400";
+  const statusBadgeClass = isArenaTheme ? "bg-cyan-400 text-black" : "bg-amber-400 text-black";
+  const activeResultPointClass = isArenaTheme ? "text-cyan-400" : "text-amber-400";
+  const isShowingPreviousRoundResult =
+    stickySnapshot !== null &&
+    snapshot !== null &&
+    stickySnapshot.current_round?.round_index !== snapshot.current_round?.round_index;
+
+  const currentRound = resultDisplaySnapshot?.current_round ?? null;
+  const currentRoundFrozen = useMemo(() => {
+    if (resultDisplaySnapshot === null || currentRound === null) {
+      return null;
+    }
+    return resultDisplaySnapshot.frozen_rounds.find((round) => round.round_index === currentRound.round_index) ?? null;
+  }, [currentRound, resultDisplaySnapshot]);
+
+  const livePreviewRoundIndex = useMemo(() => {
+    if (livePreviewSnapshot === null || livePreviewSnapshot.current_round === null) {
+      return null;
+    }
+    // When sticky is active, the upper section is showing the previous round result.
+    // In that case the preview should point to the live current round (not +1).
+    if (isShowingPreviousRoundResult) {
+      return livePreviewSnapshot.current_round.round_index;
+    }
+    return livePreviewSnapshot.current_round.round_index + 1;
+  }, [isShowingPreviousRoundResult, livePreviewSnapshot]);
+
+  const livePreviewRoundFrozen = useMemo(() => {
+    if (livePreviewSnapshot === null || livePreviewRoundIndex === null) {
+      return null;
+    }
+    return livePreviewSnapshot.frozen_rounds.find((round) => round.round_index === livePreviewRoundIndex) ?? null;
+  }, [livePreviewRoundIndex, livePreviewSnapshot]);
+
+  const currentSongTitle = currentRoundFrozen?.display.title ?? currentRound?.expected_key.title_search_key ?? "WAITING...";
+  const currentLevelLabel =
+    currentRoundFrozen?.display.level === null || currentRoundFrozen?.display.level === undefined
+      ? "-"
+      : `☆${currentRoundFrozen.display.level}`;
+  const currentPlayStyle = currentRound?.expected_key.play_style ?? "-";
+  const currentDifficulty = currentRound?.expected_key.difficulty ?? "-";
+  const currentMetricLabel = resultDisplaySnapshot?.settings.win_metric === "MISSCOUNT" ? "Miss Count" : "EX Score";
+
+  const livePreviewSongTitle = livePreviewRoundFrozen?.display.title ?? livePreviewRoundFrozen?.expected_key.title_search_key ?? "次曲準備中";
+  const livePreviewLevelLabel =
+    livePreviewRoundFrozen?.display.level === null || livePreviewRoundFrozen?.display.level === undefined
+      ? "-"
+      : `☆${livePreviewRoundFrozen.display.level}`;
+  const livePreviewPlayStyle = livePreviewRoundFrozen?.expected_key.play_style ?? "-";
+  const livePreviewDifficulty = livePreviewRoundFrozen?.expected_key.difficulty ?? "-";
+
+  const currentArenaRows = useMemo<CurrentArenaRow[]>(() => {
+    if (resultDisplaySnapshot === null || currentRound === null) {
+      return [];
+    }
+
+    const confirmedMap = new Map<string, CurrentRoundConfirmedPlayer>();
+    for (const confirmed of currentRound.confirmed) {
+      confirmedMap.set(confirmed.player_id, confirmed);
+    }
+
+    const measuredRows = resultDisplaySnapshot.players
+      .map((player) => ({
+        playerId: player.player_id,
+        name: player.display_name,
+        metricValue: confirmedMap.get(player.player_id)?.metric_value ?? null,
+      }))
+      .filter((row) => row.metricValue !== null)
+      .sort((left, right) =>
+        metricComparator(resultDisplaySnapshot.settings.win_metric)(left.metricValue as number, right.metricValue as number),
+      );
+
+    let previousMetric: number | null = null;
+    let previousRank = 0;
+    const rankedRows = measuredRows.map((row, index) => {
+      const metric = row.metricValue as number;
+      const rank = previousMetric !== null && previousMetric === metric ? previousRank : index + 1;
+      previousMetric = metric;
+      previousRank = rank;
+      return {
+        playerId: row.playerId,
+        name: row.name,
+        metricValue: metric,
+        rank,
+        point: rank === 1 ? 2 : rank === 2 ? 1 : 0,
+      };
+    });
+
+    const measuredPlayerIdSet = new Set(rankedRows.map((row) => row.playerId));
+    const pendingRows = resultDisplaySnapshot.players
+      .filter((player) => !measuredPlayerIdSet.has(player.player_id))
+      .map((player) => ({
+        playerId: player.player_id,
+        name: player.display_name,
+        metricValue: null,
+        rank: null,
+        point: null,
+      }));
+
+    return [...rankedRows, ...pendingRows];
+  }, [currentRound, resultDisplaySnapshot]);
+
+  const currentBplRows = useMemo<CurrentBplRow[]>(() => {
+    if (resultDisplaySnapshot === null || currentRound === null) {
+      return [];
+    }
+
+    const confirmedMap = new Map<string, CurrentRoundConfirmedPlayer>();
+    for (const confirmed of currentRound.confirmed) {
+      confirmedMap.set(confirmed.player_id, confirmed);
+    }
+
+    const measuredRows = resultDisplaySnapshot.players
+      .map((player) => ({
+        playerId: player.player_id,
+        name: player.display_name,
+        metricValue: confirmedMap.get(player.player_id)?.metric_value ?? null,
+      }))
+      .filter((row) => row.metricValue !== null)
+      .sort((left, right) =>
+        metricComparator(resultDisplaySnapshot.settings.win_metric)(left.metricValue as number, right.metricValue as number),
+      );
+
+    const bestMetric = measuredRows[0]?.metricValue ?? null;
+    const winnerPlayerIdSet = new Set(
+      measuredRows
+        .filter((row) => bestMetric !== null && row.metricValue === bestMetric)
+        .map((row) => row.playerId),
+    );
+
+    const mergedRows = resultDisplaySnapshot.players.map((player) => {
+      const measured = measuredRows.find((row) => row.playerId === player.player_id) ?? null;
+      const isWinner = measured !== null && winnerPlayerIdSet.has(player.player_id);
+      return {
+        playerId: player.player_id,
+        name: player.display_name,
+        metricValue: measured?.metricValue ?? null,
+        isWinner,
+        point: measured === null ? null : isWinner ? 1 : 0,
+      };
+    });
+
+    return mergedRows.sort((left, right) => {
+      if (left.metricValue === null && right.metricValue === null) {
+        return 0;
+      }
+      if (left.metricValue === null) {
+        return 1;
+      }
+      if (right.metricValue === null) {
+        return -1;
+      }
+      if (left.isWinner !== right.isWinner) {
+        return left.isWinner ? -1 : 1;
+      }
+      return metricComparator(resultDisplaySnapshot.settings.win_metric)(left.metricValue, right.metricValue);
+    });
+  }, [currentRound, resultDisplaySnapshot]);
+
+  const matchHistoryCards = useMemo<MatchHistoryCard[]>(() => finalResults.map(buildMatchHistoryCard), [finalResults]);
+
+  if (!isConnected) {
+    return (
+      <div className="h-screen bg-[#1e1e1e] flex flex-col items-center justify-center text-white relative">
+        <div className="bg-[#252526] p-8 rounded-2xl border border-white/10 w-full max-w-md shadow-2xl">
+          <h2 className="text-2xl font-bold mb-6 text-center text-gray-200">Spectator Connect</h2>
+
+          <form onSubmit={connect} className="flex flex-col gap-4">
+            <div>
+              <label className="block text-xs font-bold text-gray-400 mb-1 uppercase tracking-wider">Room ID</label>
+              <input
+                type="text"
+                value={roomRefInput}
+                onChange={(event) => {
+                  setRoomRefInput(event.target.value);
+                }}
+                className="w-full bg-[#1e1e1e] border border-white/10 rounded px-3 py-2 text-white focus:outline-none focus:border-cyan-500"
+                placeholder="0000-0000"
+                required
+              />
+            </div>
+
+            <div>
+              <label className="block text-xs font-bold text-gray-400 mb-1 uppercase tracking-wider">Join Code</label>
+              <input
+                type="password"
+                value={joinCode}
+                onChange={(event) => {
+                  setJoinCode(event.target.value.toUpperCase());
+                }}
+                className="w-full bg-[#1e1e1e] border border-white/10 rounded px-3 py-2 text-white focus:outline-none focus:border-cyan-500 font-mono tracking-widest"
+                placeholder="OPTIONAL"
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={connectionState === "connecting"}
+              className="w-full py-3 rounded font-bold mt-4 transition-all bg-cyan-500 text-black hover:bg-cyan-400 disabled:cursor-not-allowed disabled:bg-cyan-800/60 disabled:text-gray-300"
+            >
+              {connectionState === "connecting" ? "CONNECTING..." : "CONNECT TO MATCH"}
+            </button>
+          </form>
+
+          <p className="text-xs text-center text-gray-500 mt-4">
+            接続完了後、このフォームはOBS映り込み防止のため非表示になります。
+          </p>
+          <p className="text-xs text-center text-gray-500 mt-1">
+            切断は接続後画面の左上にある薄い「Disconnect」ボタンから実行します。
+          </p>
+          <p className="text-xs text-center text-gray-400 mt-2">{connectionMessage}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`h-screen ${connectedBackgroundClass} text-white flex flex-col p-6 overflow-hidden relative font-sans`}>
+      <div className="absolute top-2 left-2 z-[100] opacity-10 hover:opacity-100 transition-opacity flex gap-2">
+        <button
+          type="button"
+          onClick={disconnect}
+          className="px-2 py-1 bg-black/50 backdrop-blur-sm text-gray-400 text-[10px] font-bold rounded border border-white/10 hover:border-gray-400"
+        >
+          Disconnect
+        </button>
+      </div>
+
+      <header className="flex justify-between items-center mb-6">
+        <div>
+          <h1 className={`text-3xl font-black italic tracking-tighter uppercase ${headingAccentClass}`} style={{ fontStyle: "italic" }}>
+            SPECTATOR <span className="text-white">VIEW</span>
+          </h1>
+          <div className="flex items-center gap-2 mt-1">
+            <span className="inline-block w-2 h-2 rounded-full bg-green-500 animate-pulse" />
+            <span className="text-xs font-bold text-gray-400 tracking-widest">LIVE / {themeMode} MODE</span>
+            <span className="text-xs text-gray-600 font-mono ml-2">ID: {roomRef || "----"}</span>
+          </div>
+        </div>
+      </header>
+
+      <div className="flex gap-6 flex-1 min-h-0">
+        <div className="w-2/3 flex flex-col gap-4">
+          <div className="bg-white/5 border border-white/10 rounded-xl p-6 relative overflow-hidden backdrop-blur-sm">
+            <div
+              className={`absolute top-0 right-0 w-64 h-64 opacity-5 rounded-full blur-3xl -translate-y-1/2 translate-x-1/4 ${isArenaTheme ? "bg-cyan-500" : "bg-amber-500"}`}
+            />
+
+            <h2 className="text-sm font-black text-gray-400 uppercase tracking-widest mb-4 pl-2 border-l-2 border-gray-500">
+              Current Match
+            </h2>
+            {isShowingPreviousRoundResult ? (
+              <p className="text-xs text-gray-500 mb-2">直前ラウンド結果を保持中（次ラウンドの提出が始まるまで表示）</p>
+            ) : null}
+
+            <div className="flex items-center gap-4 mb-8 border-l-4 border-l-white pl-4 py-2">
+              <div className="flex flex-col">
+                {currentRound !== null ? (
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className={`text-xs font-black px-2 py-0.5 rounded ${statusBadgeClass}`}>{currentPlayStyle}</span>
+                    <span className="text-xs font-bold text-red-400 uppercase border border-red-400/30 px-1.5 rounded bg-red-500/10">
+                      {currentDifficulty}
+                    </span>
+                    <span className="text-xs font-bold text-gray-400">{currentLevelLabel}</span>
+                  </div>
+                ) : null}
+                <h3 className="text-3xl font-bold">{currentSongTitle}</h3>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-3">
+              {currentRound === null ? (
+                <div className="p-4 rounded-lg border border-white/10 bg-black/20 text-gray-400 text-sm">
+                  現在進行中のラウンドはありません。次ラウンド開始を待機中です。
+                </div>
+              ) : isArenaTheme ? (
+                currentArenaRows.map((row) => (
+                  <div
+                    key={row.playerId}
+                    className={`flex items-center p-3 rounded-lg border ${row.rank === 1 ? "border-amber-400/50 bg-amber-400/10" : "border-white/5 bg-black/20"}`}
+                  >
+                    <div className={`w-8 text-center font-black italic text-xl ${row.rank === 1 ? "text-amber-400" : "text-gray-500"}`}>
+                      {row.rank ?? "-"}
+                    </div>
+                    <div className="flex-1 ml-4 font-bold text-lg">{row.name}</div>
+                    <div className="text-right flex items-end gap-3">
+                      <div className="flex flex-col text-right">
+                        <span className="text-[10px] text-gray-500 font-bold uppercase">{currentMetricLabel}</span>
+                        <span className="font-mono text-2xl tracking-tight leading-none">{row.metricValue ?? "-"}</span>
+                      </div>
+                      <div className="flex flex-col text-right w-16">
+                        <span className="text-[10px] text-gray-500 font-bold uppercase">Points</span>
+                        <span className={`font-black text-xl italic leading-none ${row.point !== null && row.point > 0 ? activeResultPointClass : "text-gray-500"}`}>
+                          {row.point === null ? "-" : `+${row.point}`}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                ))
+              ) : (
+                currentBplRows.map((row) => (
+                  <div
+                    key={row.playerId}
+                    className={`flex items-center p-4 rounded-lg border ${row.isWinner ? "border-amber-400/50 bg-amber-400/10" : "border-white/5 bg-black/20"}`}
+                  >
+                    <div className="flex flex-col gap-1 w-12 items-center">
+                      {row.isWinner ? <span className="text-amber-400 font-black text-xs uppercase animate-pulse">WIN</span> : null}
+                    </div>
+                    <div className="flex-1 ml-2 font-bold text-2xl">{row.name}</div>
+                    <div className="text-right flex items-end gap-4">
+                      <div className="flex flex-col text-right">
+                        <span className="text-[10px] text-gray-500 font-bold uppercase">{currentMetricLabel}</span>
+                        <span className="font-mono text-3xl tracking-tight leading-none">{row.metricValue ?? "-"}</span>
+                      </div>
+                      <div className="flex flex-col text-right w-16">
+                        <span className="text-[10px] text-gray-500 font-bold uppercase">Points</span>
+                        <span className={`font-black text-2xl italic leading-none ${row.point !== null && row.point > 0 ? activeResultPointClass : "text-gray-500"}`}>
+                          {row.point === null ? "-" : `+${row.point}`}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+
+            <div className="mt-5 rounded-lg border border-white/10 bg-black/30 p-4">
+              <p className="text-[10px] font-black text-gray-400 uppercase tracking-widest">LIVE Next Preview</p>
+              {livePreviewRoundFrozen === null ? (
+                <p className="mt-2 text-sm text-gray-400">次曲準備中</p>
+              ) : (
+                <div className="mt-2">
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className={`text-[10px] font-black px-2 py-0.5 rounded ${statusBadgeClass}`}>{livePreviewPlayStyle}</span>
+                    <span className="text-[10px] font-bold text-red-400 uppercase border border-red-400/30 px-1.5 rounded bg-red-500/10">
+                      {livePreviewDifficulty}
+                    </span>
+                    <span className="text-[10px] font-bold text-gray-400">{livePreviewLevelLabel}</span>
+                    <span className="text-[10px] font-bold text-gray-500 ml-2">Round {livePreviewRoundFrozen.round_index}</span>
+                  </div>
+                  <p className="text-lg font-bold leading-tight">{livePreviewSongTitle}</p>
+                </div>
+              )}
+              {isShowingPreviousRoundResult ? (
+                <p className="mt-2 text-[11px] text-gray-500">上段は直前ラウンド結果を保持中です（次曲の提出開始まで）。</p>
+              ) : null}
+            </div>
+          </div>
+        </div>
+
+        <div className="w-1/3 flex flex-col gap-2">
+          <h2 className="text-sm font-black text-gray-400 uppercase tracking-widest mb-2 pl-2 border-l-2 border-gray-500">
+            Match History
+          </h2>
+
+          <div className="flex-1 overflow-y-auto pr-2 flex flex-col gap-3 pb-8">
+            {matchHistoryCards.length === 0 ? (
+              <div className="bg-[#252526] border border-white/10 rounded-lg p-3 text-sm text-gray-400">
+                RESULT_READYを受信すると履歴がここに追加されます。
+              </div>
+            ) : (
+              matchHistoryCards.map((card) => (
+                <div key={card.matchId} className="bg-[#252526] border border-white/10 rounded-lg p-3">
+                  <div className="text-xs text-gray-500 mb-2 font-bold">
+                    Match ID: {card.matchId} // <span className="text-gray-300">{card.playedAt}</span>
+                  </div>
+                  <div className="text-[10px] text-gray-500 mb-2 font-bold uppercase">Key: {card.keyLabel}</div>
+
+                  <div className="flex flex-col gap-1">
+                    {card.mode === "ARENA"
+                      ? card.arenaRows.map((row) => (
+                          <div key={row.playerId} className="flex justify-between items-center text-sm">
+                            <div className="flex items-center gap-2">
+                              <span className={`text-xs font-black w-4 text-center ${row.rank === 1 ? "text-amber-400" : "text-gray-500"}`}>
+                                {row.rank}
+                              </span>
+                              <span className={`font-bold ${row.rank === 1 ? "text-white" : "text-gray-400"}`}>{row.name}</span>
+                            </div>
+                            <span className={`font-black italic text-xs ${row.point > 0 ? "text-cyan-400" : "text-gray-500"}`}>
+                              {row.point} pt
+                            </span>
+                          </div>
+                        ))
+                      : card.bplRows.map((row) => (
+                          <div
+                            key={row.playerId}
+                            className={`flex justify-between items-center text-sm p-1 rounded ${row.isWinner ? "bg-white/5" : ""}`}
+                          >
+                            <div className="flex items-center gap-2">
+                              {row.isWinner ? (
+                                <span className="text-amber-400 text-xs font-black w-4 text-center">★</span>
+                              ) : (
+                                <span className="w-4" />
+                              )}
+                              <span className={`font-bold ${row.isWinner ? "text-white" : "text-gray-400"}`}>{row.name}</span>
+                            </div>
+                            <span className={`font-black italic text-xs ${row.point > 0 ? "text-amber-400" : "text-gray-500"}`}>
+                              {row.point} pt
+                            </span>
+                          </div>
+                        ))}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/pages/Spectate.tsx
+++ b/apps/web/src/pages/Spectate.tsx
@@ -265,8 +265,12 @@ export const SpectatePage: FC = () => {
       const wsUrl = buildSpectateWebSocketUrl(roomRef);
       const socket = new WebSocket(wsUrl);
       socketRef.current = socket;
+      const isStaleSocketEvent = (): boolean => socketRef.current !== socket;
 
       socket.addEventListener("open", () => {
+        if (isStaleSocketEvent()) {
+          return;
+        }
         setConnectionMessage("観戦参加を送信中...");
         sendClientMessage({
           type: "ROOM_JOIN",
@@ -282,6 +286,9 @@ export const SpectatePage: FC = () => {
       });
 
       socket.addEventListener("message", (messageEvent) => {
+        if (isStaleSocketEvent()) {
+          return;
+        }
         if (typeof messageEvent.data !== "string") {
           return;
         }
@@ -383,11 +390,17 @@ export const SpectatePage: FC = () => {
       });
 
       socket.addEventListener("error", () => {
+        if (isStaleSocketEvent()) {
+          return;
+        }
         setConnectionState("error");
         setConnectionMessage("接続エラー");
       });
 
       socket.addEventListener("close", (closeEvent) => {
+        if (isStaleSocketEvent()) {
+          return;
+        }
         socketRef.current = null;
         setConnectionState("closed");
         setConnectionMessage(`切断 (${closeEvent.code})`);

--- a/apps/web/src/pages/__snapshots__/Spectate.test.tsx.snap
+++ b/apps/web/src/pages/__snapshots__/Spectate.test.tsx.snap
@@ -1,0 +1,262 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`SpectatePage > matches snapshot for connected layout 1`] = `
+<DocumentFragment>
+  <div
+    class="h-screen bg-[#1a1a2e] text-white flex flex-col p-6 overflow-hidden relative font-sans"
+  >
+    <div
+      class="absolute top-2 left-2 z-[100] opacity-10 hover:opacity-100 transition-opacity flex gap-2"
+    >
+      <button
+        class="px-2 py-1 bg-black/50 backdrop-blur-sm text-gray-400 text-[10px] font-bold rounded border border-white/10 hover:border-gray-400"
+        type="button"
+      >
+        Disconnect
+      </button>
+    </div>
+    <header
+      class="flex justify-between items-center mb-6"
+    >
+      <div>
+        <h1
+          class="text-3xl font-black italic tracking-tighter uppercase text-cyan-400"
+          style="font-style: italic;"
+        >
+          SPECTATOR 
+          <span
+            class="text-white"
+          >
+            VIEW
+          </span>
+        </h1>
+        <div
+          class="flex items-center gap-2 mt-1"
+        >
+          <span
+            class="inline-block w-2 h-2 rounded-full bg-green-500 animate-pulse"
+          />
+          <span
+            class="text-xs font-bold text-gray-400 tracking-widest"
+          >
+            LIVE / ARENA MODE
+          </span>
+          <span
+            class="text-xs text-gray-600 font-mono ml-2"
+          >
+            ID: room-test-001
+          </span>
+        </div>
+      </div>
+    </header>
+    <div
+      class="flex gap-6 flex-1 min-h-0"
+    >
+      <div
+        class="w-2/3 flex flex-col gap-4"
+      >
+        <div
+          class="bg-white/5 border border-white/10 rounded-xl p-6 relative overflow-hidden backdrop-blur-sm"
+        >
+          <div
+            class="absolute top-0 right-0 w-64 h-64 opacity-5 rounded-full blur-3xl -translate-y-1/2 translate-x-1/4 bg-cyan-500"
+          />
+          <h2
+            class="text-sm font-black text-gray-400 uppercase tracking-widest mb-4 pl-2 border-l-2 border-gray-500"
+          >
+            Current Match
+          </h2>
+          <div
+            class="flex items-center gap-4 mb-8 border-l-4 border-l-white pl-4 py-2"
+          >
+            <div
+              class="flex flex-col"
+            >
+              <div
+                class="flex items-center gap-2 mb-1"
+              >
+                <span
+                  class="text-xs font-black px-2 py-0.5 rounded bg-cyan-400 text-black"
+                >
+                  SP
+                </span>
+                <span
+                  class="text-xs font-bold text-red-400 uppercase border border-red-400/30 px-1.5 rounded bg-red-500/10"
+                >
+                  ANOTHER
+                </span>
+                <span
+                  class="text-xs font-bold text-gray-400"
+                >
+                  ☆10
+                </span>
+              </div>
+              <h3
+                class="text-3xl font-bold"
+              >
+                Song 0
+              </h3>
+            </div>
+          </div>
+          <div
+            class="flex flex-col gap-3"
+          >
+            <div
+              class="flex items-center p-3 rounded-lg border border-amber-400/50 bg-amber-400/10"
+            >
+              <div
+                class="w-8 text-center font-black italic text-xl text-amber-400"
+              >
+                1
+              </div>
+              <div
+                class="flex-1 ml-4 font-bold text-lg"
+              >
+                PLAYER1
+              </div>
+              <div
+                class="text-right flex items-end gap-3"
+              >
+                <div
+                  class="flex flex-col text-right"
+                >
+                  <span
+                    class="text-[10px] text-gray-500 font-bold uppercase"
+                  >
+                    EX Score
+                  </span>
+                  <span
+                    class="font-mono text-2xl tracking-tight leading-none"
+                  >
+                    2888
+                  </span>
+                </div>
+                <div
+                  class="flex flex-col text-right w-16"
+                >
+                  <span
+                    class="text-[10px] text-gray-500 font-bold uppercase"
+                  >
+                    Points
+                  </span>
+                  <span
+                    class="font-black text-xl italic leading-none text-cyan-400"
+                  >
+                    +2
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div
+              class="flex items-center p-3 rounded-lg border border-white/5 bg-black/20"
+            >
+              <div
+                class="w-8 text-center font-black italic text-xl text-gray-500"
+              >
+                -
+              </div>
+              <div
+                class="flex-1 ml-4 font-bold text-lg"
+              >
+                PLAYER2
+              </div>
+              <div
+                class="text-right flex items-end gap-3"
+              >
+                <div
+                  class="flex flex-col text-right"
+                >
+                  <span
+                    class="text-[10px] text-gray-500 font-bold uppercase"
+                  >
+                    EX Score
+                  </span>
+                  <span
+                    class="font-mono text-2xl tracking-tight leading-none"
+                  >
+                    -
+                  </span>
+                </div>
+                <div
+                  class="flex flex-col text-right w-16"
+                >
+                  <span
+                    class="text-[10px] text-gray-500 font-bold uppercase"
+                  >
+                    Points
+                  </span>
+                  <span
+                    class="font-black text-xl italic leading-none text-gray-500"
+                  >
+                    -
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="mt-5 rounded-lg border border-white/10 bg-black/30 p-4"
+          >
+            <p
+              class="text-[10px] font-black text-gray-400 uppercase tracking-widest"
+            >
+              LIVE Next Preview
+            </p>
+            <div
+              class="mt-2"
+            >
+              <div
+                class="flex items-center gap-2 mb-1"
+              >
+                <span
+                  class="text-[10px] font-black px-2 py-0.5 rounded bg-cyan-400 text-black"
+                >
+                  SP
+                </span>
+                <span
+                  class="text-[10px] font-bold text-red-400 uppercase border border-red-400/30 px-1.5 rounded bg-red-500/10"
+                >
+                  ANOTHER
+                </span>
+                <span
+                  class="text-[10px] font-bold text-gray-400"
+                >
+                  ☆11
+                </span>
+                <span
+                  class="text-[10px] font-bold text-gray-500 ml-2"
+                >
+                  Round 1
+                </span>
+              </div>
+              <p
+                class="text-lg font-bold leading-tight"
+              >
+                Song 1
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="w-1/3 flex flex-col gap-2"
+      >
+        <h2
+          class="text-sm font-black text-gray-400 uppercase tracking-widest mb-2 pl-2 border-l-2 border-gray-500"
+        >
+          Match History
+        </h2>
+        <div
+          class="flex-1 overflow-y-auto pr-2 flex flex-col gap-3 pb-8"
+        >
+          <div
+            class="bg-[#252526] border border-white/10 rounded-lg p-3 text-sm text-gray-400"
+          >
+            RESULT_READYを受信すると履歴がここに追加されます。
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/apps/web/src/spectate-main.tsx
+++ b/apps/web/src/spectate-main.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { SpectatePage } from "./pages/Spectate";
+import "./styles.css";
+
+const container = document.getElementById("root");
+
+if (!container) {
+  throw new Error("Root container not found.");
+}
+
+createRoot(container).render(
+  <StrictMode>
+    <SpectatePage />
+  </StrictMode>,
+);

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -4,6 +4,7 @@ import react from "@vitejs/plugin-react";
 const repoRoot = new URL("../..", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1");
 const landingEntry = new URL("./index.html", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1");
 const joinEntry = new URL("./join/index.html", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1");
+const spectateEntry = new URL("./spectate/index.html", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1");
 
 export default defineConfig({
   base: process.env.VITE_WEB_BASE ?? "/",
@@ -21,6 +22,7 @@ export default defineConfig({
       input: {
         landing: landingEntry,
         join: joinEntry,
+        spectate: spectateEntry,
       },
     },
   },

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "happy-dom",
+  },
+});

--- a/apps/worker/src/durable/room-object.test.mjs
+++ b/apps/worker/src/durable/room-object.test.mjs
@@ -117,7 +117,7 @@ async function createRoomObject() {
   return roomObject;
 }
 
-function createJoinMessage(playerId, clientMessageId) {
+function createJoinMessage(playerId, clientMessageId, payloadOverrides = {}) {
   return {
     type: "ROOM_JOIN",
     client_msg_id: clientMessageId,
@@ -127,13 +127,26 @@ function createJoinMessage(playerId, clientMessageId) {
       display_name: playerId.toUpperCase(),
       source: "inf-notebook",
       client_version: "1.2.0",
+      ...payloadOverrides,
     },
   };
 }
 
-async function joinPlayer(roomObject, socket, playerId, clientMessageId) {
+async function joinPlayer(roomObject, socket, playerId, clientMessageId, payloadOverrides = {}) {
   const session = roomObject.registerSocketSession(socket);
-  await roomObject.handleRoomJoin(session, createJoinMessage(playerId, clientMessageId));
+  await roomObject.handleRoomJoin(session, createJoinMessage(playerId, clientMessageId, payloadOverrides));
+  return session;
+}
+
+async function joinSpectator(roomObject, socket, spectatorId, clientMessageId, payloadOverrides = {}) {
+  const session = roomObject.registerSocketSession(socket);
+  await roomObject.handleRoomJoin(
+    session,
+    createJoinMessage(spectatorId, clientMessageId, {
+      session_kind: "SPECTATOR",
+      ...payloadOverrides,
+    }),
+  );
   return session;
 }
 
@@ -456,4 +469,113 @@ test("internal recreate rejects when active generation exists", async () => {
   assert.equal(response.status, 409);
   const payload = await response.json();
   assert.equal(payload.error, "ACTIVE_GENERATION_EXISTS");
+});
+
+test("spectator join keeps player slots unchanged and receives redacted snapshot", async () => {
+  const roomObject = await createRoomObject();
+  roomObject.roomState.settings.visibility = "PRIVATE";
+  roomObject.roomState.settings.join_code = "ABCDEFGH";
+
+  const hostSocket = new TestSocket();
+  await joinPlayer(roomObject, hostSocket, "host", "msg-1", { join_code: "ABCDEFGH" });
+  const beforeSpectatorJoinCount = roomObject.roomState.toSnapshot().players.length;
+
+  const spectatorSocket = new TestSocket();
+  const spectatorSession = await joinSpectator(roomObject, spectatorSocket, "viewer-1", "msg-2", { join_code: "ABCDEFGH" });
+
+  assert.equal(spectatorSession.role, "SPECTATOR");
+  assert.equal(roomObject.roomState.toSnapshot().players.length, beforeSpectatorJoinCount);
+
+  const joinAccepted = spectatorSocket.sent.find((message) => message.type === "ROOM_JOIN_ACCEPTED");
+  assert.ok(joinAccepted);
+  assert.equal(joinAccepted.payload.session_role, "SPECTATOR");
+  assert.equal(joinAccepted.payload.room_state_snapshot.settings.join_code, null);
+});
+
+test("spectator join rejects invalid join_code in PRIVATE room", async () => {
+  const roomObject = await createRoomObject();
+  roomObject.roomState.settings.visibility = "PRIVATE";
+  roomObject.roomState.settings.join_code = "ABCDEFGH";
+
+  const spectatorSocket = new TestSocket();
+  await joinSpectator(roomObject, spectatorSocket, "viewer-2", "msg-1", { join_code: "WRONG999" });
+
+  const rejected = spectatorSocket.sent.find((message) => message.type === "ROOM_JOIN_REJECTED");
+  assert.ok(rejected);
+  assert.equal(rejected.payload.reason, "JOIN_CODE_INVALID");
+});
+
+test("spectator mutation messages are rejected as read-only", async () => {
+  const roomObject = await createRoomObject();
+  const spectatorSocket = new TestSocket();
+  await joinSpectator(roomObject, spectatorSocket, "viewer-3", "msg-1");
+  roomObject.roomState.readyCheckDeadline = new Date("2099-01-01T00:00:00.000Z");
+
+  const rejectedTypes = [
+    "READY_SET",
+    "START_MATCH",
+    "SOURCE_STATUS_SET",
+    "PICK_SUBMIT",
+    "RESULT_SUBMIT",
+    "FORCE_ADVANCE",
+  ];
+
+  let clientMessageIndex = 1;
+  for (const type of rejectedTypes) {
+    clientMessageIndex += 1;
+    await roomObject.webSocketMessage(
+      spectatorSocket,
+      JSON.stringify({
+        type,
+        client_msg_id: `msg-${clientMessageIndex}`,
+        room_id: "room-1",
+        player_id: "viewer-3",
+        payload: {},
+      }),
+    );
+  }
+
+  const errors = spectatorSocket.sent.filter((message) => message.type === "ERROR");
+  assert.equal(errors.length, rejectedTypes.length);
+  for (const errorMessage of errors) {
+    assert.equal(errorMessage.payload.code, "INVALID_STATE");
+    assert.equal(errorMessage.payload.message, "Spectator sessions are read-only.");
+  }
+});
+
+test("ROOM_UPDATED is redacted for spectator and full for player", async () => {
+  const roomObject = await createRoomObject();
+  roomObject.roomState.settings.visibility = "PRIVATE";
+  roomObject.roomState.settings.join_code = "ABCDEFGH";
+  roomObject.roomState.readyCheckDeadline = new Date("2099-01-01T00:00:00.000Z");
+
+  const hostSocket = new TestSocket();
+  await joinPlayer(roomObject, hostSocket, "host", "msg-1", { join_code: "ABCDEFGH" });
+  hostSocket.sent = [];
+
+  const spectatorSocket = new TestSocket();
+  await joinSpectator(roomObject, spectatorSocket, "viewer-4", "msg-2", { join_code: "ABCDEFGH" });
+  spectatorSocket.sent = [];
+
+  await roomObject.webSocketMessage(
+    hostSocket,
+    JSON.stringify({
+      type: "READY_SET",
+      client_msg_id: "msg-3",
+      room_id: "room-1",
+      player_id: "host",
+      payload: {
+        ready: true,
+        generation: 1,
+      },
+    }),
+  );
+
+  const hostUpdated = hostSocket.sent.find((message) => message.type === "ROOM_UPDATED");
+  const spectatorUpdated = spectatorSocket.sent.find((message) => message.type === "ROOM_UPDATED");
+
+  assert.ok(hostUpdated);
+  assert.ok(spectatorUpdated);
+  assert.equal(hostUpdated.payload.room_state_snapshot.settings.join_code, "ABCDEFGH");
+  assert.equal(spectatorUpdated.payload.room_state_snapshot.settings.join_code, null);
 });

--- a/apps/worker/src/durable/room-object.ts
+++ b/apps/worker/src/durable/room-object.ts
@@ -17,7 +17,6 @@ import {
   type JsonObject,
   type LobbyRoomSummary,
   type RequestIdPayload,
-  type RoomJoinPayload,
   type RoomSettings,
   type RoomStateSnapshot,
   type SongUnlockSettings,
@@ -40,6 +39,7 @@ import {
 import { workerChartMaster } from "../master/chart-master";
 
 type RoomSocketRole = "HOST" | "PLAYER" | "SPECTATOR";
+type JoinAcceptedSessionRole = "HOST" | "PLAYER" | "SPECTATOR";
 
 type RoomSocketAttachment = {
   playerId: string | null;
@@ -94,6 +94,8 @@ const CLIENT_VERSION_UNSUPPORTED_REASON = "CLIENT_VERSION_UNSUPPORTED";
 const CLIENT_VERSION_PATTERN = /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 const ROOM_RECREATE_WINDOW_MS = ROOM_RECREATE_WINDOW_MINUTES * 60_000;
 const ROOM_STATE_CHANGED_ERROR_MESSAGE = "部屋の状態が変わりました。一覧に戻ってください。";
+const SPECTATOR_READ_ONLY_ERROR_MESSAGE = "Spectator sessions are read-only.";
+const ROOM_JOIN_SESSION_KINDS = ["PLAYER", "SPECTATOR"] as const;
 
 interface ParsedClientVersion {
   major: number;
@@ -389,10 +391,22 @@ function parseRecreateInput(payload: unknown): ParsedRecreateInput | null {
   };
 }
 
-interface ParsedRoomJoinPayload extends RoomJoinPayload {
+interface ParsedPlayerJoinPayload {
+  session_kind: "PLAYER";
+  display_name: string;
+  source: RoomStateSnapshot["players"][number]["source"];
+  join_code?: string;
+  client_version?: string;
   song_unlocks: SongUnlockSettings;
+}
+
+interface ParsedSpectatorJoinPayload {
+  session_kind: "SPECTATOR";
+  join_code?: string;
   client_version?: string;
 }
+
+type ParsedRoomJoinPayload = ParsedPlayerJoinPayload | ParsedSpectatorJoinPayload;
 
 function parseClientVersion(rawValue: string): ParsedClientVersion | null {
   const match = CLIENT_VERSION_PATTERN.exec(rawValue.trim());
@@ -501,18 +515,28 @@ function parseRoomJoinPayload(payload: unknown): ParsedRoomJoinPayload | null {
     return null;
   }
 
-  const displayNameRaw = asOptionalString(payload.display_name);
-  const source = asEnumValue(payload.source, SOURCE_TYPES);
+  const sessionKind = asEnumValue(payload.session_kind, ROOM_JOIN_SESSION_KINDS) ?? "PLAYER";
   const joinCode = asOptionalString(payload.join_code);
   const clientVersionRaw = asOptionalString(payload.client_version);
   const clientVersion = clientVersionRaw?.trim() ?? "";
 
+  if (sessionKind === "SPECTATOR") {
+    return {
+      session_kind: "SPECTATOR",
+      ...(clientVersion.length === 0 ? {} : { client_version: clientVersion }),
+      ...(joinCode === undefined ? {} : { join_code: joinCode }),
+    };
+  }
+
+  const displayNameRaw = asOptionalString(payload.display_name);
+  const source = asEnumValue(payload.source, SOURCE_TYPES);
   const displayName = displayNameRaw?.trim() ?? "";
   if (displayName.length === 0 || source === undefined) {
     return null;
   }
 
   return {
+    session_kind: "PLAYER",
     display_name: displayName,
     source,
     ...(clientVersion.length === 0 ? {} : { client_version: clientVersion }),
@@ -1259,6 +1283,42 @@ export class RoomDurableObject {
     return this.roomState.getHostPlayerId() === playerId ? "HOST" : "PLAYER";
   }
 
+  private isSpectatorAllowedMessage(type: string): boolean {
+    return type === "ROOM_JOIN" || type === "ROOM_LEAVE" || type === "STATE_GET" || type === "PING";
+  }
+
+  private redactSnapshotForSpectator(snapshot: RoomStateSnapshot): RoomStateSnapshot {
+    if (snapshot.settings.join_code === null) {
+      return snapshot;
+    }
+
+    return {
+      ...snapshot,
+      settings: {
+        ...snapshot.settings,
+        join_code: null,
+      },
+    };
+  }
+
+  private buildSnapshotForSession(
+    session: RoomSocketSession | undefined,
+    baseSnapshot: RoomStateSnapshot,
+  ): RoomStateSnapshot {
+    return session?.role === "SPECTATOR" ? this.redactSnapshotForSpectator(baseSnapshot) : baseSnapshot;
+  }
+
+  private resolveJoinAcceptedSessionRole(
+    session: RoomSocketSession,
+    fallbackPlayerId: string,
+  ): JoinAcceptedSessionRole {
+    if (session.role === "HOST" || session.role === "PLAYER" || session.role === "SPECTATOR") {
+      return session.role;
+    }
+
+    return this.resolveSocketRole(fallbackPlayerId);
+  }
+
   private parseAttachmentTimestamp(value: string | null): number {
     if (typeof value !== "string") {
       return Number.NEGATIVE_INFINITY;
@@ -1273,7 +1333,7 @@ export class RoomDurableObject {
     const newestAttachedAtByPlayerId = new Map<string, number>();
 
     for (const session of this.sessionsBySocket.values()) {
-      if (session.playerId === null) {
+      if (session.playerId === null || session.role === "SPECTATOR") {
         continue;
       }
 
@@ -1317,6 +1377,19 @@ export class RoomDurableObject {
     session.attachedAt = attachedAt;
     this.syncSocketAttachment(session);
     this.activeSocketByPlayerId.set(playerId, session.socket);
+  }
+
+  private assignSessionToSpectator(
+    session: RoomSocketSession,
+    spectatorId: string,
+    attachedAt: string,
+  ): void {
+    session.playerId = spectatorId;
+    session.joinedAt = attachedAt;
+    session.role = "SPECTATOR";
+    session.connectionId = crypto.randomUUID();
+    session.attachedAt = attachedAt;
+    this.syncSocketAttachment(session);
   }
 
   private replacePlayerSocket(playerId: string, currentSession: RoomSocketSession): void {
@@ -1413,6 +1486,16 @@ export class RoomDurableObject {
 
       if (message.type !== "ROOM_JOIN" && session.playerId === null) {
         this.sendError(socket, "INVALID_STATE", "Send ROOM_JOIN before this message.", this.buildMessageLogInput(message));
+        return;
+      }
+
+      if (session.role === "SPECTATOR" && !this.isSpectatorAllowedMessage(message.type)) {
+        this.sendError(socket, "INVALID_STATE", SPECTATOR_READ_ONLY_ERROR_MESSAGE, this.buildMessageLogInput(message, {
+          detail: {
+            validation: "spectator_read_only",
+            rejected_type: message.type,
+          },
+        }));
         return;
       }
 
@@ -1521,6 +1604,10 @@ export class RoomDurableObject {
     });
 
     this.sessionsBySocket.delete(socket);
+    if (session.role === "SPECTATOR") {
+      return;
+    }
+
     if (playerId === null || !isCurrentSocket) {
       return;
     }
@@ -1555,13 +1642,18 @@ export class RoomDurableObject {
       return;
     }
 
-    if (
+    const isCurrentPlayerSession =
       session.playerId === message.player_id &&
+      session.role !== "SPECTATOR" &&
       this.roomState.isPlayerConnected(message.player_id) &&
-      this.isCurrentSocketForPlayer(message.player_id, session.socket)
-    ) {
+      this.isCurrentSocketForPlayer(message.player_id, session.socket);
+    const isCurrentSpectatorSession = session.playerId === message.player_id && session.role === "SPECTATOR";
+
+    if (isCurrentPlayerSession || isCurrentSpectatorSession) {
+      const snapshot = this.roomState.toSnapshot();
       this.send(session.socket, "ROOM_JOIN_ACCEPTED", {
-        room_state_snapshot: this.roomState.toSnapshot(),
+        room_state_snapshot: this.buildSnapshotForSession(session, snapshot),
+        session_role: session.role ?? this.resolveSocketRole(message.player_id),
       });
       this.sendResultReadyIfAvailable(session.socket);
       this.logRoomEvent(this.buildMessageLogInput(message, {
@@ -1584,18 +1676,20 @@ export class RoomDurableObject {
       return;
     }
 
-    if (payload.source === "inf_daken_counter") {
-      this.sendJoinRejected(
-        session.socket,
-        "SOURCE_DEPRECATED",
-        this.buildMessageLogInput(message, {
-          source: payload.source,
-          detail: {
-            validation: "source_deprecated",
-          },
-        }),
-      );
-      return;
+    if (payload.session_kind === "PLAYER") {
+      if (payload.source === "inf_daken_counter") {
+        this.sendJoinRejected(
+          session.socket,
+          "SOURCE_DEPRECATED",
+          this.buildMessageLogInput(message, {
+            source: payload.source,
+            detail: {
+              validation: "source_deprecated",
+            },
+          }),
+        );
+        return;
+      }
     }
 
     const parsedClientVersion =
@@ -1608,7 +1702,7 @@ export class RoomDurableObject {
         session.socket,
         buildUnsupportedClientVersionReason(this.minSupportedClientVersion),
         this.buildMessageLogInput(message, {
-          source: payload.source,
+          ...(payload.session_kind === "PLAYER" ? { source: payload.source } : {}),
           detail: {
             validation: "client_version_unsupported",
             client_version: payload.client_version ?? null,
@@ -1625,13 +1719,33 @@ export class RoomDurableObject {
       const observedJoinCode = normalizeJoinCode(payload.join_code);
       if (expectedJoinCode === null || observedJoinCode !== expectedJoinCode) {
         this.sendJoinRejected(session.socket, "JOIN_CODE_INVALID", this.buildMessageLogInput(message, {
-          source: payload.source,
+          ...(payload.session_kind === "PLAYER" ? { source: payload.source } : {}),
           detail: {
             validation: "join_code_invalid",
           },
         }));
         return;
       }
+    }
+
+    if (payload.session_kind === "SPECTATOR") {
+      const attachedAt = new Date().toISOString();
+      this.assignSessionToSpectator(session, message.player_id, attachedAt);
+      const snapshot = this.roomState.toSnapshot();
+      this.send(session.socket, "ROOM_JOIN_ACCEPTED", {
+        room_state_snapshot: this.buildSnapshotForSession(session, snapshot),
+        session_role: this.resolveJoinAcceptedSessionRole(session, message.player_id),
+      });
+      this.sendResultReadyIfAvailable(session.socket);
+      this.logRoomEvent(this.buildMessageLogInput(message, {
+        event: "room.join",
+        outcome: "ok",
+        detail: {
+          join_type: "SPECTATOR",
+          attached_at: attachedAt,
+        },
+      }));
+      return;
     }
 
     const now = new Date();
@@ -1669,6 +1783,7 @@ export class RoomDurableObject {
 
     this.send(session.socket, "ROOM_JOIN_ACCEPTED", {
       room_state_snapshot: snapshot,
+      session_role: this.resolveJoinAcceptedSessionRole(session, message.player_id),
     });
     this.sendResultReadyIfAvailable(session.socket);
     this.logRoomEvent(this.buildMessageLogInput(message, {
@@ -1687,6 +1802,11 @@ export class RoomDurableObject {
   private async handleRoomLeaveMessage(session: RoomSocketSession, message: ClientMessage<"ROOM_LEAVE">): Promise<void> {
     if (session.playerId === null) {
       this.sendError(session.socket, "INVALID_STATE", "Send ROOM_JOIN before this message.", this.buildMessageLogInput(message));
+      return;
+    }
+
+    if (session.role === "SPECTATOR") {
+      await this.handleRoomLeave(session, true);
       return;
     }
 
@@ -1709,10 +1829,29 @@ export class RoomDurableObject {
 
   private async handleRoomLeave(session: RoomSocketSession, closeSocket: boolean): Promise<void> {
     const playerId = session.playerId;
+    const role = session.role;
     const previousState = this.roomState.isInitialized() ? this.roomState.getRoomState() : "(uninitialized)";
     this.clearSessionPlayerBinding(session);
 
     if (playerId === null) {
+      if (closeSocket) {
+        this.safeCloseSocket(session.socket, 1000, "Left room.");
+      }
+      return;
+    }
+
+    if (role === "SPECTATOR") {
+      this.logRoomEvent({
+        event: "room.leave",
+        player_id: playerId,
+        outcome: "ok",
+        detail: {
+          close_socket: closeSocket,
+          leave_reason: "SPECTATOR_LEFT",
+          was_host: false,
+          room_was_closed: false,
+        },
+      });
       if (closeSocket) {
         this.safeCloseSocket(session.socket, 1000, "Left room.");
       }
@@ -2588,16 +2727,25 @@ export class RoomDurableObject {
   }
 
   private sendStateSnapshot(socket: WebSocket): void {
+    const session = this.getOrCreateSocketSession(socket);
+    const snapshot = this.roomState.toSnapshot();
     this.send(socket, "STATE_SNAPSHOT", {
-      room_state_snapshot: this.roomState.toSnapshot(),
+      room_state_snapshot: this.buildSnapshotForSession(session, snapshot),
     });
     this.sendResultReadyIfAvailable(socket);
   }
 
   private broadcastRoomUpdated(): void {
-    this.broadcast("ROOM_UPDATED", {
-      room_state_snapshot: this.roomState.toSnapshot(),
-    });
+    const snapshot = this.roomState.toSnapshot();
+    for (const session of this.sessionsBySocket.values()) {
+      if (session.playerId === null) {
+        continue;
+      }
+
+      this.send(session.socket, "ROOM_UPDATED", {
+        room_state_snapshot: this.buildSnapshotForSession(session, snapshot),
+      });
+    }
   }
 
   private broadcastAcceptedPick(acceptedPick: {
@@ -2664,6 +2812,13 @@ export class RoomDurableObject {
   ): void {
     for (const session of this.sessionsBySocket.values()) {
       if (!includeUnjoined && session.playerId === null) {
+        continue;
+      }
+      if (session.role === "SPECTATOR" && type === "ROOM_UPDATED") {
+        const roomUpdatedPayload = payload as ServerMessagePayloadMap["ROOM_UPDATED"];
+        this.send(session.socket, type, {
+          room_state_snapshot: this.redactSnapshotForSpectator(roomUpdatedPayload.room_state_snapshot),
+        } as ServerMessagePayloadMap[TType]);
         continue;
       }
       this.send(session.socket, type, payload);

--- a/docs/design/01_fsm.md
+++ b/docs/design/01_fsm.md
@@ -16,6 +16,7 @@
 - ルーム: 対戦セッション単位（DOインスタンス）
 - ホスト: ルーム作成者（固定。非明示切断時は `rejoin_cooldown` 以内の再接続を許容し、超過で解散）
 - プレイヤー: 参加者（最大4）
+- 観戦者（spectator）: read-only 接続者。`max_players` を消費せず、FSM進行・集計・勝敗判定へ参与しない
 - ラウンド: PLAYING中の1譜面単位（譜面リストのindex）
 - Round Result（曲別リザルト）: 1ラウンド単位の結果表示（UIフェーズ）
 - Match Result（最終結果 / RESULT）: マッチ全体の最終集計表示（`room_state=RESULT`）
@@ -94,6 +95,7 @@
 
 ## 6. LOBBY（参加・設定閲覧）
 - 参加/退出は自由（最大 `max_players`）
+- spectator は `LOBBY/PICKING/PLAYING/RESULT` の全状態で接続可能だが、操作系メッセージは送信不可（read-only）
 - ready 管理は `LOBBY` の内部状態として扱う
 - 全員が `ready=true` になって初めて `START_MATCH` 条件を満たせる
 - ホスト自身も `ready=true` 必須

--- a/docs/design/02_ws_protocol.md
+++ b/docs/design/02_ws_protocol.md
@@ -44,9 +44,11 @@
 
 ### 3.1 ルーム
 - `ROOM_JOIN`
-  - payload: `{ join_code?: string, display_name: string, source: "inf_daken_counter"|"inf-notebook"|"daken_counter_v3"|"reflux", client_version?: string, client_capabilities?: object }`
+  - payload（PLAYER）: `{ session_kind?: "PLAYER", join_code?: string, display_name: string, source: "inf_daken_counter"|"inf-notebook"|"daken_counter_v3"|"reflux", client_version?: string, client_capabilities?: object }`
+  - payload（SPECTATOR）: `{ session_kind: "SPECTATOR", join_code?: string, client_version?: string }`
   - 備考: WS接続直後に必ず送る（DOがJOIN完了するまでstate配信しない）
   - 備考: `client_capabilities.song_unlocks = { bit_unlocked: boolean, djp_unlocked: boolean, allow_leggendaria: boolean, owned_pack_ids: number[] }` を送ると、`START_MATCH` 時の共通解禁フィルタ計算に利用される
+  - 備考: `session_kind="SPECTATOR"` は read-only 観戦セッションを要求する（player slot 非消費）
 - `ROOM_LEAVE`
   - payload: `{ generation: number }`
 
@@ -92,7 +94,7 @@
 
 ### 4.1 ルーム
 - `ROOM_JOIN_ACCEPTED`
-  - payload: `{ room_state_snapshot: RoomStateSnapshot }`
+  - payload: `{ room_state_snapshot: RoomStateSnapshot, session_role?: "HOST"|"PLAYER"|"SPECTATOR" }`
 - `ROOM_JOIN_REJECTED`
   - payload: `{ reason: string }`
   - 備考: `client_version` が最小対応版未満または未送信の場合、`reason` には `CLIENT_VERSION_UNSUPPORTED: ...` を返す
@@ -247,6 +249,9 @@
   - `play_style/difficulty/title_search_key` は常に一致必須
   - `chart_id` は双方にある場合のみ一致必須。`expected_key.chart_id` がある `daken_counter_v3` 観測で `observed_key.chart_id` 欠落時は不採用
 - ROOM_JOIN: `client_version >= MIN_SUPPORTED_CLIENT_VERSION` を満たさない場合は `ROOM_JOIN_REJECTED` を返す
+- SPECTATOR: `ROOM_JOIN/ROOM_LEAVE/STATE_GET/PING` 以外は `ERROR(code="INVALID_STATE")` で拒否する
+- SPECTATOR: `PRIVATE` ルームでは player と同様に `join_code` 認可を必須化する
+- SPECTATOR: 配信する `room_state_snapshot` は redacted 形（少なくとも `settings.join_code=null`）で返す
 - `READY_SET / START_MATCH / RETURN_TO_LOBBY / RESULT_SUBMIT / ROOM_LEAVE` は `payload.generation == current_generation` のときのみ受理し、不一致時は操作を拒否する
 - PICKING timeout: 未pickプレイヤーへランダム割当を行ってから `PICK_FROZEN` / `ROUND_BEGIN` を配信
 - `RESULT_READY` 生成後の `RESULT` / `CLOSED` では提出系はすべて拒否（勝敗改変防止）

--- a/docs/design/03_data_model.md
+++ b/docs/design/03_data_model.md
@@ -63,6 +63,14 @@
 - `rejoin_until: datetime|null`（退出後の再入室クールダウン終端）
 - `role: HOST|GUEST`（ホスト判定補助）
 
+### 2.3.1 Spectator Session（read-only）
+- spectator は `Player` エンティティとして永続化しない（`players[]` 非包含）
+- spectator は WS セッション属性としてのみ保持する
+  - `session_role = SPECTATOR`
+  - `player_id` は接続識別子として利用可
+- spectator 接続は `max_players` / `currentPlayers` / 勝敗集計へ影響しない
+- spectator 向け `RoomStateSnapshot` は redacted 形で返す（少なくとも `settings.join_code=null`）
+
 ### 2.4 Pick（指名）
 - `player_id: string`
 - `pick_chart_key: string`

--- a/docs/design/05_screen_list.md
+++ b/docs/design/05_screen_list.md
@@ -29,6 +29,7 @@ Ph1 の画面は以下とする。
    - RESULT
 4. 統計画面
 5. エラーダイアログ / 通知
+6. Web観戦ページ（read-only）
 
 ---
 
@@ -388,6 +389,34 @@ Ph1 の画面は以下とする。
 ## 10.4 主な操作
 - ルール切替
 - モード切替
+
+---
+
+## 11. Web観戦ページ（read-only）
+
+## 11.1 目的
+- ブラウザから read-only で対戦進行を監視する
+- スコア進行・状態遷移を閲覧し、ルーム操作権限は持たない
+
+## 11.2 主な表示項目
+- room_id（URLクエリ `r`）
+- join_code 入力欄（PRIVATE 観戦時）
+- 接続状態（connecting / joined / closed / error）
+- 現在状態（room_state, mode, win_metric）
+- 現在ラウンド（round_index, expected_key, confirmed status）
+- プレイヤー別進行（status / metric_value）
+- 観戦開始後イベントログ（接続後に受信したWSイベントのみ）
+
+## 11.3 主な操作
+- 観戦接続（`ROOM_JOIN(session_kind=SPECTATOR)`）
+- 切断
+- 状態再取得（`STATE_GET`）
+
+## 11.4 制約
+- spectator は read-only。操作系メッセージは server-authoritative で拒否される
+- spectator は `max_players` を消費しない
+- PRIVATE 観戦は join_code 認可を必須とする
+- 表示履歴は観戦開始後のイベントのみを扱う
 
 ---
 

--- a/docs/design/10_regression_guard_addendum.md
+++ b/docs/design/10_regression_guard_addendum.md
@@ -78,3 +78,11 @@
 - `CloseReason` 変更: `01/02/07` + client 表示仕様
 - `RESULT_READY` 変更: `02/03` + shared 型 + worker/client 利用箇所
 
+## 6. Spectator 契約（固定）
+
+- `ROOM_JOIN.payload.session_kind` は additive で導入する（`PLAYER` 既定、`SPECTATOR` 追加）。
+- `session_kind=SPECTATOR` は read-only セッションを意味し、player slot を消費しない。
+- `PRIVATE` ルームの spectator 参加は join_code 認可を必須とする。
+- spectator 向け `RoomStateSnapshot` は redacted 形で返す（最低限 `settings.join_code=null`）。
+- spectator からの操作系メッセージは `INVALID_STATE` で拒否する。
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "infinitas-arena",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "infinitas-arena",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -22,7 +22,7 @@
     },
     "apps/client": {
       "name": "@infinitas/client",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.5.1",
         "@tauri-apps/plugin-deep-link": "^2.0.0",
@@ -45,7 +45,7 @@
     },
     "apps/update-worker": {
       "name": "@infinitas/update-worker",
-      "version": "1.1.1"
+      "version": "1.2.0"
     },
     "apps/web": {
       "name": "@infinitas/web",
@@ -56,19 +56,22 @@
         "react-dom": "^19.1.0"
       },
       "devDependencies": {
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.1.5",
         "@types/react-dom": "^19.1.5",
         "@vitejs/plugin-react": "^5.0.4",
         "autoprefixer": "^10.4.19",
+        "happy-dom": "^20.8.9",
         "postcss": "^8.4.39",
         "tailwindcss": "^3.4.4",
         "typescript": "^5.8.2",
-        "vite": "^7.1.7"
+        "vite": "^7.1.7",
+        "vitest": "^4.1.2"
       }
     },
     "apps/worker": {
       "name": "@infinitas/worker",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "devDependencies": {
         "tsx": "^4.21.0"
       }
@@ -349,6 +352,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2211,6 +2224,13 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tauri-apps/api": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
@@ -2465,6 +2485,63 @@
         "@tauri-apps/api": "^2.0.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2510,6 +2587,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2523,6 +2618,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
@@ -2542,6 +2647,23 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2847,6 +2969,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2885,6 +3120,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -2950,6 +3196,27 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
@@ -3126,6 +3393,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3313,6 +3590,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3337,6 +3625,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.307",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
@@ -3353,6 +3649,13 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -3563,6 +3866,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3571,6 +3884,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3802,6 +4125,69 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.8.9",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.9.tgz",
+      "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/happy-dom/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/happy-dom/node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/has-flag": {
@@ -4106,6 +4492,27 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4258,6 +4665,17 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -4576,6 +4994,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4627,6 +5075,14 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -4882,6 +5338,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4891,6 +5354,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -5015,6 +5492,23 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -5030,6 +5524,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -5153,6 +5657,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.24",
@@ -5287,6 +5798,88 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5301,6 +5894,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -5438,7 +6048,7 @@
     },
     "packages/shared": {
       "name": "@infinitas/shared",
-      "version": "1.1.1"
+      "version": "1.2.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build:client": "npm --workspace @infinitas/client run build",
     "dev:web": "npm --workspace @infinitas/web run dev",
     "build:web": "npm --workspace @infinitas/web run build",
+    "test:web": "npm --workspace @infinitas/web run test",
     "test:worker": "npm --workspace @infinitas/worker run test",
     "test:client-stats": "node -e \"require('node:fs').rmSync('./.tmp/client-stats-tests', { recursive: true, force: true })\" && node ./node_modules/typescript/bin/tsc -p apps/client/tsconfig.stats-test.json && node ./.tmp/client-stats-tests/apps/client/src/features/stats/stats.test.js"
   },

--- a/packages/shared/src/ws/client.ts
+++ b/packages/shared/src/ws/client.ts
@@ -15,13 +15,25 @@ export interface GenerationPayload {
 
 export interface RequestIdWithGenerationPayload extends RequestIdPayload, GenerationPayload {}
 
-export interface RoomJoinPayload {
+export type RoomJoinSessionKind = "PLAYER" | "SPECTATOR";
+
+interface BaseRoomJoinPayload {
   join_code?: string;
-  display_name: string;
-  source: SourceType;
   client_version?: string;
   client_capabilities?: JsonObject;
 }
+
+export interface PlayerRoomJoinPayload extends BaseRoomJoinPayload {
+  session_kind?: "PLAYER";
+  display_name: string;
+  source: SourceType;
+}
+
+export interface SpectatorRoomJoinPayload extends BaseRoomJoinPayload {
+  session_kind: "SPECTATOR";
+}
+
+export type RoomJoinPayload = PlayerRoomJoinPayload | SpectatorRoomJoinPayload;
 
 export interface ReadySetPayload extends GenerationPayload {
   ready: boolean;

--- a/packages/shared/src/ws/server.ts
+++ b/packages/shared/src/ws/server.ts
@@ -10,8 +10,11 @@ import type { WsEmptyPayload } from "./common";
 import type { ServerEnvelope } from "./envelope";
 import type { ServerMessageType } from "./message-types";
 
+export type RoomJoinAcceptedSessionRole = "HOST" | "PLAYER" | "SPECTATOR";
+
 export interface RoomJoinAcceptedPayload {
   room_state_snapshot: RoomStateSnapshot;
+  session_role?: RoomJoinAcceptedSessionRole;
 }
 
 export interface RoomRejectedPayload {


### PR DESCRIPTION
## Purpose
- Implement Issue #139: add read-only Spectate flow that can watch score progression from web.
- Apply mock-based Spectate UI/UX to production web entry and keep OBS-safe behavior.

## Changes
- Add Spectate web entrypoint and page (`/spectate`) with ROOM_JOIN as `SPECTATOR` and read-only display flow.
- Add local join endpoint fallback for `localhost:1430` -> `http://127.0.0.1:8787/api/join` and improve join status/error UX.
- Add navigation to Spectate from Landing/Join pages and simplify user-facing copy.
- Add spectator protocol support details and worker handling updates for role/session acceptance and read-only enforcement.
- Add Spectate regression tests (Vitest + snapshot) for sticky-result and LIVE next preview behavior.
- Update relevant design docs for FSM/protocol/data-model/screen/regression expectations.

## Non-Changes
- No desktop gameplay action flow changes for player sessions.
- No DB schema/migration work.

## Impact
- User impact: Spectator can connect from web and watch MATCH/ROUND progress with history and final result visibility.
- Data impact: none.
- Compatibility impact: additive WS behavior (`session_role`, spectator handling) with existing player flow kept.
- Cloudflare/infra impact: none.

## Validation
- Commands run:
  - `npm run typecheck`: pass
  - `npm run lint`: pass
  - `npm run build:web`: pass
  - `npm run test:worker`: pass
  - `npm run test:web`: pass
- Notes:
  - Added web test environment via Vitest + happy-dom; snapshot baseline committed.

## Regression Checks
- [x] Spectator join accepts valid room/join_code and keeps player slots unchanged.
- [x] Spectator mutation messages are rejected as read-only.
- [x] Sticky current-result view persists while LIVE next preview remains visible.
- [x] Round 0 without next frozen round shows "次曲準備中".
- [x] Sticky releases after first submission of the live round.

## Risk and Rollback
- Risk level: normal
- Rollback plan: revert commit `3c71d8d` (or revert this PR) to restore previous web/join/spectate behavior.

## Related
- Issue: #139
- Plan item/task label: Spectate read-only + spawn/phase operation flow