### PR TITLE
refactor: commonize arena/bpl room presentation helpers

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -7,6 +7,7 @@
     "dev": "vite --host 0.0.0.0 --port 1420",
     "build": "vite build",
     "build:test": "vite build --mode test",
+    "test": "tsx --test src/dev/visual-scenarios.test.ts src/features/room/presentation-shared.test.ts src/pages/auto-match-waiting-count-polling.test.ts src/services/worker-api-client.test.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -30,6 +30,7 @@
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.39",
     "tailwindcss": "^3.4.4",
+    "tsx": "^4.21.0",
     "vite": "^7.1.7"
   }
 }

--- a/apps/client/src/app/App.tsx
+++ b/apps/client/src/app/App.tsx
@@ -426,12 +426,13 @@ export function App() {
     }
 
     let cancelled = false;
+    const captureDelayMs = mockScenario.captureDelayMs ?? runtimeConfig.captureDelayMs;
 
     void (async () => {
       if ("fonts" in document) {
         await document.fonts.ready;
       }
-      await new Promise((resolve) => window.setTimeout(resolve, runtimeConfig.captureDelayMs));
+      await new Promise((resolve) => window.setTimeout(resolve, captureDelayMs));
       if (cancelled) {
         return;
       }

--- a/apps/client/src/components/RoomArena.tsx
+++ b/apps/client/src/components/RoomArena.tsx
@@ -1,25 +1,21 @@
 import React, { useEffect, useRef, useState, type ReactNode } from 'react';
 import { User, CircleCheck as CheckCircle2, Circle, Play, LogOut, MessageSquare, Info, ShieldCheck, Database, Zap, Music, Copy, Check, Clock } from 'lucide-react';
-import SongSearchModal from './SongSearchModal';
+import { RoomPickDecisionCutIn, RoomSearchModalGate } from '../features/room/presentation-components';
+import { useClipboardFeedback, useResultPhaseTimer } from '../features/room/presentation-hooks';
+import {
+    formatCountdown,
+    formatRankLabel,
+    getDifficultyBadgeClass,
+    getDifficultyBadgeLabel,
+    maskJoinCode,
+    type RoomHistoryItem,
+    type RoomPlayerStatusLabel,
+    type RoomSong
+} from '../features/room/presentation-shared';
 import { resolveSongVersionLabel } from './SongSearchModalView';
 
-export interface Song {
-    id?: string | number;
-    title: string;
-    artist: string;
-    version?: string;
-    playStyle?: string;
-    difficulty?: string;
-    level: string | number;
-    genre?: string;
-}
-
-export interface HistoryItem {
-    round: number;
-    song: Song;
-    scores: Record<string, number>;
-    winnerId: string | 'DRAW';
-}
+export type Song = RoomSong;
+export type HistoryItem = RoomHistoryItem;
 
 export interface RoomArenaPlayer {
     id: string;
@@ -88,7 +84,7 @@ export interface RoomArenaControlledState {
     playTime: number;
     playingPhase: 'MUSIC_SELECT' | 'PLAY_START' | 'IN_PLAY';
     playingCountdownSeconds?: number | null;
-    playerStatus: Record<string, 'UNCONFIRMED' | 'PLAYED' | 'SKIPPED' | 'TIMEOUT'>;
+    playerStatus: Record<string, RoomPlayerStatusLabel>;
     playerMetrics?: Record<string, number | null>;
     metricLabel?: string;
     resultSong?: Song | null;
@@ -117,70 +113,10 @@ export function RoomArenaPresentational(props: RoomArenaControlledState) {
     return <RoomArena controlled={props} />;
 }
 
-function maskJoinCode(joinCode: string): string {
-    return '*'.repeat(joinCode.length);
-}
-
-function formatRankLabel(rank: number | null): string {
-    if (rank === null) {
-        return '-';
-    }
-
-    if (rank % 100 >= 11 && rank % 100 <= 13) {
-        return `${rank}th`;
-    }
-
-    switch (rank % 10) {
-        case 1:
-            return `${rank}st`;
-        case 2:
-            return `${rank}nd`;
-        case 3:
-            return `${rank}rd`;
-        default:
-            return `${rank}th`;
-    }
-}
-
-function getDifficultyBadgeClass(difficulty: string | undefined): string {
-    switch (difficulty) {
-        case 'B':
-            return 'bg-green-500 text-black shadow-[0_0_18px_rgba(34,197,94,0.35)]';
-        case 'N':
-            return 'bg-blue-500 text-white shadow-[0_0_18px_rgba(59,130,246,0.35)]';
-        case 'H':
-            return 'bg-yellow-400 text-black shadow-[0_0_20px_rgba(250,204,21,0.45)]';
-        case 'A':
-            return 'bg-red-600 text-white shadow-[0_0_20px_rgba(220,38,38,0.4)]';
-        case 'L':
-            return 'bg-purple-600 text-white shadow-[0_0_20px_rgba(147,51,234,0.4)]';
-        default:
-            return 'bg-gray-600 text-white';
-    }
-}
-
-function getDifficultyBadgeLabel(difficulty: string | undefined): string {
-    switch (difficulty) {
-        case 'B':
-            return 'BEGINNER';
-        case 'N':
-            return 'NORMAL';
-        case 'H':
-            return 'HYPER';
-        case 'A':
-            return 'ANOTHER';
-        case 'L':
-            return 'LEGGENDARIA';
-        default:
-            return difficulty ?? '-';
-    }
-}
-
 export default function RoomArena({ onNavigate, initialStatus, controlled }: RoomProps) {
     const [isReadyState, setIsReady] = useState(initialStatus === 'SELECTING' || initialStatus === 'PLAYING' || initialStatus === 'RESULT' || initialStatus === 'CLOSED');
     const [roomStatusState, setRoomStatus] = useState<'WAITING' | 'SELECTING' | 'PLAYING' | 'RESULT' | 'CLOSED'>(initialStatus || 'WAITING');
     const [closeReasonState, setCloseReason] = useState<string>('ALL_ROUNDS_COMPLETED');
-    const [resultTimerState, setResultTimer] = useState(10);
     const [roundCountState, setRoundCount] = useState(1);
     const [historyState, setHistory] = useState<HistoryItem[]>([]);
     const [playerPicksState, setPlayerPicks] = useState<Record<string, Song | null>>(initialStatus === 'PLAYING' || initialStatus === 'RESULT' ? {
@@ -192,11 +128,13 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
     const [showSearchState, setShowSearch] = useState(false);
     const [showCutInState, setShowCutIn] = useState(false);
     const [lastPickedSongState, setLastPickedSong] = useState<Song | null>(null);
-    const [copiedIdState, setCopiedId] = useState(false);
-    const [copiedCodeState, setCopiedCode] = useState(false);
     const [lobbyTimerState, setLobbyTimer] = useState(1200); // 20 minutes in seconds
     const [currentPlayersState, _setCurrentPlayers] = useState(2); // Mock current players
     const [maxPlayersState, _setMaxPlayers] = useState(4); // Mock room capacity
+    const roomStatus = controlled?.roomStatus ?? roomStatusState;
+    const [resultTimerState] = useResultPhaseTimer(roomStatus === 'RESULT', finalizeRound);
+    const roomIdCopy = useClipboardFeedback();
+    const joinCodeCopy = useClipboardFeedback();
 
     const roomId = controlled?.roomId ?? "3f8e6f5d-9ba0-4268-936d-a5a2ebfd7ccd";
     const joinCode = controlled?.joinCode ?? "ARENA123";
@@ -205,18 +143,13 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
     const regCount = controlled?.regCount ?? maxPlayersState;
     const isPrivateRoom = controlled?.isPrivateRoom ?? false;
 
-    const handleCopy = (text: string, setCopied: (v: boolean) => void) => {
-        navigator.clipboard.writeText(text);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
-    };
     const handleCopyRoomId = () => {
         if (controlled?.onCopyRoomId) {
             controlled.onCopyRoomId();
             return;
         }
 
-        handleCopy(roomId, setCopiedId);
+        roomIdCopy.copy(roomId);
     };
     const handleCopyJoinCode = () => {
         if (controlled?.onCopyJoinCode) {
@@ -224,13 +157,13 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
             return;
         }
 
-        handleCopy(joinCode, setCopiedCode);
+        joinCodeCopy.copy(joinCode);
     };
 
     // PLAYING state logic
     const [playTimeState, setPlayTime] = useState(0);
     const [playingPhaseState, setPlayingPhase] = useState<'MUSIC_SELECT' | 'PLAY_START' | 'IN_PLAY'>('MUSIC_SELECT');
-    const [playerStatusState, setPlayerStatus] = useState<Record<string, 'UNCONFIRMED' | 'PLAYED' | 'SKIPPED' | 'TIMEOUT'>>(
+    const [playerStatusState, setPlayerStatus] = useState<Record<string, RoomPlayerStatusLabel>>(
         initialStatus === 'PLAYING' ? {
             '1': 'PLAYED',
             '2': 'UNCONFIRMED',
@@ -252,7 +185,6 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
     const isHost = controlled?.isHost ?? true;
 
     const isReady = controlled?.isReady ?? isReadyState;
-    const roomStatus = controlled?.roomStatus ?? roomStatusState;
     const closeReason = controlled?.closeReason ?? closeReasonState;
     const resultTimer = controlled?.resultTimer ?? resultTimerState;
     const roundCount = controlled?.roundCount ?? roundCountState;
@@ -261,8 +193,8 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
     const showSearch = controlled?.showSearch ?? showSearchState;
     const showCutIn = controlled?.showCutIn ?? showCutInState;
     const lastPickedSong = controlled?.lastPickedSong ?? lastPickedSongState;
-    const copiedId = controlled?.copiedId ?? copiedIdState;
-    const copiedCode = controlled?.copiedCode ?? copiedCodeState;
+    const copiedId = controlled?.copiedId ?? roomIdCopy.copied;
+    const copiedCode = controlled?.copiedCode ?? joinCodeCopy.copied;
     const lobbyTimer = controlled?.lobbyTimer ?? lobbyTimerState;
     const currentPlayers = controlled?.currentPlayers ?? currentPlayersState;
     const maxPlayers = controlled?.maxPlayers ?? maxPlayersState;
@@ -368,12 +300,6 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
         return () => clearInterval(interval);
     }, [roomStatus]);
 
-    const formatTime = (seconds: number) => {
-        const mins = Math.floor(seconds / 60);
-        const secs = seconds % 60;
-        return `${mins}:${secs.toString().padStart(2, '0')}`;
-    };
-
     // PLAYING タイム管理
     React.useEffect(() => {
         if (roomStatus !== 'PLAYING') return;
@@ -391,27 +317,6 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
         return () => clearInterval(interval);
     }, [roomStatus]);
 
-    // RESULT タイム管理 (10秒で自動遷移)
-    React.useEffect(() => {
-        if (roomStatus !== 'RESULT') {
-            setResultTimer(10);
-            return;
-        }
-
-        const interval = setInterval(() => {
-            setResultTimer(prev => {
-                if (prev <= 1) {
-                    clearInterval(interval);
-                    finalizeRound();
-                    return 0;
-                }
-                return prev - 1;
-            });
-        }, 1000);
-
-        return () => clearInterval(interval);
-    }, [roomStatus]);
-
     const handleSkip = (playerId: string) => {
         if (controlled?.onSkip) {
             controlled.onSkip(playerId);
@@ -421,7 +326,7 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
         setPlayerStatus(prev => ({ ...prev, [playerId]: 'SKIPPED' }));
     };
 
-    const finalizeRound = () => {
+    function finalizeRound() {
         const currentSong = playerPicks['1'] || { title: 'Unknown', artist: 'Unknown', level: '?' };
 
         const mockScores: Record<string, number> = {
@@ -465,7 +370,7 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
             setRoomStatus('CLOSED');
             setCloseReason('ALL_ROUNDS_COMPLETED');
         }
-    };
+    }
 
     const handleProceedToResult = () => {
         if (controlled?.onProceedToResult) {
@@ -491,48 +396,14 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
     return (
         <div className="flex h-screen w-screen bg-[#1a1a1b] text-white font-sans overflow-hidden">
 
-            {/* 決定カットイン演出 */}
-            {showCutIn && lastPickedSong && (
-                <div className="fixed inset-0 z-[300] flex items-center justify-center pointer-events-none">
-                    <div className="absolute inset-0 bg-cyan-500/10 animate-pulse opacity-50" />
-                    <div className="w-full bg-black/90 border-y-4 border-cyan-500 h-64 relative flex items-center justify-center overflow-hidden animate-[in-out_3s_ease-in-out]">
-                        <div className="absolute inset-0 flex items-center justify-center opacity-10">
-                            <span className="text-[200px] font-black italic tracking-tighter text-cyan-500">DECISION</span>
-                        </div>
-                        <div className="relative flex items-center gap-8 px-12 w-full max-w-5xl">
-                            <div className="w-32 h-32 bg-[#252526] border-4 border-cyan-500 rounded-2xl flex-shrink-0 flex items-center justify-center shadow-[0_0_50px_rgba(6,182,212,0.4)]">
-                                <Music size={48} className="text-cyan-500" />
-                            </div>
-                            <div className="flex-1 min-w-0">
-                                <p className="text-cyan-500 font-black italic tracking-[0.5em] text-lg mb-1 animate-bounce">TRACK DECIDED</p>
-                                <h2 className="text-xl lg:text-2xl font-black italic tracking-tighter text-white drop-shadow-lg leading-tight line-clamp-2 break-words whitespace-normal">{lastPickedSong.title}</h2>
-                                <p className="text-xl font-bold text-gray-400 mt-1 truncate">{lastPickedSong.artist}</p>
-                            </div>
-                            <div className="text-right shrink-0">
-                                <span className="text-6xl font-black italic tracking-tighter text-cyan-500">Lv{lastPickedSong.level}</span>
-                            </div>
-                        </div>
-                    </div>
+            {showCutIn ? <RoomPickDecisionCutIn song={lastPickedSong} /> : null}
 
-                    <style dangerouslySetInnerHTML={{
-                        __html: `
-                        @keyframes in-out {
-                            0% { transform: scaleY(0); opacity: 0; }
-                            10% { transform: scaleY(1); opacity: 1; }
-                            90% { transform: scaleY(1); opacity: 1; }
-                            100% { transform: scaleY(0); opacity: 0; }
-                        }
-                    `}} />
-                </div>
-            )}
-
-            {controlled?.searchModal ?? (
-                <SongSearchModal
-                    isOpen={showSearch}
-                    onClose={() => setShowSearch(false)}
-                    onSelect={handleSelectSong}
-                />
-            )}
+            <RoomSearchModalGate
+                modal={controlled?.searchModal}
+                isOpen={showSearch}
+                onClose={() => setShowSearch(false)}
+                onSelect={handleSelectSong}
+            />
 
             {/* メインエリア */}
             <main className="flex-1 flex flex-col p-6 gap-6 relative">
@@ -826,7 +697,7 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
                                 <div className="px-4 py-1.5 bg-cyan-500 text-black font-black italic tracking-widest rounded-lg text-sm">ARENA SELECTION</div>
                                 <div className="flex flex-col">
                                     <span className="text-[9px] font-black text-gray-500 uppercase tracking-widest">Time Remaining</span>
-                                    <span className="text-2xl font-black italic tracking-tighter font-mono text-cyan-400">{formatTime(pickingCountdownSeconds)}</span>
+                                    <span className="text-2xl font-black italic tracking-tighter font-mono text-cyan-400">{formatCountdown(pickingCountdownSeconds)}</span>
                                 </div>
                             </div>
                             <div className="flex items-center gap-4">
@@ -888,7 +759,7 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
                                             <Clock size={8} /> Lobby TTL
                                         </span>
                                         <span className={`font-mono font-bold text-sm ${lobbyTimer < 60 ? 'text-red-500 animate-pulse' : 'text-gray-300'}`}>
-                                            {formatTime(lobbyTimer)}
+                                            {formatCountdown(lobbyTimer)}
                                         </span>
                                     </div>
                                     <div className="px-3 py-2 border-r border-white/10 flex flex-col items-center justify-center flex-1 min-w-0">

--- a/apps/client/src/components/RoomBPL.tsx
+++ b/apps/client/src/components/RoomBPL.tsx
@@ -3,26 +3,22 @@ import {
     User, CheckCircle2, Circle, LogOut,
     Database, Swords, Music, Copy, Check, Clock
 } from 'lucide-react';
-import SongSearchModal from './SongSearchModal';
+import { RoomPickDecisionCutIn, RoomSearchModalGate } from '../features/room/presentation-components';
+import { useClipboardFeedback, useResultPhaseTimer } from '../features/room/presentation-hooks';
+import {
+    formatCountdown,
+    formatOrdinal,
+    getDifficultyBadgeClass,
+    getDifficultyBadgeLabel,
+    maskJoinCode,
+    type RoomHistoryItem,
+    type RoomPlayerStatusLabel,
+    type RoomSong
+} from '../features/room/presentation-shared';
 import { resolveSongVersionLabel } from './SongSearchModalView';
 
-export interface Song {
-    id?: string | number;
-    title: string;
-    artist: string;
-    version?: string;
-    playStyle?: string;
-    level: string | number;
-    difficulty?: string | undefined;
-    genre?: string;
-}
-
-export interface HistoryItem {
-    round: number;
-    song: Song;
-    scores: Record<string, number>;
-    winnerId: string | 'DRAW';
-}
+export type Song = RoomSong;
+export type HistoryItem = RoomHistoryItem;
 
 export interface ResultPhasePlayerSummary {
     metricValue: number | null;
@@ -71,7 +67,7 @@ export interface RoomBPLControlledState {
     playTime: number;
     playingPhase: 'MUSIC_SELECT' | 'PLAY_START' | 'IN_PLAY';
     playingCountdownSeconds?: number | null;
-    playerStatus: Record<string, 'UNCONFIRMED' | 'PLAYED' | 'SKIPPED' | 'TIMEOUT'>;
+    playerStatus: Record<string, RoomPlayerStatusLabel>;
     playerMetrics?: Record<string, number | null>;
     metricLabel?: string;
     resultPlayers?: Record<string, ResultPhasePlayerSummary>;
@@ -105,64 +101,10 @@ const BPL_PLAY_BEGIN_SECONDS = BPL_MUSIC_SELECT_SECONDS + BPL_PLAY_START_SECONDS
 const BPL_STAGE_COUNT = 4;
 const BPL_REGULATION_LABEL = `${BPL_STAGE_COUNT} STAGES`;
 
-function maskJoinCode(joinCode: string): string {
-    return '*'.repeat(joinCode.length);
-}
-
-function formatOrdinal(value: number): string {
-    const mod10 = value % 10;
-    const mod100 = value % 100;
-    if (mod10 === 1 && mod100 !== 11) {
-        return `${value}st`;
-    }
-    if (mod10 === 2 && mod100 !== 12) {
-        return `${value}nd`;
-    }
-    if (mod10 === 3 && mod100 !== 13) {
-        return `${value}rd`;
-    }
-    return `${value}th`;
-}
-
-function getDifficultyBadgeClass(difficulty: string | undefined): string {
-    switch (difficulty) {
-        case 'B':
-            return 'bg-green-500 text-black shadow-[0_0_18px_rgba(34,197,94,0.35)]';
-        case 'N':
-            return 'bg-blue-500 text-white shadow-[0_0_18px_rgba(59,130,246,0.35)]';
-        case 'H':
-            return 'bg-yellow-400 text-black shadow-[0_0_20px_rgba(250,204,21,0.45)]';
-        case 'A':
-            return 'bg-red-600 text-white shadow-[0_0_20px_rgba(220,38,38,0.4)]';
-        case 'L':
-            return 'bg-purple-600 text-white shadow-[0_0_20px_rgba(147,51,234,0.4)]';
-        default:
-            return 'bg-gray-600 text-white';
-    }
-}
-
-function getDifficultyBadgeLabel(difficulty: string | undefined): string {
-    switch (difficulty) {
-        case 'B':
-            return 'BEGINNER';
-        case 'N':
-            return 'NORMAL';
-        case 'H':
-            return 'HYPER';
-        case 'A':
-            return 'ANOTHER';
-        case 'L':
-            return 'LEGGENDARIA';
-        default:
-            return difficulty ?? '-';
-    }
-}
-
 export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomBPLProps) {
     const [roomStatusState, setRoomStatus] = useState<'WAITING' | 'SELECTING' | 'PLAYING' | 'RESULT' | 'CLOSED'>(initialStatus || 'WAITING');
     const [isReadyState, setIsReady] = useState(initialStatus === 'SELECTING' || initialStatus === 'PLAYING' || initialStatus === 'RESULT' || initialStatus === 'CLOSED');
     const [closeReasonState, setCloseReason] = useState<string>('ALL_ROUNDS_COMPLETED');
-    const [resultTimerState, setResultTimer] = useState(10);
     const [currentTurnState, setCurrentTurn] = useState(0); // 0: 1P, 1: 2P
     const [roundCountState, setRoundCount] = useState(1);
     const [picksState, setPicks] = useState<(Song | null)[]>(Array.from({ length: BPL_STAGE_COUNT }, () => null));
@@ -170,9 +112,11 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
     const [showSearchState, setShowSearch] = useState(false);
     const [lastPickedSongState, setLastPickedSong] = useState<Song | null>(null);
     const [showCutInState, setShowCutIn] = useState(false);
-    const [copiedIdState, setCopiedId] = useState(false);
-    const [copiedCodeState, setCopiedCode] = useState(false);
     const [lobbyTimerState, setLobbyTimer] = useState(1200); // 20 minutes in seconds
+    const roomStatus = controlled?.roomStatus ?? roomStatusState;
+    const [resultTimerState] = useResultPhaseTimer(roomStatus === 'RESULT', finalizeRound);
+    const roomIdCopy = useClipboardFeedback();
+    const joinCodeCopy = useClipboardFeedback();
 
     const roomId = controlled?.roomId ?? "";
     const joinCode = controlled?.joinCode ?? "";
@@ -180,18 +124,13 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
     const hasJoinCode = joinCode.trim().length > 0;
     const maskedJoinCode = hasJoinCode ? maskJoinCode(joinCode) : '';
 
-    const handleCopy = (text: string, setCopied: (v: boolean) => void) => {
-        navigator.clipboard.writeText(text);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
-    };
     const handleCopyRoomId = () => {
         if (controlled?.onCopyRoomId) {
             controlled.onCopyRoomId();
             return;
         }
 
-        handleCopy(roomId, setCopiedId);
+        roomIdCopy.copy(roomId);
     };
     const handleCopyJoinCode = () => {
         if (controlled?.onCopyJoinCode) {
@@ -199,13 +138,13 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
             return;
         }
 
-        handleCopy(joinCode, setCopiedCode);
+        joinCodeCopy.copy(joinCode);
     };
 
     // PLAYING state logic
     const [playTimeState, setPlayTime] = useState(0);
     const [playingPhaseState, setPlayingPhase] = useState<'MUSIC_SELECT' | 'PLAY_START' | 'IN_PLAY'>('MUSIC_SELECT');
-    const [playerStatusState, setPlayerStatus] = useState<Record<string, 'UNCONFIRMED' | 'PLAYED' | 'SKIPPED' | 'TIMEOUT'>>(
+    const [playerStatusState, setPlayerStatus] = useState<Record<string, RoomPlayerStatusLabel>>(
         initialStatus === 'PLAYING' ? {
             '1': 'PLAYED',
             '2': 'UNCONFIRMED'
@@ -227,7 +166,6 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
 
     const isHost = controlled?.isHost ?? true;
 
-    const roomStatus = controlled?.roomStatus ?? roomStatusState;
     const isReady = controlled?.isReady ?? isReadyState;
     const closeReason = controlled?.closeReason ?? closeReasonState;
     const resultTimer = controlled?.resultTimer ?? resultTimerState;
@@ -238,8 +176,8 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
     const showSearch = controlled?.showSearch ?? showSearchState;
     const lastPickedSong = controlled?.lastPickedSong ?? lastPickedSongState;
     const showCutIn = controlled?.showCutIn ?? showCutInState;
-    const copiedId = controlled?.copiedId ?? copiedIdState;
-    const copiedCode = controlled?.copiedCode ?? copiedCodeState;
+    const copiedId = controlled?.copiedId ?? roomIdCopy.copied;
+    const copiedCode = controlled?.copiedCode ?? joinCodeCopy.copied;
     const lobbyTimer = controlled?.lobbyTimer ?? lobbyTimerState;
     const playTime = controlled?.playTime ?? playTimeState;
     const playingPhase = controlled?.playingPhase ?? playingPhaseState;
@@ -308,27 +246,6 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
         }, 3000);
     };
 
-    // RESULT タイム管理 (10秒で自動遷移)
-    useEffect(() => {
-        if (roomStatus !== 'RESULT') {
-            setResultTimer(10);
-            return;
-        }
-
-        const interval = setInterval(() => {
-            setResultTimer(prev => {
-                if (prev <= 1) {
-                    clearInterval(interval);
-                    finalizeRound();
-                    return 0;
-                }
-                return prev - 1;
-            });
-        }, 1000);
-
-        return () => clearInterval(interval);
-    }, [roomStatus]);
-
     // Lobby Timer management
     useEffect(() => {
         if (roomStatus !== 'WAITING') return;
@@ -347,12 +264,6 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
 
         return () => clearInterval(interval);
     }, [roomStatus]);
-
-    const formatTime = (seconds: number) => {
-        const mins = Math.floor(seconds / 60);
-        const secs = seconds % 60;
-        return `${mins}:${secs.toString().padStart(2, '0')}`;
-    };
 
     // PLAYING タイム管理
     useEffect(() => {
@@ -383,7 +294,7 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
         setPlayerStatus(prev => ({ ...prev, [playerId]: 'SKIPPED' }));
     };
 
-    const finalizeRound = () => {
+    function finalizeRound() {
         const currentSong = picks[roundCount - 1] || picks[2];
         if (!currentSong) return;
 
@@ -416,7 +327,7 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
             setRoomStatus('CLOSED');
             setCloseReason('ALL_ROUNDS_COMPLETED');
         }
-    };
+    }
 
     const handleProceedToResult = () => {
         if (controlled?.onProceedToResult) {
@@ -439,48 +350,14 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
     return (
         <div className="flex h-screen w-screen bg-[#0f0f10] text-white font-sans overflow-hidden">
 
-            {/* 決定カットイン演出 */}
-            {showCutIn && lastPickedSong && (
-                <div className="fixed inset-0 z-[300] flex items-center justify-center pointer-events-none">
-                    <div className="absolute inset-0 bg-cyan-500/10 animate-pulse opacity-50" />
-                    <div className="w-full bg-black/90 border-y-4 border-cyan-500 h-64 relative flex items-center justify-center overflow-hidden animate-[in-out_3s_ease-in-out]">
-                        <div className="absolute inset-0 flex items-center justify-center opacity-10">
-                            <span className="text-[200px] font-black italic tracking-tighter text-cyan-500">DECISION</span>
-                        </div>
-                        <div className="relative flex items-center gap-8 px-12 w-full max-w-5xl">
-                            <div className="w-32 h-32 bg-[#252526] border-4 border-cyan-500 rounded-2xl flex-shrink-0 flex items-center justify-center shadow-[0_0_50px_rgba(6,182,212,0.4)]">
-                                <Music size={48} className="text-cyan-500" />
-                            </div>
-                            <div className="flex-1 min-w-0">
-                                <p className="text-cyan-500 font-black italic tracking-[0.5em] text-lg mb-1 animate-bounce">TRACK DECIDED</p>
-                                <h2 className="text-xl lg:text-2xl font-black italic tracking-tighter text-white drop-shadow-lg leading-tight line-clamp-2 break-words whitespace-normal">{lastPickedSong.title}</h2>
-                                <p className="text-xl font-bold text-gray-400 mt-1 truncate">{lastPickedSong.artist}</p>
-                            </div>
-                            <div className="text-right shrink-0">
-                                <span className="text-6xl font-black italic tracking-tighter text-cyan-500">Lv{lastPickedSong.level}</span>
-                            </div>
-                        </div>
-                    </div>
+            {showCutIn ? <RoomPickDecisionCutIn song={lastPickedSong} /> : null}
 
-                    <style dangerouslySetInnerHTML={{
-                        __html: `
-                        @keyframes in-out {
-                            0% { transform: scaleY(0); opacity: 0; }
-                            10% { transform: scaleY(1); opacity: 1; }
-                            90% { transform: scaleY(1); opacity: 1; }
-                            100% { transform: scaleY(0); opacity: 0; }
-                        }
-                    `}} />
-                </div>
-            )}
-
-            {controlled?.searchModal ?? (
-                <SongSearchModal
-                    isOpen={showSearch}
-                    onClose={() => setShowSearch(false)}
-                    onSelect={handleSelectSong}
-                />
-            )}
+            <RoomSearchModalGate
+                modal={controlled?.searchModal}
+                isOpen={showSearch}
+                onClose={() => setShowSearch(false)}
+                onSelect={handleSelectSong}
+            />
 
             {/* メイン対峙エリア */}
             <main className="flex-1 flex flex-col p-8 relative overflow-hidden">
@@ -522,7 +399,7 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
                                 <Clock size={8} /> Lobby TTL
                             </span>
                             <span className={`font-mono font-bold text-xs ${lobbyTimer < 60 ? 'text-red-500 animate-pulse' : 'text-gray-300'}`}>
-                                {formatTime(lobbyTimer)}
+                                {formatCountdown(lobbyTimer)}
                             </span>
                         </div>
                     </div>

--- a/apps/client/src/dev/visual-scenarios.test.ts
+++ b/apps/client/src/dev/visual-scenarios.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  VISUAL_SCENARIO_IDS,
+  findVisualScenarioChartByChartKey,
+  getVisualScenario,
+} from "./visual-scenarios";
+
+test("cut-in visual scenarios are listed", () => {
+  assert.equal(VISUAL_SCENARIO_IDS.includes("bpl-cut-in"), true);
+  assert.equal(VISUAL_SCENARIO_IDS.includes("arena-cut-in"), true);
+});
+
+test("bpl cut-in scenario exposes own pick presentation metadata", () => {
+  const scenario = getVisualScenario("bpl-cut-in");
+  assert.ok(scenario);
+  assert.equal(scenario.label, "BPL Pick Cut-In");
+  assert.equal(scenario.captureDelayMs, 100);
+  assert.equal(scenario.presentation?.ownPickCutInChartKey, scenario.room.snapshot?.picks[0]?.pick_chart_key);
+});
+
+test("arena cut-in scenario exposes own pick presentation metadata", () => {
+  const scenario = getVisualScenario("arena-cut-in");
+  assert.ok(scenario);
+  assert.equal(scenario.label, "Arena Pick Cut-In");
+  assert.equal(scenario.captureDelayMs, 100);
+  assert.equal(scenario.presentation?.ownPickCutInChartKey, scenario.room.snapshot?.picks[0]?.pick_chart_key);
+});
+
+test("chart lookup by exact pick chart key resolves cut-in charts", () => {
+  const bplScenario = getVisualScenario("bpl-cut-in");
+  const arenaScenario = getVisualScenario("arena-cut-in");
+  assert.ok(bplScenario);
+  assert.ok(arenaScenario);
+
+  const bplChartKey = bplScenario.room.snapshot?.picks[0]?.pick_chart_key ?? null;
+  const arenaChartKey = arenaScenario.room.snapshot?.picks[0]?.pick_chart_key ?? null;
+
+  const bplChart = findVisualScenarioChartByChartKey("bpl-cut-in", bplChartKey);
+  const arenaChart = findVisualScenarioChartByChartKey("arena-cut-in", arenaChartKey);
+
+  assert.equal(bplChart?.chart_key, bplChartKey);
+  assert.equal(arenaChart?.chart_key, arenaChartKey);
+});

--- a/apps/client/src/dev/visual-scenarios.ts
+++ b/apps/client/src/dev/visual-scenarios.ts
@@ -14,14 +14,20 @@ import type { ClientSettings } from "../stores/settings-store";
 type VisualScenarioId =
   | "bpl-lobby"
   | "bpl-picking"
+  | "bpl-cut-in"
   | "bpl-playing"
   | "bpl-result-phase"
   | "bpl-final"
   | "arena-lobby"
   | "arena-picking"
+  | "arena-cut-in"
   | "arena-playing"
   | "arena-result"
   | "room-closed";
+
+export interface VisualScenarioPresentation {
+  ownPickCutInChartKey?: string;
+}
 
 export interface VisualScenarioRoomState {
   roomId: string;
@@ -42,16 +48,20 @@ export interface VisualScenario {
   settings: ClientSettings;
   room: VisualScenarioRoomState;
   charts: ChartSearchEntry[];
+  presentation?: VisualScenarioPresentation;
+  captureDelayMs?: number;
 }
 
 export const VISUAL_SCENARIO_IDS: VisualScenarioId[] = [
   "bpl-lobby",
   "bpl-picking",
+  "bpl-cut-in",
   "bpl-playing",
   "bpl-result-phase",
   "bpl-final",
   "arena-lobby",
   "arena-picking",
+  "arena-cut-in",
   "arena-playing",
   "arena-result",
   "room-closed",
@@ -642,6 +652,42 @@ function buildScenario(id: VisualScenarioId, nowMs: number): VisualScenario {
         charts: VISUAL_CHARTS,
       };
     }
+    case "bpl-cut-in": {
+      const snapshot = createSnapshot({
+        roomId,
+        roomState: "PICKING",
+        settings: createBplSettings(bplJoinCode),
+        players: bplPlayers,
+        picks: [
+          createPick(HOST_PLAYER_ID, bplChartOne, isoAt(nowMs, -1)),
+        ],
+        pickingDeadline: isoAt(nowMs, 92),
+        createdAt,
+      });
+
+      return {
+        id,
+        label: "BPL Pick Cut-In",
+        settings,
+        captureDelayMs: 100,
+        room: {
+          roomId,
+          joinCode: bplJoinCode,
+          connectionStatus: "CONNECTED",
+          connectionDetail: "Mock scenario: BPL pick cut-in.",
+          snapshot,
+          resultReady: null,
+          roundConfirmations: {},
+          endedRoundIndices: [],
+          errorDialog: null,
+          eventLog: ["Mock scenario: BPL pick cut-in.", "Own pick accepted."],
+        },
+        charts: VISUAL_CHARTS,
+        presentation: {
+          ownPickCutInChartKey: bplChartOne.chart_key,
+        },
+      };
+    }
     case "bpl-playing": {
       const picks = [
         createPick(HOST_PLAYER_ID, bplChartOne, isoAt(nowMs, -150)),
@@ -898,6 +944,43 @@ function buildScenario(id: VisualScenarioId, nowMs: number): VisualScenario {
         charts: VISUAL_CHARTS,
       };
     }
+    case "arena-cut-in": {
+      const snapshot = createSnapshot({
+        roomId,
+        roomState: "PICKING",
+        settings: createArenaSettings(arenaJoinCode),
+        players: arenaPlayers,
+        picks: [
+          createPick(HOST_PLAYER_ID, arenaChartOne, isoAt(nowMs, -1)),
+          createPick(GUEST_PLAYER_ID, arenaChartTwo, isoAt(nowMs, -28)),
+        ],
+        pickingDeadline: isoAt(nowMs, 80),
+        createdAt,
+      });
+
+      return {
+        id,
+        label: "Arena Pick Cut-In",
+        settings,
+        captureDelayMs: 100,
+        room: {
+          roomId,
+          joinCode: arenaJoinCode,
+          connectionStatus: "CONNECTED",
+          connectionDetail: "Mock scenario: Arena pick cut-in.",
+          snapshot,
+          resultReady: null,
+          roundConfirmations: {},
+          endedRoundIndices: [],
+          errorDialog: null,
+          eventLog: ["Mock scenario: Arena pick cut-in.", "Own pick accepted."],
+        },
+        charts: VISUAL_CHARTS,
+        presentation: {
+          ownPickCutInChartKey: arenaChartOne.chart_key,
+        },
+      };
+    }
     case "arena-playing": {
       const currentRound = createCurrentRound(
         arenaChartOne,
@@ -1146,4 +1229,15 @@ export function findVisualScenarioChart(id: string, expectedKey: ExpectedKey | n
         ),
     ) ?? null
   );
+}
+
+export function findVisualScenarioChartByChartKey(id: string, chartKey: string | null | undefined): ChartSearchEntry | null {
+  const normalizedChartKey = chartKey?.trim();
+  if (!normalizedChartKey) {
+    return null;
+  }
+
+  const scenario = getVisualScenario(id);
+  const charts = scenario?.charts ?? VISUAL_CHARTS;
+  return charts.find((chart) => chart.chart_key === normalizedChartKey) ?? null;
 }

--- a/apps/client/src/features/room/presentation-components.tsx
+++ b/apps/client/src/features/room/presentation-components.tsx
@@ -1,0 +1,84 @@
+import { Music } from "lucide-react";
+import type { ReactNode } from "react";
+import SongSearchModal from "../../components/SongSearchModal";
+import type { SongSearchModalSong } from "../../components/SongSearchModalView";
+import type { RoomSong } from "./presentation-shared";
+
+type RoomPickDecisionCutInProps = {
+  song: RoomSong | null;
+};
+
+type RoomSearchModalGateProps = {
+  modal?: ReactNode;
+  isOpen: boolean;
+  onClose: () => void;
+  onSelect: (song: SongSearchModalSong) => void;
+};
+
+export function RoomPickDecisionCutIn({
+  song,
+}: RoomPickDecisionCutInProps): ReactNode {
+  if (song === null) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-[300] flex items-center justify-center pointer-events-none">
+      <div className="absolute inset-0 bg-cyan-500/10 animate-pulse opacity-50" />
+      <div className="w-full bg-black/90 border-y-4 border-cyan-500 h-64 relative flex items-center justify-center overflow-hidden animate-[in-out_3s_ease-in-out]">
+        <div className="absolute inset-0 flex items-center justify-center opacity-10">
+          <span className="text-[200px] font-black italic tracking-tighter text-cyan-500">
+            DECISION
+          </span>
+        </div>
+        <div className="relative flex items-center gap-8 px-12 w-full max-w-5xl">
+          <div className="w-32 h-32 bg-[#252526] border-4 border-cyan-500 rounded-2xl flex-shrink-0 flex items-center justify-center shadow-[0_0_50px_rgba(6,182,212,0.4)]">
+            <Music size={48} className="text-cyan-500" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-cyan-500 font-black italic tracking-[0.5em] text-lg mb-1 animate-bounce">
+              TRACK DECIDED
+            </p>
+            <h2 className="text-xl lg:text-2xl font-black italic tracking-tighter text-white drop-shadow-lg leading-tight line-clamp-2 break-words whitespace-normal">
+              {song.title}
+            </h2>
+            <p className="text-xl font-bold text-gray-400 mt-1 truncate">
+              {song.artist}
+            </p>
+          </div>
+          <div className="text-right shrink-0">
+            <span className="text-6xl font-black italic tracking-tighter text-cyan-500">
+              Lv{song.level}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <style
+        dangerouslySetInnerHTML={{
+          __html: `
+            @keyframes in-out {
+              0% { transform: scaleY(0); opacity: 0; }
+              10% { transform: scaleY(1); opacity: 1; }
+              90% { transform: scaleY(1); opacity: 1; }
+              100% { transform: scaleY(0); opacity: 0; }
+            }
+          `,
+        }}
+      />
+    </div>
+  );
+}
+
+export function RoomSearchModalGate({
+  modal,
+  isOpen,
+  onClose,
+  onSelect,
+}: RoomSearchModalGateProps): ReactNode {
+  return (
+    modal ?? (
+      <SongSearchModal isOpen={isOpen} onClose={onClose} onSelect={onSelect} />
+    )
+  );
+}

--- a/apps/client/src/features/room/presentation-hooks.ts
+++ b/apps/client/src/features/room/presentation-hooks.ts
@@ -1,0 +1,86 @@
+import { useEffect, useRef, useState } from "react";
+
+const DEFAULT_COPY_FEEDBACK_MS = 2_000;
+const DEFAULT_RESULT_PHASE_SECONDS = 10;
+
+export function useClipboardFeedback(feedbackMs = DEFAULT_COPY_FEEDBACK_MS) {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<number | null>(null);
+
+  function reset(): void {
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    setCopied(false);
+  }
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  function copy(text: string): void {
+    if (!text || typeof navigator === "undefined" || !navigator.clipboard) {
+      return;
+    }
+
+    void navigator.clipboard.writeText(text).then(() => {
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+      }
+
+      setCopied(true);
+      timeoutRef.current = window.setTimeout(() => {
+        setCopied(false);
+        timeoutRef.current = null;
+      }, feedbackMs);
+    });
+  }
+
+  return {
+    copied,
+    copy,
+    reset,
+  };
+}
+
+export function useResultPhaseTimer(
+  isActive: boolean,
+  onElapsed: () => void,
+  initialSeconds = DEFAULT_RESULT_PHASE_SECONDS,
+) {
+  const [remainingSeconds, setRemainingSeconds] = useState(initialSeconds);
+  const onElapsedRef = useRef(onElapsed);
+
+  useEffect(() => {
+    onElapsedRef.current = onElapsed;
+  }, [onElapsed]);
+
+  useEffect(() => {
+    if (!isActive) {
+      setRemainingSeconds(initialSeconds);
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      setRemainingSeconds((current) => {
+        if (current <= 1) {
+          window.clearInterval(interval);
+          onElapsedRef.current();
+          return 0;
+        }
+        return current - 1;
+      });
+    }, 1_000);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [initialSeconds, isActive]);
+
+  return [remainingSeconds, setRemainingSeconds] as const;
+}

--- a/apps/client/src/features/room/presentation-shared.test.ts
+++ b/apps/client/src/features/room/presentation-shared.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildPresentationPlayerMaps,
+  formatCountdown,
+  formatOrdinal,
+  formatRankLabel,
+  getDifficultyBadgeClass,
+  getDifficultyBadgeLabel,
+  maskJoinCode,
+  normalizeRoomPlayerStatus,
+} from "./presentation-shared";
+
+test("maskJoinCode preserves length", () => {
+  assert.equal(maskJoinCode("ARENA123"), "********");
+});
+
+test("formatCountdown renders placeholder for null", () => {
+  assert.equal(formatCountdown(null), "--:--");
+});
+
+test("formatCountdown renders mm:ss", () => {
+  assert.equal(formatCountdown(125), "2:05");
+});
+
+test("formatOrdinal handles ordinal suffixes", () => {
+  assert.equal(formatOrdinal(1), "1st");
+  assert.equal(formatOrdinal(2), "2nd");
+  assert.equal(formatOrdinal(3), "3rd");
+  assert.equal(formatOrdinal(11), "11th");
+  assert.equal(formatOrdinal(23), "23rd");
+});
+
+test("formatRankLabel supports null ranks", () => {
+  assert.equal(formatRankLabel(null), "-");
+  assert.equal(formatRankLabel(4), "4th");
+});
+
+test("difficulty badge helpers map known labels", () => {
+  assert.equal(getDifficultyBadgeLabel("A"), "ANOTHER");
+  assert.match(getDifficultyBadgeClass("A"), /bg-red-600/);
+});
+
+test("normalizeRoomPlayerStatus falls back to UNCONFIRMED", () => {
+  assert.equal(normalizeRoomPlayerStatus("PLAYED"), "PLAYED");
+  assert.equal(normalizeRoomPlayerStatus("UNKNOWN"), "UNCONFIRMED");
+  assert.equal(normalizeRoomPlayerStatus(null), "UNCONFIRMED");
+});
+
+test("buildPresentationPlayerMaps derives status and metrics together", () => {
+  const maps = buildPresentationPlayerMaps(
+    [{ id: "left" }, { id: "right" }, { id: "bench" }],
+    ["p1", "p2", null],
+    (playerId) =>
+      playerId === "p1"
+        ? { label: "PLAYED", metric: 1800 }
+        : { label: "TIMEOUT", metric: null },
+  );
+
+  assert.deepEqual(maps.playerStatus, {
+    left: "PLAYED",
+    right: "TIMEOUT",
+    bench: "UNCONFIRMED",
+  });
+  assert.deepEqual(maps.playerMetrics, {
+    left: 1800,
+    right: null,
+    bench: null,
+  });
+});

--- a/apps/client/src/features/room/presentation-shared.ts
+++ b/apps/client/src/features/room/presentation-shared.ts
@@ -1,0 +1,124 @@
+export type RoomSong = {
+  id?: string | number;
+  title: string;
+  artist: string;
+  version?: string;
+  playStyle?: string;
+  difficulty?: string;
+  level: string | number;
+  genre?: string;
+};
+
+export type RoomHistoryItem = {
+  round: number;
+  song: RoomSong;
+  scores: Record<string, number>;
+  winnerId: string | "DRAW";
+};
+
+export type RoomPlayerStatusLabel = "UNCONFIRMED" | "PLAYED" | "SKIPPED" | "TIMEOUT";
+
+export type RoomPlayerStatusSnapshot = {
+  label: string | null | undefined;
+  metric: number | null | undefined;
+};
+
+export function maskJoinCode(joinCode: string): string {
+  return "*".repeat(joinCode.length);
+}
+
+export function formatCountdown(seconds: number | null): string {
+  if (seconds === null) {
+    return "--:--";
+  }
+
+  return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`;
+}
+
+export function formatOrdinal(value: number): string {
+  const mod10 = value % 10;
+  const mod100 = value % 100;
+  if (mod10 === 1 && mod100 !== 11) {
+    return `${value}st`;
+  }
+  if (mod10 === 2 && mod100 !== 12) {
+    return `${value}nd`;
+  }
+  if (mod10 === 3 && mod100 !== 13) {
+    return `${value}rd`;
+  }
+  return `${value}th`;
+}
+
+export function formatRankLabel(rank: number | null): string {
+  return rank === null ? "-" : formatOrdinal(rank);
+}
+
+export function getDifficultyBadgeClass(difficulty: string | null | undefined): string {
+  switch (difficulty) {
+    case "B":
+      return "bg-green-500 text-black shadow-[0_0_18px_rgba(34,197,94,0.35)]";
+    case "N":
+      return "bg-blue-500 text-white shadow-[0_0_18px_rgba(59,130,246,0.35)]";
+    case "H":
+      return "bg-yellow-400 text-black shadow-[0_0_20px_rgba(250,204,21,0.45)]";
+    case "A":
+      return "bg-red-600 text-white shadow-[0_0_20px_rgba(220,38,38,0.4)]";
+    case "L":
+      return "bg-purple-600 text-white shadow-[0_0_20px_rgba(147,51,234,0.4)]";
+    default:
+      return "bg-gray-600 text-white";
+  }
+}
+
+export function getDifficultyBadgeLabel(difficulty: string | null | undefined): string {
+  switch (difficulty) {
+    case "B":
+      return "BEGINNER";
+    case "N":
+      return "NORMAL";
+    case "H":
+      return "HYPER";
+    case "A":
+      return "ANOTHER";
+    case "L":
+      return "LEGGENDARIA";
+    default:
+      return difficulty ?? "-";
+  }
+}
+
+export function normalizeRoomPlayerStatus(
+  status: string | null | undefined,
+): RoomPlayerStatusLabel {
+  return status === "PLAYED" || status === "SKIPPED" || status === "TIMEOUT"
+    ? status
+    : "UNCONFIRMED";
+}
+
+export function buildPresentationPlayerMaps<TPlayer extends { id: string }>(
+  presentationPlayers: readonly TPlayer[],
+  actualPlayerIds: ReadonlyArray<string | null | undefined>,
+  resolveStatus: (actualPlayerId: string) => RoomPlayerStatusSnapshot,
+): {
+  playerStatus: Record<string, RoomPlayerStatusLabel>;
+  playerMetrics: Record<string, number | null>;
+} {
+  return presentationPlayers.reduce<{
+    playerStatus: Record<string, RoomPlayerStatusLabel>;
+    playerMetrics: Record<string, number | null>;
+  }>(
+    (accumulator, player, index) => {
+      const actualPlayerId = actualPlayerIds[index] ?? null;
+      const statusSnapshot =
+        actualPlayerId === null ? null : resolveStatus(actualPlayerId);
+
+      accumulator.playerStatus[player.id] = normalizeRoomPlayerStatus(
+        statusSnapshot?.label,
+      );
+      accumulator.playerMetrics[player.id] = statusSnapshot?.metric ?? null;
+      return accumulator;
+    },
+    { playerStatus: {}, playerMetrics: {} },
+  );
+}

--- a/apps/client/src/pages/RoomPage.tsx
+++ b/apps/client/src/pages/RoomPage.tsx
@@ -28,23 +28,25 @@ import {
 } from "lucide-react";
 import { useDeferredValue, useEffect, useRef, useState, type ReactNode } from "react";
 import { DebugInjectionPanel } from "../components/DebugInjectionPanel";
-import { findVisualScenarioChart, listVisualScenarioCharts } from "../dev/visual-scenarios";
+import {
+  findVisualScenarioChart,
+  findVisualScenarioChartByChartKey,
+  getVisualScenario,
+  listVisualScenarioCharts,
+} from "../dev/visual-scenarios";
 import {
   RoomArenaPresentational,
   type RoomArenaFinalResultPlayerSummary,
-  type HistoryItem as ArenaHistoryItem,
   type RoomArenaControlledState,
   type RoomArenaLogEntry,
   type RoomArenaMatchInfoItem,
   type RoomArenaPlayer,
   type RoomArenaResultPhasePlayerSummary,
-  type Song as ArenaSong,
 } from "../components/RoomArena";
 import {
   RoomBPLPresentational,
   type RoomBPLControlledState,
   type RoomBPLPlayer,
-  type Song as BplSong,
 } from "../components/RoomBPL";
 import {
   resolveSongVersionDbValue,
@@ -52,6 +54,13 @@ import {
   SongSearchModalView,
   type SongSearchModalSong,
 } from "../components/SongSearchModalView";
+import { useClipboardFeedback } from "../features/room/presentation-hooks";
+import {
+  buildPresentationPlayerMaps,
+  formatCountdown,
+  type RoomHistoryItem,
+  type RoomSong,
+} from "../features/room/presentation-shared";
 import { runtimeConfig } from "../runtime/runtime-config";
 import { useLocalResultArchiveStore } from "../services/result-archive";
 import { logClientShareAnalytics } from "../services/share-analytics";
@@ -372,7 +381,10 @@ function parsePickChartKey(pickChartKey: string | null | undefined): CurrentRoun
 }
 
 function findVisualScenarioChartByPickKey(id: string, pickChartKey: string): ChartSearchEntry | null {
-  return findVisualScenarioChart(id, parsePickChartKey(pickChartKey));
+  return (
+    findVisualScenarioChartByChartKey(id, pickChartKey) ??
+    findVisualScenarioChart(id, parsePickChartKey(pickChartKey))
+  );
 }
 
 function compareMetricValues(winMetric: RoomStateSnapshot["settings"]["win_metric"], left: number, right: number): number {
@@ -632,14 +644,6 @@ function parseResultRounds(resultReady: ResultReadyPayload | null): ParsedResult
   return rounds.sort((left, right) => left.roundIndex - right.roundIndex);
 }
 
-function formatCountdown(seconds: number | null): string {
-  if (seconds === null) {
-    return "--:--";
-  }
-
-  return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`;
-}
-
 function formatDurationLabel(totalSeconds: number | null): string {
   if (totalSeconds === null) {
     return "-";
@@ -799,9 +803,12 @@ export function RoomPage() {
   const [chartLoading, setChartLoading] = useState(false);
   const [chartNextCursor, setChartNextCursor] = useState<string | null>(null);
   const [clockNowMs, setClockNowMs] = useState(() => Date.now());
-  const [copiedRoomId, setCopiedRoomId] = useState(false);
-  const [copiedJoinCode, setCopiedJoinCode] = useState(false);
-  const [copiedShareUrl, setCopiedShareUrl] = useState(false);
+  const roomIdCopy = useClipboardFeedback();
+  const joinCodeCopy = useClipboardFeedback();
+  const shareUrlCopy = useClipboardFeedback();
+  const copiedRoomId = roomIdCopy.copied;
+  const copiedJoinCode = joinCodeCopy.copied;
+  const copiedShareUrl = shareUrlCopy.copied;
   const [includeJoinCodeInXShare, setIncludeJoinCodeInXShare] = useState(false);
   const [showHostLeaveConfirm, setShowHostLeaveConfirm] = useState(false);
   const [showRoomAudioMenu, setShowRoomAudioMenu] = useState(false);
@@ -814,6 +821,7 @@ export function RoomPage() {
   const [matchResultStartedAtMs, setMatchResultStartedAtMs] = useState<number | null>(null);
   const chartRequestIdRef = useRef(0);
   const cutInTimeoutRef = useRef<number | null>(null);
+  const autoTriggeredCutInKeyRef = useRef<string | null>(null);
   const arenaLobbyLogSequenceRef = useRef(0);
   const previousArenaLobbySnapshotRef = useRef<RoomStateSnapshot | null>(null);
   const previousLobbySoundSnapshotRef = useRef<RoomStateSnapshot | null>(null);
@@ -824,6 +832,10 @@ export function RoomPage() {
   const pickerModalVisibleRef = useRef(false);
   const mySubmittedPicks = snapshot?.picks.filter((pick) => pick.player_id === activePlayerId) ?? [];
   const mySubmittedPick = mySubmittedPicks[mySubmittedPicks.length - 1] ?? null;
+  const visualScenarioPresentation =
+    runtimeConfig.mockScenarioId === null
+      ? null
+      : getVisualScenario(runtimeConfig.mockScenarioId)?.presentation ?? null;
   const requiredPickCountPerPlayer =
     snapshot && isBplFourStageMode(snapshot.settings.mode) ? 2 : 1;
   const showPickerModal =
@@ -1218,7 +1230,7 @@ export function RoomPage() {
     setPendingOwnPickCutIn(null);
     setOwnPickCutInChart(null);
     setShowRoomAudioMenu(false);
-    setCopiedShareUrl(false);
+    shareUrlCopy.reset();
     setIncludeJoinCodeInXShare(false);
     initialShareClosedByStateRef.current = false;
     if (cutInTimeoutRef.current !== null) {
@@ -1272,6 +1284,39 @@ export function RoomPage() {
       cutInTimeoutRef.current = null;
     }, BPL_PICK_CUTIN_SECONDS * 1_000);
   }, [mySubmittedPick?.pick_chart_key, pendingOwnPickCutIn]);
+
+  useEffect(() => {
+    const ownPickCutInChartKey = visualScenarioPresentation?.ownPickCutInChartKey ?? null;
+    const roomId = snapshot?.room_id ?? null;
+    if (ownPickCutInChartKey === null || roomId === null) {
+      autoTriggeredCutInKeyRef.current = null;
+      return;
+    }
+
+    if (mySubmittedPick?.pick_chart_key !== ownPickCutInChartKey) {
+      return;
+    }
+
+    const triggerKey = `${roomId}:${ownPickCutInChartKey}`;
+    if (autoTriggeredCutInKeyRef.current === triggerKey) {
+      return;
+    }
+
+    const resolvedChart =
+      resolvedChartsByPickKey[ownPickCutInChartKey] ??
+      findVisualScenarioChartByPickKey(runtimeConfig.mockScenarioId ?? "", ownPickCutInChartKey);
+    if (resolvedChart === null) {
+      return;
+    }
+
+    autoTriggeredCutInKeyRef.current = triggerKey;
+    setPendingOwnPickCutIn(resolvedChart);
+  }, [
+    mySubmittedPick?.pick_chart_key,
+    resolvedChartsByPickKey,
+    snapshot?.room_id,
+    visualScenarioPresentation?.ownPickCutInChartKey,
+  ]);
 
   useEffect(() => {
     if (snapshot === null) {
@@ -1826,17 +1871,6 @@ export function RoomPage() {
     roomStore.leaveRoom();
   }
 
-  function handleCopy(text: string, setCopied: (value: boolean) => void): void {
-    if (!text || typeof navigator === "undefined" || !navigator.clipboard) {
-      return;
-    }
-
-    void navigator.clipboard.writeText(text).then(() => {
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 2_000);
-    });
-  }
-
   function handleCopyShareUrl(): void {
     if (!shareJoinPageUrl) {
       return;
@@ -1847,7 +1881,7 @@ export function RoomPage() {
       source: "copy",
       includeJoinCodeInX: includeJoinCodeInXShare,
     });
-    handleCopy(shareJoinPageUrl, setCopiedShareUrl);
+    shareUrlCopy.copy(shareJoinPageUrl);
   }
 
   async function handleShareToX(): Promise<void> {
@@ -2082,7 +2116,7 @@ export function RoomPage() {
     };
   });
 
-  const buildHistorySong = (round: ParsedResultRound) => {
+  const buildHistorySong = (round: ParsedResultRound): RoomSong => {
     const song = roundSongsByIndex.get(round.roundIndex);
     return {
       title: song?.playingTitle ?? round.title,
@@ -2094,7 +2128,7 @@ export function RoomPage() {
     };
   };
 
-  const bplHistory = [...historyRounds]
+  const bplHistory: RoomHistoryItem[] = [...historyRounds]
     .filter((round) => round.results.slice(0, 2).every((result) => result.metricValue !== null))
     .reverse()
     .map((round) => {
@@ -2117,7 +2151,7 @@ export function RoomPage() {
         winnerId,
       };
     });
-  const arenaHistory: ArenaHistoryItem[] = [...historyRounds]
+  const arenaHistory: RoomHistoryItem[] = [...historyRounds]
     .filter((round) => round.results.some((result) => result.metricValue !== null || result.arenaPoints !== null))
     .reverse()
     .map((round) => {
@@ -2142,7 +2176,7 @@ export function RoomPage() {
       };
     });
 
-  const bplPicks: (BplSong | null)[] = Array.from({ length: bplStageCount }, (_, index) => {
+  const bplPicks: Array<RoomSong | null> = Array.from({ length: bplStageCount }, (_, index) => {
     const roundSong = roundSongsByIndex.get(index);
     if (roundSong) {
       const revealActualSong =
@@ -2194,7 +2228,7 @@ export function RoomPage() {
     return null;
   });
 
-  const arenaPicks: Record<string, ArenaSong | null> = {
+  const arenaPicks: Record<string, RoomSong | null> = {
     "1": null,
     "2": null,
     "3": null,
@@ -2243,18 +2277,11 @@ export function RoomPage() {
     };
   });
 
-  const bplPlayerStatus = bplPlayers.reduce<Record<string, "UNCONFIRMED" | "PLAYED" | "SKIPPED" | "TIMEOUT">>((accumulator, player, index) => {
-    const actualPlayer = slots[index];
-    const status = actualPlayer ? getPlayerStatus(currentRound, actualPlayer.player_id).label : "UNCONFIRMED";
-    accumulator[player.id] =
-      status === "PLAYED" || status === "SKIPPED" || status === "TIMEOUT" ? status : "UNCONFIRMED";
-    return accumulator;
-  }, {});
-  const bplPlayerMetrics = bplPlayers.reduce<Record<string, number | null>>((accumulator, player, index) => {
-    const actualPlayer = slots[index];
-    accumulator[player.id] = actualPlayer ? getPlayerStatus(currentRound, actualPlayer.player_id).metric : null;
-    return accumulator;
-  }, {});
+  const { playerStatus: bplPlayerStatus, playerMetrics: bplPlayerMetrics } = buildPresentationPlayerMaps(
+    bplPlayers,
+    slots.map((player) => player?.player_id ?? null),
+    (playerId) => getPlayerStatus(currentRound, playerId),
+  );
   const bplMetricLabel = snapshot.settings.win_metric === "MISSCOUNT" ? "MISS COUNT" : "EX SCORE";
   const bplResultPlayers = bplPlayers.reduce<Record<string, {
     metricValue: number | null;
@@ -2415,18 +2442,11 @@ export function RoomPage() {
     };
     return accumulator;
   }, {});
-  const arenaPlayerStatus = arenaPlayers.reduce<Record<string, "UNCONFIRMED" | "PLAYED" | "SKIPPED" | "TIMEOUT">>((accumulator, player, index) => {
-    const actualPlayer = orderedPlayers[index] ?? null;
-    const status = actualPlayer ? getPlayerStatus(currentRound, actualPlayer.player_id).label : "UNCONFIRMED";
-    accumulator[player.id] =
-      status === "PLAYED" || status === "SKIPPED" || status === "TIMEOUT" ? status : "UNCONFIRMED";
-    return accumulator;
-  }, {});
-  const arenaPlayerMetrics = arenaPlayers.reduce<Record<string, number | null>>((accumulator, player, index) => {
-    const actualPlayer = orderedPlayers[index] ?? null;
-    accumulator[player.id] = actualPlayer ? getPlayerStatus(currentRound, actualPlayer.player_id).metric : null;
-    return accumulator;
-  }, {});
+  const { playerStatus: arenaPlayerStatus, playerMetrics: arenaPlayerMetrics } = buildPresentationPlayerMaps(
+    arenaPlayers,
+    orderedPlayers.map((player) => player?.player_id ?? null),
+    (playerId) => getPlayerStatus(currentRound, playerId),
+  );
   const arenaMetricLabel = snapshot.settings.win_metric === "MISSCOUNT" ? "MISS COUNT" : "EX SCORE";
   const arenaResultSong = arenaResultRound ? buildHistorySong(arenaResultRound) : null;
   const arenaResultRoundResultsByPlayerId = new Map(
@@ -2703,8 +2723,8 @@ export function RoomPage() {
           (isHost && lobbyStartIssues.length > 0),
         disableLeave: leaveRoomDisabled,
         searchModal: pickerModal,
-        onCopyRoomId: () => handleCopy(roomIdLabel, setCopiedRoomId),
-        onCopyJoinCode: () => handleCopy(joinCodeLabel, setCopiedJoinCode),
+        onCopyRoomId: () => roomIdCopy.copy(roomIdLabel),
+        onCopyJoinCode: () => joinCodeCopy.copy(joinCodeLabel),
         onPrimaryAction: onPrimaryRoomAction,
         onSkip: onMockSkip,
         onProceedToResult: () => {
@@ -2793,8 +2813,8 @@ export function RoomPage() {
         snapshot.settings.auto_match === true ||
         (isHost && lobbyStartIssues.length > 0),
       disableLeave: leaveRoomDisabled,
-      onCopyRoomId: () => handleCopy(roomIdLabel, setCopiedRoomId),
-      onCopyJoinCode: () => handleCopy(joinCodeLabel, setCopiedJoinCode),
+      onCopyRoomId: () => roomIdCopy.copy(roomIdLabel),
+      onCopyJoinCode: () => joinCodeCopy.copy(joinCodeLabel),
       onPrimaryAction: onPrimaryRoomAction,
       onToggleReady: onPrimaryRoomAction,
       onSkip: onMockSkip,

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "autoprefixer": "^10.4.19",
         "postcss": "^8.4.39",
         "tailwindcss": "^3.4.4",
+        "tsx": "^4.21.0",
         "vite": "^7.1.7"
       }
     },


### PR DESCRIPTION
## Purpose
- Reduce duplicated ARENA/BPL room presentation logic from Issue #154 without changing room-state semantics.
- Add explicit cut-in visual scenarios and a first-class client test command so the shared presentation path is easier to regress-check.

## Changes
- Extract shared room presentation primitives into `apps/client/src/features/room/` for song/history types, badge helpers, join-code masking, clipboard feedback, result timer, cut-in, and search modal gating.
- Apply the shared presentation layer to `RoomArena.tsx` and `RoomBPL.tsx`.
- Integrate `RoomPage.tsx` with shared player status/metric builders and shared clipboard/countdown helpers.
- Add dedicated `bpl-cut-in` / `arena-cut-in` visual scenarios, exact `pick_chart_key` lookup for mock cut-in playback, and scenario-specific capture delay support.
- Add `apps/client` test coverage for shared presentation helpers and visual scenarios, plus an `npm --workspace @infinitas/client run test` script.

## Non-Changes
- No worker/shared contract changes.
- No `roomStatus` / `roundCount` / `resultTimer` semantic unification beyond the existing agreed client-only scope.
- No dependency update, Cloudflare resource change, or design-doc update.

## Impact
- User impact: none intended beyond maintaining ARENA/BPL UI behavior with stronger regression coverage.
- Data impact: none.
- Compatibility impact: none.
- Cloudflare/infra impact: none.

## Validation
- Commands run:
  - `npm --workspace @infinitas/client run typecheck`: pass
  - `npm --workspace @infinitas/client run test`: pass
  - `npm run lint`: pass
  - `npm --workspace @infinitas/client run build`: pass
- Notes:
  - Verified `bpl-cut-in` and `arena-cut-in` in browser and confirmed `TRACK DECIDED` cut-in rendering.

## Regression Checks
- [x] ARENA/BPL shared presentation primitives compile and render through the presentational components.
- [x] `RoomPage` shared player status / metric derivation stays in the agreed client-only scope.
- [x] `bpl-cut-in` / `arena-cut-in` visual scenarios explicitly render the cut-in overlay.

## Risk and Rollback
- Risk level: normal
- Rollback plan: revert commits `9b1dc5d` and `5580d0c` to restore the prior direct implementations.

## Related
- Issue: #154
- Plan item/task label: `issue-154-arena-bpl-non-header-commonization`
