### PR TITLE
fix(worker): hide auto-match rooms from lobby create-time listing

### DIFF
--- a/apps/worker/src/routes/matchmaking.test.mjs
+++ b/apps/worker/src/routes/matchmaking.test.mjs
@@ -6,6 +6,7 @@ import {
   handlePostMatchmakingQueue,
   matchMatchmakingQueueTicketPath,
 } from "./matchmaking.ts";
+import { handlePostRooms } from "./rooms.ts";
 
 function createEnv(doFetch) {
   return {
@@ -46,6 +47,40 @@ function createEnv(doFetch) {
     MIN_SUPPORTED_CLIENT_VERSION: "1.2.0",
     ISSUE_TOKEN: "",
     DISCORD_WEBHOOK_URL: "",
+  };
+}
+
+function createRoomsEnv() {
+  const initPayloads = [];
+  const lobbyUpserts = [];
+  const env = createEnv(async () => new Response("{}", { status: 200 }));
+
+  env.ROOM_DO.get = () => ({
+    fetch: async (request) => {
+      const url = new URL(request.url);
+      if (url.pathname === "/internal/init" && request.method === "POST") {
+        initPayloads.push(await request.json());
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "unexpected room request" }), { status: 400 });
+    },
+  });
+
+  env.LOBBY_DIRECTORY_DO.get = () => ({
+    fetch: async (request) => {
+      const url = new URL(request.url);
+      if (url.pathname === "/internal/upsert" && request.method === "POST") {
+        lobbyUpserts.push(await request.json());
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    },
+  });
+
+  return {
+    env,
+    getInitPayloads: () => initPayloads,
+    getLobbyUpserts: () => lobbyUpserts,
   };
 }
 
@@ -139,4 +174,54 @@ test("handleGetMatchmakingQueueTicket and handleDeleteMatchmakingQueueTicket ret
   assert.equal(lastMethod, "DELETE");
   const payload = await deleteResponse.json();
   assert.equal(payload.status, "CANCELLED");
+});
+
+test("handlePostRooms does not upsert lobby for PUBLIC auto-match rooms", async () => {
+  const { env, getInitPayloads, getLobbyUpserts } = createRoomsEnv();
+  const response = await handlePostRooms(
+    new Request("https://example.com/api/rooms", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        visibility: "PUBLIC",
+        auto_match: true,
+        mode: "ARENA",
+        win_metric: "SCORE",
+        play_style: "SP",
+        level_filter: "ANY",
+        max_players: 2,
+        room_comment: "Auto match room",
+      }),
+    }),
+    env,
+  );
+
+  assert.equal(response.status, 201);
+  assert.equal(getInitPayloads().length, 1);
+  assert.equal(getInitPayloads()[0]?.settings.auto_match, true);
+  assert.equal(getLobbyUpserts().length, 0);
+});
+
+test("handlePostRooms keeps lobby upsert for normal PUBLIC rooms", async () => {
+  const { env, getLobbyUpserts } = createRoomsEnv();
+  const response = await handlePostRooms(
+    new Request("https://example.com/api/rooms", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        visibility: "PUBLIC",
+        mode: "ARENA",
+        win_metric: "SCORE",
+        play_style: "SP",
+        level_filter: "ANY",
+        max_players: 2,
+        room_comment: "Public room",
+      }),
+    }),
+    env,
+  );
+
+  assert.equal(response.status, 201);
+  assert.equal(getLobbyUpserts().length, 1);
+  assert.equal(getLobbyUpserts()[0]?.isPublic, true);
 });

