### PR TITLE
fix: resolve Node 20 deprecation warnings and Tauri unused var (#144)

### DIFF
--- a/.github/workflows/deploy-web-pages.yml
+++ b/.github/workflows/deploy-web-pages.yml
@@ -17,16 +17,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
 
       - name: Set up GitHub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Resolve Vite base path for Pages
         shell: bash
@@ -49,10 +49,25 @@ jobs:
       - name: Build web app
         run: npm run build:web
 
+      - name: Archive Pages artifact
+        shell: bash
+        run: |
+          tar \
+            --dereference --hard-dereference \
+            --directory "apps/web/dist" \
+            -cvf "${RUNNER_TEMP}/artifact.tar" \
+            --exclude=.git \
+            --exclude=.github \
+            --exclude=".[^/]*" \
+            .
+
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
-          path: apps/web/dist
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: 1
+          if-no-files-found: error
 
   deploy:
     needs: build
@@ -63,4 +78,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -27,10 +27,10 @@ jobs:
         shell: pwsh
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -201,7 +201,7 @@ jobs:
             -OutputDirectory "${{ steps.release_meta.outputs.artifact_dir }}"
 
       - name: Upload normalized updater artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: desktop-updater-${{ steps.release_meta.outputs.app_version }}
           path: ${{ steps.release_meta.outputs.artifact_dir }}

--- a/.github/workflows/update-worker-chart-master.yml
+++ b/.github/workflows/update-worker-chart-master.yml
@@ -75,7 +75,7 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       - name: Check out repository at resolved tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.resolve_tag.outputs.target_tag }}
           fetch-depth: 0
@@ -103,7 +103,7 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -215,7 +215,7 @@ jobs:
           PY
 
       - name: Upload generated chart master and metadata artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.resolve_tag.outputs.artifact_name }}
           if-no-files-found: error
@@ -225,7 +225,7 @@ jobs:
 
       - name: Set up Node.js
         if: steps.detect_diff.outputs.diff_detected == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/validate-reusable.yml
+++ b/.github/workflows/validate-reusable.yml
@@ -23,10 +23,10 @@ jobs:
           }
 
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/apps/client/src-tauri/src/lib.rs
+++ b/apps/client/src-tauri/src/lib.rs
@@ -36,13 +36,13 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_tts::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
-        .setup(|app| {
+        .setup(|_app| {
             #[cfg(any(target_os = "linux", all(debug_assertions, windows)))]
             {
                 use tauri_plugin_deep_link::DeepLinkExt;
 
                 if !should_skip_deep_link_registration() {
-                    app.deep_link().register_all()?;
+                    _app.deep_link().register_all()?;
                 }
             }
 

--- a/tasks/issue-144-node20-rust-warning.md
+++ b/tasks/issue-144-node20-rust-warning.md
@@ -1,0 +1,58 @@
+# Issue 144 Plan: Node 20 deprecation and Rust warning cleanup
+
+## Objective
+- Remove GitHub Actions Node 20 deprecation warnings in this repository workflows.
+- Remove the Rust unused variable warning in `apps/client/src-tauri/src/lib.rs`.
+
+## Non-goals
+- Large refactors outside the warning fixes.
+- Unrelated dependency updates.
+- Contract-sensitive changes (FSM/WS/shared model/schema).
+
+## Change Summary
+- Update workflow action versions to Node 24 runtime compatible majors.
+- Replace Pages artifact upload usage path if it still depends on Node 20 runtime.
+- Rename `setup` closure parameter from `app` to `_app` in Tauri entrypoint.
+
+## Impact Scope
+- User impact: none expected (CI/runtime warning cleanup only).
+- Data/compatibility impact: none expected.
+- Cloudflare impact: none expected (no resource topology change).
+- Operational impact: GitHub Actions action runtime version updates.
+
+## Target Layers and Files
+- Layer: CI/CD workflow
+  - `.github/workflows/release-desktop.yml`
+  - `.github/workflows/validate-reusable.yml`
+  - `.github/workflows/deploy-worker.yml`
+  - `.github/workflows/update-worker-chart-master.yml`
+  - `.github/workflows/deploy-web-pages.yml`
+- Layer: Client (Tauri Rust)
+  - `apps/client/src-tauri/src/lib.rs`
+
+## Validation Plan
+- Diff checks:
+  - `git diff --check`
+  - Confirm intended files only are changed.
+- Technical checks:
+  - `cargo check --manifest-path apps/client/src-tauri/Cargo.toml`
+  - Optional local sanity checks for workflow YAML syntax via inspection.
+- CI evidence:
+  - Confirm no Node 20 deprecation warning in relevant workflow runs after merge.
+
+## Rollback Plan
+- Revert this change set in one commit if workflow runtime changes cause failures.
+- If only specific workflow fails, rollback that workflow file first and keep Rust warning fix.
+
+## Commit Split Plan
+- Single commit is acceptable (all changes are one bounded objective: warning cleanup).
+
+## Delegation Packet Record
+- task label: `issue-144-bounded-packet`
+- objective: bounded execution steps, validation, risks, escalation criteria
+- in-scope: workflows above + `apps/client/src-tauri/src/lib.rs`
+- non-goals: broad refactor, unrelated dependency updates
+- forbidden scope: contract-sensitive shared/worker protocol changes
+- expected output: executable bounded packet with checks
+- validation: QUALITY.md universal checks + client rust compile check
+- escalation: if contract-sensitive or incompatible workflow change is required


### PR DESCRIPTION
## Purpose
- Resolve the warning cleanup scope defined in Issue #144.
- Remove Node 20 deprecation warnings from repository workflows.
- Remove the Rust unused variable warning in Tauri entrypoint.

## Changes
- Updated workflow action versions to Node 24-compatible major versions in:
  - `.github/workflows/release-desktop.yml`
  - `.github/workflows/validate-reusable.yml`
  - `.github/workflows/deploy-worker.yml`
  - `.github/workflows/update-worker-chart-master.yml`
  - `.github/workflows/deploy-web-pages.yml`
- Replaced Pages artifact upload path in `deploy-web-pages.yml` with `tar` archive + `actions/upload-artifact@v7` to avoid Node 20 runtime dependency.
- Renamed Tauri setup closure variable from `app` to `_app` in `apps/client/src-tauri/src/lib.rs`.
- Added Plan artifact: `tasks/issue-144-node20-rust-warning.md`.

## Non-Changes
- No contract-sensitive changes (FSM/WS/shared schema/model).
- No unrelated dependency updates or broad refactors.

## Impact
- User impact: none expected.
- Data impact: none.
- Compatibility impact: none expected.
- Cloudflare/infra impact: none (workflow runtime only).

## Validation
- Commands run:
  - `git diff --check`: pass
  - `cargo check` (apps/client/src-tauri): pass
  - `npm run lint`: pass
  - `npm run typecheck`: pass
  - `npm run test:client-stats`: pass
  - `npm run test:worker`: pass
- Notes:
  - Local scan confirms workflow `uses:` entries now resolve to `node24` or `composite` runtimes.

## Regression Checks
- [x] Existing TypeScript lint/typecheck/test paths continue to pass.
- [x] Tauri Rust compile check passes after `_app` rename.
- [x] Workflow diff stays within warning-fix scope.

## Risk and Rollback
- Risk level: normal
- Rollback plan: revert this single commit to restore previous workflow/action references and Tauri variable name.

## Related
- Issue: #144
- Plan item/task label: `issue-144-bounded-packet` / `tasks/issue-144-node20-rust-warning.md`