### PR TITLE
feat: add auto-match waiting count display and polling

### DIFF
--- a/apps/client/src/pages/AutoMatchPage.tsx
+++ b/apps/client/src/pages/AutoMatchPage.tsx
@@ -17,6 +17,7 @@ import {
   cancelMatchmakingQueueTicket,
   enqueueMatchmakingQueue,
   getMatchmakingQueueTicket,
+  getMatchmakingWaitingCount,
 } from "../services/worker-api-client";
 import { roomStore, useRoomStore } from "../stores/room-store";
 import { useStatsArchiveStore } from "../services/stats-archive";
@@ -29,6 +30,8 @@ interface AutoMatchProps {
 type MatchState = "CONFIG" | "IN_QUEUE" | "MATCH_FOUND";
 
 const QUEUE_POLL_INTERVAL_MS = 2_000;
+const WAITING_COUNT_POLL_INTERVAL_MS = 5_000;
+const CANCEL_TOAST_HIDE_DELAY_MS = 3_000;
 const AUTO_MATCH_PHASE1_MODES: Mode[] = ["ARENA", "BPL4"];
 
 function getModeDescription(mode: Mode): string {
@@ -54,6 +57,10 @@ function getQueuedPlayersLabel(mode: Mode): string {
     : "2";
 }
 
+function formatCurrentRating(value: number | null): string {
+  return value === null ? "--" : String(Math.round(value));
+}
+
 function formatQueueSeconds(elapsedSeconds: number): string {
   const minutes = Math.floor(elapsedSeconds / 60)
     .toString()
@@ -75,12 +82,15 @@ export function AutoMatchPage({ onNavigate }: AutoMatchProps) {
   const [playStyle, setPlayStyle] = useState<PlayStyle>("SP");
   const [winMetric, setWinMetric] = useState<WinMetric>("SCORE");
   const [ticket, setTicket] = useState<MatchmakingQueueTicket | null>(null);
+  const [waitingCount, setWaitingCount] = useState<number | null>(null);
   const [queueTimeSeconds, setQueueTimeSeconds] = useState(0);
   const [busy, setBusy] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [displayedPlayers, setDisplayedPlayers] = useState(1);
   const [playerIncreasePulse, setPlayerIncreasePulse] = useState(false);
   const previousFoundPlayersRef = useRef(1);
+  const waitingCountRequestIdRef = useRef(0);
+  const statusMessageTimerIdRef = useRef<number | null>(null);
 
   const currentRating = getCurrentRating(statsArchive, mode === "ARENA" ? "ARENA" : "BPL", playStyle);
   const estimatedRating = currentRating ?? 1500;
@@ -138,6 +148,54 @@ export function AutoMatchPage({ onNavigate }: AutoMatchProps) {
     setMatchState("IN_QUEUE");
     setStatusMessage("ルームへの接続に失敗しました。再試行します。");
   }, [matchState, roomConnectionStatus, roomSnapshot, ticket]);
+
+  useEffect(() => {
+    return () => {
+      if (statusMessageTimerIdRef.current !== null) {
+        window.clearTimeout(statusMessageTimerIdRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (matchState !== "CONFIG") {
+      setWaitingCount(null);
+      return;
+    }
+
+    const requestId = waitingCountRequestIdRef.current + 1;
+    waitingCountRequestIdRef.current = requestId;
+    let disposed = false;
+    setWaitingCount(null);
+
+    const refreshWaitingCount = async (): Promise<void> => {
+      try {
+        const response = await getMatchmakingWaitingCount(savedSettings.apiBaseUrl, {
+          mode,
+          play_style: playStyle,
+          win_metric: winMetric,
+        });
+        if (disposed || requestId !== waitingCountRequestIdRef.current) {
+          return;
+        }
+        setWaitingCount(response.waiting_count);
+      } catch {
+        if (disposed || requestId !== waitingCountRequestIdRef.current) {
+          return;
+        }
+        setWaitingCount(null);
+      }
+    };
+
+    void refreshWaitingCount();
+    const intervalId = window.setInterval(() => {
+      void refreshWaitingCount();
+    }, WAITING_COUNT_POLL_INTERVAL_MS);
+    return () => {
+      disposed = true;
+      window.clearInterval(intervalId);
+    };
+  }, [matchState, mode, playStyle, winMetric, savedSettings.apiBaseUrl]);
 
   function connectToMatchedRoom(roomId: string): boolean {
     return roomStore.connect(
@@ -278,7 +336,15 @@ export function AutoMatchPage({ onNavigate }: AutoMatchProps) {
       setMatchState("CONFIG");
       setQueueTimeSeconds(0);
       setTicket(null);
-      setStatusMessage("マッチングキューをキャンセルしました。");
+      const message = "マッチングキューをキャンセルしました。";
+      setStatusMessage(message);
+      if (statusMessageTimerIdRef.current !== null) {
+        window.clearTimeout(statusMessageTimerIdRef.current);
+      }
+      statusMessageTimerIdRef.current = window.setTimeout(() => {
+        setStatusMessage((current) => (current === message ? null : current));
+        statusMessageTimerIdRef.current = null;
+      }, CANCEL_TOAST_HIDE_DELAY_MS);
     } catch (error) {
       setStatusMessage(error instanceof Error ? error.message : "マッチングキューのキャンセルに失敗しました。");
     } finally {
@@ -392,15 +458,29 @@ export function AutoMatchPage({ onNavigate }: AutoMatchProps) {
               </div>
 
               <div className="flex flex-col gap-6">
-                <div className="relative overflow-hidden rounded-3xl border border-white/5 bg-[#15151a] p-6 shadow-xl">
-                  <div className="absolute right-0 top-0 h-32 w-32 rounded-full bg-cyan-500/10 blur-3xl" />
-                  <h3 className="mb-6 flex items-center gap-2 text-sm font-bold text-gray-400">
-                    <Activity size={16} /> Queue Status
+                <div className="bg-[#15151a] border border-white/5 rounded-3xl p-6 shadow-xl relative overflow-hidden">
+                  <div className="absolute top-0 right-0 w-32 h-32 bg-cyan-500/10 blur-3xl rounded-full" />
+                  <h3 className="text-sm font-bold text-gray-400 mb-6 flex items-center gap-2">
+                    <Activity size={16} /> Player Status
                   </h3>
                   <div className="space-y-4">
-                    <div className="border-t border-white/5 pt-4">
-                      <div className="mb-2 text-[10px] font-black uppercase text-gray-500">Match Condition</div>
-                      <ul className="space-y-2 text-sm font-semibold">
+                    <div className="grid grid-cols-2 gap-4">
+                      <div>
+                        <div className="text-[10px] text-gray-500 font-black uppercase mb-1">Current Rating</div>
+                        <div className="text-4xl font-black text-transparent bg-clip-text bg-gradient-to-r from-cyan-400 to-blue-500">
+                          {formatCurrentRating(currentRating)}
+                        </div>
+                      </div>
+                      <div>
+                        <div className="text-[10px] text-gray-500 font-black uppercase mb-1">Waiting Players</div>
+                        <div className="text-4xl font-black text-transparent bg-clip-text bg-gradient-to-r from-yellow-400 to-orange-500">
+                          {waitingCount === null ? "—" : waitingCount}<span className="text-xl text-yellow-500/50 font-bold ml-1">人</span>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="pt-4 border-t border-white/5">
+                      <div className="text-[10px] text-gray-500 font-black uppercase mb-2">Search Condition</div>
+                      <ul className="text-sm font-semibold space-y-2">
                         <li className="flex justify-between">
                           <span className="text-gray-400">Target Range</span>
                           <span className="text-cyan-400">±{MATCHMAKING_INITIAL_RATING_RANGE} (Auto Expand)</span>
@@ -424,14 +504,16 @@ export function AutoMatchPage({ onNavigate }: AutoMatchProps) {
                   onClick={() => {
                     void handleStartQueue();
                   }}
-                  className={`group flex w-full flex-col items-center justify-center gap-1 rounded-3xl py-6 text-xl font-black transition-all ${
+                  className={`w-full h-[84px] text-black font-black text-xl rounded-3xl shadow-[0_15px_40px_rgba(6,182,212,0.3)] transition-all flex items-center justify-center relative overflow-hidden group ${
                     busy || !roomEntryReady
-                      ? "cursor-not-allowed bg-gray-800 text-gray-500"
-                      : "bg-gradient-to-r from-cyan-500 to-blue-600 text-black shadow-[0_15px_40px_rgba(6,182,212,0.3)] hover:from-cyan-400 hover:to-blue-500 hover:shadow-[0_20px_50px_rgba(6,182,212,0.5)] active:scale-95"
+                      ? "cursor-not-allowed bg-gray-800 text-gray-500 shadow-none"
+                      : "bg-gradient-to-r from-cyan-500 to-blue-600 hover:from-cyan-400 hover:to-blue-500 hover:shadow-[0_20px_50px_rgba(6,182,212,0.5)] active:scale-95"
                   }`}
                 >
-                  START MATCHING
-                  <span className="h-0 text-[10px] font-bold uppercase tracking-widest text-black/60 opacity-0 transition-all group-hover:h-auto group-hover:opacity-100">
+                  <span className="transition-transform duration-300 ease-out group-hover:-translate-y-2">
+                    START MATCHING
+                  </span>
+                  <span className="absolute bottom-4 opacity-0 translate-y-4 group-hover:opacity-100 group-hover:translate-y-0 transition-all duration-300 ease-out text-[10px] font-bold text-black/60 uppercase tracking-widest">
                     Enqueue now
                   </span>
                 </button>

--- a/apps/client/src/pages/AutoMatchPage.tsx
+++ b/apps/client/src/pages/AutoMatchPage.tsx
@@ -166,6 +166,7 @@ export function AutoMatchPage({ onNavigate }: AutoMatchProps) {
     const requestId = waitingCountRequestIdRef.current + 1;
     waitingCountRequestIdRef.current = requestId;
     let disposed = false;
+    let timerId: number | null = null;
     setWaitingCount(null);
 
     const refreshWaitingCount = async (): Promise<void> => {
@@ -184,16 +185,21 @@ export function AutoMatchPage({ onNavigate }: AutoMatchProps) {
           return;
         }
         setWaitingCount(null);
+      } finally {
+        if (!disposed && requestId === waitingCountRequestIdRef.current) {
+          timerId = window.setTimeout(() => {
+            void refreshWaitingCount();
+          }, WAITING_COUNT_POLL_INTERVAL_MS);
+        }
       }
     };
 
     void refreshWaitingCount();
-    const intervalId = window.setInterval(() => {
-      void refreshWaitingCount();
-    }, WAITING_COUNT_POLL_INTERVAL_MS);
     return () => {
       disposed = true;
-      window.clearInterval(intervalId);
+      if (timerId !== null) {
+        window.clearTimeout(timerId);
+      }
     };
   }, [matchState, mode, playStyle, winMetric, savedSettings.apiBaseUrl]);
 

--- a/apps/client/src/services/worker-api-client.ts
+++ b/apps/client/src/services/worker-api-client.ts
@@ -5,6 +5,8 @@ import type {
   LobbyListResponse,
   MatchmakingQueueRequest,
   MatchmakingQueueTicket,
+  MatchmakingWaitingCountQuery,
+  MatchmakingWaitingCountResponse,
   PlayStyle,
   RoomSettings,
   SongPack,
@@ -278,5 +280,20 @@ export async function cancelMatchmakingQueueTicket(
   return requestJson<MatchmakingQueueTicket>(
     `${normalizedBaseUrl}/api/matchmaking/queue/${encodeURIComponent(normalizedTicketId)}`,
     { method: "DELETE" },
+  );
+}
+
+export async function getMatchmakingWaitingCount(
+  baseUrl: string,
+  query: MatchmakingWaitingCountQuery,
+): Promise<MatchmakingWaitingCountResponse> {
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+  const searchParams = new URLSearchParams();
+  searchParams.set("mode", query.mode);
+  searchParams.set("play_style", query.play_style);
+  searchParams.set("win_metric", query.win_metric);
+  return requestJson<MatchmakingWaitingCountResponse>(
+    `${normalizedBaseUrl}/api/matchmaking/waiting-count?${searchParams}`,
+    { method: "GET" },
   );
 }

--- a/apps/worker/src/durable/matchmaking-object.test.mjs
+++ b/apps/worker/src/durable/matchmaking-object.test.mjs
@@ -93,6 +93,11 @@ async function getTicket(matchmakingObject, ticketId) {
   return matchmakingObject.fetch(new Request(`https://example.com/internal/queue/${ticketId}`));
 }
 
+async function getWaitingCount(matchmakingObject, query) {
+  const searchParams = new URLSearchParams(query);
+  return matchmakingObject.fetch(new Request(`https://example.com/internal/waiting-count?${searchParams}`));
+}
+
 test("enqueue reuses the active searching ticket for the same player", async () => {
   const { matchmakingObject, state } = await createMatchmakingObject();
 
@@ -210,4 +215,125 @@ test("stale searching tickets are evicted before matching", async () => {
   const tickets = Object.values(stored);
   assert.equal(tickets.length, 1);
   assert.equal(tickets[0]?.player_id, "active-player");
+});
+
+test("waiting-count returns searching ticket count for exact condition", async () => {
+  const nowIso = new Date().toISOString();
+  const initialTickets = {
+    ticket_1: {
+      ticket_id: "ticket_1",
+      status: "SEARCHING",
+      mode: "ARENA",
+      play_style: "SP",
+      win_metric: "SCORE",
+      rating: 2000,
+      player_id: "player-1",
+      display_name: "P1",
+      queued_at: nowIso,
+      updated_at: nowIso,
+      room_id: null,
+      matched_player_count: null,
+    },
+    ticket_2: {
+      ticket_id: "ticket_2",
+      status: "SEARCHING",
+      mode: "ARENA",
+      play_style: "SP",
+      win_metric: "SCORE",
+      rating: 2100,
+      player_id: "player-2",
+      display_name: "P2",
+      queued_at: nowIso,
+      updated_at: nowIso,
+      room_id: null,
+      matched_player_count: null,
+    },
+    ticket_3: {
+      ticket_id: "ticket_3",
+      status: "SEARCHING",
+      mode: "ARENA",
+      play_style: "DP",
+      win_metric: "SCORE",
+      rating: 2200,
+      player_id: "player-3",
+      display_name: "P3",
+      queued_at: nowIso,
+      updated_at: nowIso,
+      room_id: null,
+      matched_player_count: null,
+    },
+    ticket_4: {
+      ticket_id: "ticket_4",
+      status: "CANCELLED",
+      mode: "ARENA",
+      play_style: "SP",
+      win_metric: "SCORE",
+      rating: 2300,
+      player_id: "player-4",
+      display_name: "P4",
+      queued_at: nowIso,
+      updated_at: nowIso,
+      room_id: null,
+      matched_player_count: null,
+    },
+  };
+  const { matchmakingObject } = await createMatchmakingObject(initialTickets);
+
+  const response = await getWaitingCount(matchmakingObject, {
+    mode: "ARENA",
+    play_style: "SP",
+    win_metric: "SCORE",
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.waiting_count, 2);
+});
+
+test("waiting-count evicts stale searching tickets before counting", async () => {
+  const nowIso = new Date().toISOString();
+  const initialTickets = {
+    active_ticket: {
+      ticket_id: "active_ticket",
+      status: "SEARCHING",
+      mode: "ARENA",
+      play_style: "SP",
+      win_metric: "SCORE",
+      rating: 2100,
+      player_id: "active-player",
+      display_name: "ACTIVE",
+      queued_at: nowIso,
+      updated_at: nowIso,
+      room_id: null,
+      matched_player_count: null,
+    },
+    stale_ticket: {
+      ticket_id: "stale_ticket",
+      status: "SEARCHING",
+      mode: "ARENA",
+      play_style: "SP",
+      win_metric: "SCORE",
+      rating: 2200,
+      player_id: "stale-player",
+      display_name: "STALE",
+      queued_at: "2026-04-06T00:00:00.000Z",
+      updated_at: "2026-04-06T00:00:00.000Z",
+      room_id: null,
+      matched_player_count: null,
+    },
+  };
+  const { matchmakingObject, state } = await createMatchmakingObject(initialTickets);
+
+  const response = await getWaitingCount(matchmakingObject, {
+    mode: "ARENA",
+    play_style: "SP",
+    win_metric: "SCORE",
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.waiting_count, 1);
+
+  const stored = await state.storage.get("matchmaking-tickets");
+  assert.equal(stored.stale_ticket, undefined);
 });

--- a/apps/worker/src/durable/matchmaking-object.ts
+++ b/apps/worker/src/durable/matchmaking-object.ts
@@ -11,6 +11,8 @@ import {
   WIN_METRICS,
   type MatchmakingQueueRequest,
   type MatchmakingQueueTicket,
+  type MatchmakingWaitingCountQuery,
+  type MatchmakingWaitingCountResponse,
   type MatchmakingTicketStatus,
   type Mode,
   type PlayStyle,
@@ -47,6 +49,7 @@ interface MatchmakingQueueTicketRecord {
 }
 
 const TICKETS_STORAGE_KEY = "matchmaking-tickets";
+const INTERNAL_WAITING_COUNT_PATH = "/internal/waiting-count";
 const INTERNAL_QUEUE_TICKET_PATH_PATTERN = /^\/internal\/queue\/([^/]+)$/;
 const SEARCHING_TICKET_STALE_MS = 120_000;
 
@@ -103,6 +106,22 @@ function parseQueueRequest(payload: unknown): MatchmakingQueueRequest | null {
     rating: normalizedRating,
     player_id: playerId,
     display_name: displayName,
+  };
+}
+
+function parseWaitingCountQuery(url: URL): MatchmakingWaitingCountQuery | null {
+  const mode = asEnumValue(url.searchParams.get("mode"), MODES);
+  const playStyle = asEnumValue(url.searchParams.get("play_style"), PLAY_STYLES);
+  const winMetric = asEnumValue(url.searchParams.get("win_metric"), WIN_METRICS);
+
+  if (mode === undefined || playStyle === undefined || winMetric === undefined) {
+    return null;
+  }
+
+  return {
+    mode,
+    play_style: playStyle,
+    win_metric: winMetric,
   };
 }
 
@@ -258,6 +277,9 @@ export class MatchmakingDurableObject {
     await this.readyPromise;
 
     const url = new URL(request.url);
+    if (url.pathname === INTERNAL_WAITING_COUNT_PATH && request.method === "GET") {
+      return this.handleGetWaitingCount(url);
+    }
     if (url.pathname === "/internal/queue" && request.method === "POST") {
       return this.handleEnqueue(request);
     }
@@ -366,6 +388,23 @@ export class MatchmakingDurableObject {
     }
 
     return jsonResponse(200, this.buildQueueTicketResponse(normalizedTicketId, nowMs));
+  }
+
+  private async handleGetWaitingCount(url: URL): Promise<Response> {
+    const query = parseWaitingCountQuery(url);
+    if (query === null) {
+      return jsonResponse(400, { error: "Invalid waiting-count query." });
+    }
+
+    const nowMs = Date.now();
+    if (this.expireStaleSearchingTickets(nowMs)) {
+      await this.persistTickets();
+    }
+
+    const response: MatchmakingWaitingCountResponse = {
+      waiting_count: this.countWaitingTickets(query),
+    };
+    return jsonResponse(200, response);
   }
 
   private async handleCancelTicket(ticketId: string): Promise<Response> {
@@ -647,6 +686,21 @@ export class MatchmakingDurableObject {
       if (this.isCompatible(anchor, ticket, nowMs)) {
         count += 1;
       }
+    }
+
+    return count;
+  }
+
+  private countWaitingTickets(query: MatchmakingWaitingCountQuery): number {
+    let count = 0;
+    for (const ticket of this.tickets.values()) {
+      if (ticket.status !== "SEARCHING") {
+        continue;
+      }
+      if (ticket.mode !== query.mode || ticket.play_style !== query.play_style || ticket.win_metric !== query.win_metric) {
+        continue;
+      }
+      count += 1;
     }
 
     return count;

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -5,6 +5,7 @@ import { handleGetJoin } from "./routes/join";
 import { handleGetLobby } from "./routes/lobby";
 import {
   handleDeleteMatchmakingQueueTicket,
+  handleGetMatchmakingWaitingCount,
   handleGetMatchmakingQueueTicket,
   handlePostMatchmakingQueue,
   matchMatchmakingQueueTicketPath,
@@ -25,6 +26,7 @@ const LOBBY_ALLOWED_METHODS = ["GET"];
 const FEEDBACK_ALLOWED_METHODS = ["POST"];
 const SONG_PACKS_ALLOWED_METHODS = ["GET"];
 const ROOM_CHARTS_ALLOWED_METHODS = ["GET"];
+const MATCHMAKING_WAITING_COUNT_ALLOWED_METHODS = ["GET"];
 const MATCHMAKING_QUEUE_ALLOWED_METHODS = ["POST"];
 const MATCHMAKING_QUEUE_TICKET_ALLOWED_METHODS = ["GET", "DELETE"];
 
@@ -64,6 +66,21 @@ export default {
         methodNotAllowed([...MATCHMAKING_QUEUE_ALLOWED_METHODS, "OPTIONS"]),
         request,
         MATCHMAKING_QUEUE_ALLOWED_METHODS,
+      );
+    }
+
+    if (url.pathname === "/api/matchmaking/waiting-count") {
+      if (request.method === "OPTIONS") {
+        return withCors(noContent(), request, MATCHMAKING_WAITING_COUNT_ALLOWED_METHODS);
+      }
+      if (request.method === "GET") {
+        return withCors(await handleGetMatchmakingWaitingCount(request, env), request, MATCHMAKING_WAITING_COUNT_ALLOWED_METHODS);
+      }
+
+      return withCors(
+        methodNotAllowed([...MATCHMAKING_WAITING_COUNT_ALLOWED_METHODS, "OPTIONS"]),
+        request,
+        MATCHMAKING_WAITING_COUNT_ALLOWED_METHODS,
       );
     }
 

--- a/apps/worker/src/routes/matchmaking.test.mjs
+++ b/apps/worker/src/routes/matchmaking.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   handleDeleteMatchmakingQueueTicket,
+  handleGetMatchmakingWaitingCount,
   handleGetMatchmakingQueueTicket,
   handlePostMatchmakingQueue,
   matchMatchmakingQueueTicketPath,
@@ -88,6 +89,7 @@ test("matchMatchmakingQueueTicketPath decodes ticket id", () => {
   const matched = matchMatchmakingQueueTicketPath("/api/matchmaking/queue/ticket%2D1");
   assert.equal(matched, "ticket-1");
   assert.equal(matchMatchmakingQueueTicketPath("/api/lobby"), null);
+  assert.equal(matchMatchmakingQueueTicketPath("/api/matchmaking/waiting-count"), null);
 });
 
 test("handlePostMatchmakingQueue forwards to matchmaking do", async () => {
@@ -174,6 +176,43 @@ test("handleGetMatchmakingQueueTicket and handleDeleteMatchmakingQueueTicket ret
   assert.equal(lastMethod, "DELETE");
   const payload = await deleteResponse.json();
   assert.equal(payload.status, "CANCELLED");
+});
+
+test("handleGetMatchmakingWaitingCount returns waiting_count from matchmaking do", async () => {
+  let forwardedPath = "";
+  const env = createEnv(async (request) => {
+    const url = new URL(request.url);
+    forwardedPath = `${url.pathname}?${url.searchParams.toString()}`;
+    return new Response(JSON.stringify({ waiting_count: 4 }), { status: 200 });
+  });
+
+  const response = await handleGetMatchmakingWaitingCount(
+    new Request("https://example.com/api/matchmaking/waiting-count?mode=ARENA&play_style=SP&win_metric=SCORE"),
+    env,
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(forwardedPath, "/internal/waiting-count?mode=ARENA&play_style=SP&win_metric=SCORE");
+  const payload = await response.json();
+  assert.equal(payload.waiting_count, 4);
+});
+
+test("handleGetMatchmakingWaitingCount rejects invalid query", async () => {
+  let called = false;
+  const env = createEnv(async () => {
+    called = true;
+    return new Response(JSON.stringify({ waiting_count: 0 }), { status: 200 });
+  });
+
+  const response = await handleGetMatchmakingWaitingCount(
+    new Request("https://example.com/api/matchmaking/waiting-count?mode=ARENA&play_style=SP"),
+    env,
+  );
+
+  assert.equal(response.status, 400);
+  assert.equal(called, false);
+  const payload = await response.json();
+  assert.equal(payload.error?.code, "BAD_REQUEST");
 });
 
 test("handlePostRooms does not upsert lobby for PUBLIC auto-match rooms", async () => {

--- a/apps/worker/src/routes/matchmaking.ts
+++ b/apps/worker/src/routes/matchmaking.ts
@@ -1,11 +1,19 @@
-import type { MatchmakingQueueRequest } from "@infinitas/shared";
+import {
+  MODES,
+  PLAY_STYLES,
+  WIN_METRICS,
+  type MatchmakingQueueRequest,
+  type MatchmakingWaitingCountQuery,
+} from "@infinitas/shared";
 import {
   cancelMatchmakingTicket,
   enqueueMatchmakingTicket,
+  fetchMatchmakingWaitingCount,
   fetchMatchmakingTicket,
 } from "../services/matchmaking-do";
 import type { WorkerEnv } from "../types/env";
 import { badRequest, created, ok, parseJsonBody } from "../utils/http";
+import { asEnumValue } from "../utils/validation";
 
 const MATCHMAKING_QUEUE_TICKET_PATH_PATTERN = /^\/api\/matchmaking\/queue\/([^/]+)$/;
 
@@ -21,6 +29,23 @@ export function matchMatchmakingQueueTicketPath(pathname: string): string | null
   }
 
   return decodeURIComponent(encodedTicketId);
+}
+
+function parseWaitingCountQuery(request: Request): MatchmakingWaitingCountQuery | null {
+  const url = new URL(request.url);
+  const mode = asEnumValue(url.searchParams.get("mode"), MODES);
+  const playStyle = asEnumValue(url.searchParams.get("play_style"), PLAY_STYLES);
+  const winMetric = asEnumValue(url.searchParams.get("win_metric"), WIN_METRICS);
+
+  if (mode === undefined || playStyle === undefined || winMetric === undefined) {
+    return null;
+  }
+
+  return {
+    mode,
+    play_style: playStyle,
+    win_metric: winMetric,
+  };
 }
 
 export async function handlePostMatchmakingQueue(
@@ -61,6 +86,24 @@ export async function handleDeleteMatchmakingQueueTicket(
     return ok(response);
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to cancel matchmaking ticket.";
+    return badRequest(message);
+  }
+}
+
+export async function handleGetMatchmakingWaitingCount(
+  request: Request,
+  env: WorkerEnv,
+): Promise<Response> {
+  try {
+    const query = parseWaitingCountQuery(request);
+    if (query === null) {
+      return badRequest("Invalid waiting-count query.");
+    }
+
+    const response = await fetchMatchmakingWaitingCount(env, query);
+    return ok(response);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to fetch waiting count.";
     return badRequest(message);
   }
 }

--- a/apps/worker/src/services/matchmaking-do.ts
+++ b/apps/worker/src/services/matchmaking-do.ts
@@ -1,7 +1,13 @@
-import type { MatchmakingQueueRequest, MatchmakingQueueTicket } from "@infinitas/shared";
+import type {
+  MatchmakingQueueRequest,
+  MatchmakingQueueTicket,
+  MatchmakingWaitingCountQuery,
+  MatchmakingWaitingCountResponse,
+} from "@infinitas/shared";
 import type { WorkerEnv } from "../types/env";
 
 const INTERNAL_MATCHMAKING_QUEUE_URL = "https://matchmaking.internal/internal/queue";
+const INTERNAL_MATCHMAKING_WAITING_COUNT_URL = "https://matchmaking.internal/internal/waiting-count";
 const JSON_CONTENT_TYPE = "application/json; charset=utf-8";
 const MATCHMAKING_GLOBAL_QUEUE_KEY = "global";
 
@@ -12,6 +18,14 @@ interface MatchmakingErrorPayload {
 function buildQueueTicketUrl(ticketId: string): string {
   const encodedTicketId = encodeURIComponent(ticketId);
   return `${INTERNAL_MATCHMAKING_QUEUE_URL}/${encodedTicketId}`;
+}
+
+function buildWaitingCountUrl(query: MatchmakingWaitingCountQuery): string {
+  const searchParams = new URLSearchParams();
+  searchParams.set("mode", query.mode);
+  searchParams.set("play_style", query.play_style);
+  searchParams.set("win_metric", query.win_metric);
+  return `${INTERNAL_MATCHMAKING_WAITING_COUNT_URL}?${searchParams}`;
 }
 
 async function parseErrorMessage(response: Response): Promise<string> {
@@ -88,4 +102,23 @@ export async function cancelMatchmakingTicket(
   }
 
   return (await response.json()) as MatchmakingQueueTicket;
+}
+
+export async function fetchMatchmakingWaitingCount(
+  env: WorkerEnv,
+  query: MatchmakingWaitingCountQuery,
+): Promise<MatchmakingWaitingCountResponse> {
+  const response = await getMatchmakingStub(env).fetch(
+    new Request(buildWaitingCountUrl(query), {
+      method: "GET",
+      headers: {
+        "content-type": JSON_CONTENT_TYPE,
+      },
+    }),
+  );
+  if (!response.ok) {
+    throw new Error(await parseErrorMessage(response));
+  }
+
+  return (await response.json()) as MatchmakingWaitingCountResponse;
 }

--- a/docs/design/03_data_model.md
+++ b/docs/design/03_data_model.md
@@ -200,6 +200,9 @@ type LobbyRoomSummary = {
 - `POST /api/matchmaking/queue`
 - `GET /api/matchmaking/queue/:ticket_id`
 - `DELETE /api/matchmaking/queue/:ticket_id`
+- `GET /api/matchmaking/waiting-count?mode=...&play_style=...&win_metric=...`
+  - response: `{ waiting_count: number }`
+  - counting rule: stale ticket 清掃後、`status=SEARCHING` かつ `mode + play_style + win_metric` 一致件数
 
 ### 3.4.4 成立後ルーム運用（Phase1）
 - 自動マッチ成立で生成するルームは `settings.auto_match=true` の `PUBLIC` ルーム

--- a/packages/shared/src/models/matchmaking.ts
+++ b/packages/shared/src/models/matchmaking.ts
@@ -17,6 +17,16 @@ export interface MatchmakingQueueRequest {
   display_name: string;
 }
 
+export interface MatchmakingWaitingCountQuery {
+  mode: Mode;
+  play_style: PlayStyle;
+  win_metric: WinMetric;
+}
+
+export interface MatchmakingWaitingCountResponse {
+  waiting_count: number;
+}
+
 export interface MatchmakingQueueTicket {
   ticket_id: string;
   status: MatchmakingTicketStatus;

--- a/tasks/issue-149-waiting-count.md
+++ b/tasks/issue-149-waiting-count.md
@@ -1,0 +1,68 @@
+## Issue
+- #149 自動マッチングの条件設定画面で待ち人数を表示する
+
+## 目的
+- Auto Match の `CONFIG` 画面で、`mode/play_style/win_metric` 条件に一致する待ち人数を表示する。
+
+## 非目的
+- rating 許容幅を使った人数表示
+- リアルタイムポーリング表示
+- `IN_QUEUE` 画面演出や既存 `candidate_count` 表示仕様の変更
+
+## fixed decisions
+- 待ち人数定義は `status=SEARCHING` かつ `mode + play_style + win_metric` 一致件数。
+- 取得失敗時は `—` を表示する。
+- 更新タイミングは初回表示時と条件変更時のみ（定期ポーリングなし）。
+
+## 変更点
+- Worker に waiting-count 取得 API を追加する。
+- DO に条件一致件数の集計処理を追加する（stale 清掃後）。
+- Client の Queue Status に待ち人数行を追加する。
+- Client から waiting-count API を呼ぶ API クライアント関数を追加する。
+- 共有型に waiting-count 応答型を追加する。
+- `docs/design/03_data_model.md` に API と counting rule を追記する。
+
+## 影響範囲
+- ユーザー影響: Auto Match の設定画面で待ち人数が見えるようになる。
+- データ影響: 永続データ構造の変更なし（既存チケット走査のみ）。
+- 互換性: additive endpoint 追加のみ。既存 endpoint の wire 契約は維持。
+- Cloudflare 影響: Worker route/DO の処理追加のみ。リソース追加なし。
+
+## 対象レイヤ / 対象ファイル
+- `apps/worker/src/index.ts`
+- `apps/worker/src/routes/matchmaking.ts`
+- `apps/worker/src/services/matchmaking-do.ts`
+- `apps/worker/src/durable/matchmaking-object.ts`
+- `apps/worker/src/routes/matchmaking.test.mjs`
+- `apps/worker/src/durable/matchmaking-object.test.mjs`
+- `apps/client/src/services/worker-api-client.ts`
+- `apps/client/src/pages/AutoMatchPage.tsx`
+- `packages/shared/src/models/matchmaking.ts`
+- `docs/design/03_data_model.md`
+
+## validation plan
+- `npm run typecheck`
+- `npm run lint`
+- `npm run test:worker`
+- `npm run typecheck:client`
+- `npm run build:client`
+
+## rollback 方針
+- waiting-count API の route 追加と client 表示追加をまとめて revert すれば復旧可能。
+- 既存 queue ticket API には変更を入れないため、ロールバックは局所的に実施できる。
+
+## commit 分割方針
+1. worker/shared/docs: waiting-count API と契約追加
+2. client: waiting-count 表示実装
+
+## delegation packet
+- server-implementer
+  - objective: waiting-count API と DO 集計実装
+  - forbidden scope: client UI / Room-Lobby 契約変更
+- front-implementer
+  - objective: Queue Status への待ち人数表示追加
+  - forbidden scope: worker/DO ロジック変更
+- contract-auditor
+  - objective: route/query/response/shared/docs の整合監査
+- implementation-auditor
+  - objective: race condition / fallback / 回帰の監査


### PR DESCRIPTION
## Purpose
- Auto Match の条件設定画面で、条件一致の待ち人数を表示できるようにする（Issue #149）。

## Changes
- worker に `GET /api/matchmaking/waiting-count` を追加（`mode/play_style/win_metric` 指定）。
- DO 側で stale 清掃後に `SEARCHING` かつ条件一致件数を集計。
- shared に waiting-count 用 query/response 型を追加。
- client に waiting-count API 呼び出しを追加。
- AutoMatch 設定画面で待ち人数を表示し、5秒ポーリング更新を追加。
- `Current Rating` を統計画面と同じ表示ルール（`--` / 丸め）で表示。
- キャンセル成功トーストを一定時間後に自動非表示化。
- START MATCHING ボタンを Mock デザインを維持しつつ、`busy/roomEntryReady` と既存ハンドラ連携を復元。
- `docs/design/03_data_model.md` と `tasks/issue-149-waiting-count.md` を更新。

## Non-Changes
- rating 条件込みの待ち人数指標は追加していない。
- IN_QUEUE 画面の仕様・演出は変更していない。
- WS/FSM 契約は変更していない。

## Impact
- User impact: Auto Match 設定画面で待ち人数が見える。
- Data impact: なし（永続スキーマ変更なし）。
- Compatibility impact: additive（既存 endpoint/response は非破壊）。
- Cloudflare/infra impact: worker route/DO 処理追加のみ。

## Validation
- Commands run:
  - `npm run typecheck`: pass
  - `npm run lint`: pass
  - `npm run test:worker`: pass
  - `npm run typecheck:client`: pass
  - `npm run build:client`: pass
- Notes:
  - 追加の review follow-up（Should fix）として client 側の自動テスト拡張余地あり。

## Regression Checks
- [x] 条件一致の待ち人数が取得・表示される。
- [x] 取得失敗時に `—` 表示へフォールバックする。
- [x] 条件変更とポーリング更新で表示が更新される。
- [x] キャンセル成功トーストが一定時間で消える。
- [x] START MATCHING ボタン hover で高さが変わらず、クリックで動作する。

## Risk and Rollback
- Risk level: high（cross-layer 変更）
- Rollback plan: このPRの2コミットを revert すれば API/表示追加を安全に戻せる。

## Related
- Issue: #149
- Plan item/task label: `tasks/issue-149-waiting-count.md`