--- a/apps/worker/src/services/room-create.ts
+++ b/apps/worker/src/services/room-create.ts
@@ -215,7 +215,7 @@ export async function createRoom(
 
   await initializeRoomDurableObject(env, roomId, parsed.settings, createdAtIso);
 
-  if (parsed.settings.visibility === "PUBLIC") {
+  if (parsed.settings.visibility === "PUBLIC" && parsed.settings.auto_match !== true) {
     await upsertLobbyDirectoryRoom(env, toLobbySummary(roomId, parsed));
   }
 

--- a/tasks/issue-147-hide-automatch-from-lobby.md
+++ b/tasks/issue-147-hide-automatch-from-lobby.md
@@ -1,0 +1,47 @@
+# Issue #147 Execution Plan
+
+## 目的
+- オートマッチで作成された部屋をロビー一覧に表示しない。
+
+## 非目的
+- visibility モデル（PUBLIC/PRIVATE/UNLISTED）の再設計
+- 既存ロビー誤登録データの即時クリーンアップ
+- client/shared/WS/FSM/timer の仕様変更
+
+## 変更点
+- `apps/worker/src/services/room-create.ts` の create-time ロビー upsert 条件を `PUBLIC && auto_match !== true` に制限する。
+- create-time 経路の回帰テストを worker 既存テスト実行対象に追加する。
+
+## 影響範囲
+- ユーザー影響: 新規オートマッチ部屋はロビー一覧に出なくなる。
+- データ/互換性: 既存誤登録分は TTL で自然消滅。互換フォーマット変更なし。
+- Cloudflare: 既存 Worker/DO 資源のみ利用、構成変更なし。
+
+## 対象レイヤ/対象ファイル
+- worker:
+  - `apps/worker/src/services/room-create.ts`
+  - `apps/worker/src/routes/matchmaking.test.mjs`
+
+## Validation Plan
+- `npm run test:worker`
+- `npm --workspace @infinitas/worker run typecheck`
+- `npm run lint`
+- `npm --workspace @infinitas/worker exec wrangler deploy --dry-run`
+
+## Rollback 方針
+- create-time upsert 条件を元に戻す単一差分でロールバック可能。
+
+## Commit 分割方針
+- 1コミット:
+  - worker実装修正
+  - worker回帰テスト
+
+## Delegation Packet
+- task label: `issue-147-hide-automatch-from-lobby-on-create`
+- objective: create-time で auto_match 部屋が LobbyDirectory に入らないことを保証する。
+- in-scope files/layer: worker / `room-create.ts`, `matchmaking.test.mjs`
+- non-goals: visibility再設計、backfill除去、cross-layer変更
+- forbidden scope: `apps/client/**`, `packages/shared/**`, `docs/design/**`, lockfile/依存更新
+- expected output: auto_match PUBLIC は upsert されず、通常 PUBLIC は従来どおり upsert される
+- validation: 上記 Validation Plan を満たす
+- escalation: 追加の契約変更・cross-layer化・CI/依存変更が必要化した場合


### PR DESCRIPTION
## Purpose
- Prevent auto-match rooms from appearing in lobby listing when rooms are created.

## Changes
- Limit create-time lobby upsert in `apps/worker/src/services/room-create.ts` to `PUBLIC && auto_match !== true`.
- Add regression tests in `apps/worker/src/routes/matchmaking.test.mjs`:
  - `PUBLIC + auto_match=true` does not upsert to LobbyDirectory.
  - Normal `PUBLIC` rooms still upsert.
- Add execution-boundary artifact: `tasks/issue-147-hide-automatch-from-lobby.md`.

## Non-Changes
- No visibility model redesign (`PUBLIC/PRIVATE/UNLISTED` semantics unchanged).
- No immediate cleanup/backfill of existing stale lobby entries.
- No client/shared/WS/FSM/timer/CI/dependency changes.

## Impact
- User impact: New auto-match rooms are no longer shown in lobby list.
- Data impact: Existing stale entries are left to TTL cleanup (no migration).
- Compatibility impact: None.
- Cloudflare/infra impact: None.

## Validation
- Commands run:
  - `npm run test:worker`: pass (74/74)
  - `npm --workspace @infinitas/worker run typecheck`: pass
  - `npm run lint`: pass
  - `npm --workspace @infinitas/worker exec wrangler deploy --dry-run`: pass
- Notes:
  - No required checks were skipped.

## Regression Checks
- [x] `PUBLIC + auto_match=true` path does not create lobby entry.
- [x] Normal `PUBLIC` room creation still creates lobby entry.
- [x] Existing worker test suite remains green.

## Risk and Rollback
- Risk level: high (contract-sensitive lobby filter area), implementation scope: minimal.
- Rollback plan: Revert this PR commit to restore previous create-time behavior.

## Related
- Issue: #147
- Plan item/task label: `issue-147-hide-automatch-from-lobby-on-create`