### PR TITLE
fix: suppress READY_SET dialog during auto-match transition

### DIFF
--- a/apps/client/src-tauri/Cargo.lock
+++ b/apps/client/src-tauri/Cargo.lock
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "infinitas-arena-client"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "notify",
  "reqwest 0.12.28",

--- a/apps/client/src/pages/RoomPage.tsx
+++ b/apps/client/src/pages/RoomPage.tsx
@@ -1185,7 +1185,13 @@ export function RoomPage() {
     const amHost =
       snapshot?.host_player_id === activePlayerId || roomHost?.role === "HOST";
 
-    if (snapshot?.room_state === "LOBBY" && amHost && roomHost && !roomHost.ready) {
+    if (
+      snapshot?.room_state === "LOBBY" &&
+      snapshot.settings.auto_match !== true &&
+      amHost &&
+      roomHost &&
+      !roomHost.ready
+    ) {
       roomStore.setReady(true);
     }
   }, [activePlayerId, snapshot]);

--- a/apps/client/src/stores/room-store.ts
+++ b/apps/client/src/stores/room-store.ts
@@ -1205,6 +1205,15 @@ export const roomStore = {
     }
   },
   setReady(ready: boolean): boolean {
+    const snapshot = internalStore.getState().snapshot;
+    if (
+      snapshot === null ||
+      snapshot.room_state !== "LOBBY" ||
+      snapshot.settings.auto_match === true
+    ) {
+      return false;
+    }
+
     const generation = requireCurrentGeneration();
     if (generation === null) {
       return false;


### PR DESCRIPTION
## Purpose
- Resolve Issue #145 by preventing the `READY_SET is only available in LOBBY.` dialog from appearing during auto-match transition.

## Changes
- Add `auto_match !== true` guard to host auto-ready effect in `RoomPage` so auto-match rooms do not send `READY_SET` from client-side auto-ready logic.
- Add defensive preflight in `roomStore.setReady()` to skip sending `READY_SET` when snapshot is missing, room state is not `LOBBY`, or `auto_match` is enabled.
- Include `apps/client/src-tauri/Cargo.lock` version update (`1.2.0` -> `1.3.0`) as requested.

## Non-Changes
- No WS `type/payload` contract changes.
- No worker/shared logic changes.
- No docs/design/CI/dependency update beyond the included lockfile line.

## Impact
- User impact: Removes the confusing error dialog during auto-match transition.
- Data impact: none.
- Compatibility impact: none (client-side guard only; protocol unchanged).
- Cloudflare/infra impact: none.

## Validation
- Commands run:
  - `npm run typecheck:client`: pass
  - `npm run build:client`: pass
  - `npm run lint`: pass
- Notes:
  - Contract and implementation post-checks completed with no Blocker/Must fix findings.

## Regression Checks
- [x] Auto-match room: verify no `READY_SET is only available in LOBBY.` dialog on `LOBBY -> PICKING` transition.
- [x] Normal room (`auto_match=false`): verify host auto-ready/start flow still works.
- [x] Stale generation path: verify `ROOM_STATE_CHANGED` remains blocking as before.

## Risk and Rollback
- Risk level: high (FSM/protocol-adjacent timing path), mitigated by client-only minimal diff and unchanged contracts.
- Rollback plan: revert commit `771d0aa`.

## Related
- Issue: #145
- Plan item/task label: issue-145-ready-set-dialog