### PR TITLE
[codex] remove stale lobby entries during lobby reads

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "test": "tsx --test src/durable/room-state.test.mjs src/durable/room-object.test.mjs src/durable/matchmaking-object.test.mjs src/durable/contract-guards.test.mjs src/master/chart-master.test.mjs src/routes/join.test.mjs src/routes/matchmaking.test.mjs",
+    "test": "tsx --test src/durable/room-state.test.mjs src/durable/room-object.test.mjs src/durable/lobby-directory-object.test.mjs src/durable/matchmaking-object.test.mjs src/durable/contract-guards.test.mjs src/master/chart-master.test.mjs src/routes/join.test.mjs src/routes/lobby.test.mjs src/routes/matchmaking.test.mjs",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "devDependencies": {

--- a/apps/worker/src/durable/lobby-directory-object.test.mjs
+++ b/apps/worker/src/durable/lobby-directory-object.test.mjs
@@ -86,13 +86,13 @@ async function listRooms(lobbyDirectory, now) {
   );
 }
 
-test("conditional remove does not delete a newer lobby summary", async () => {
+test("conditional remove does not delete a newer lobby summary from the same millisecond", async () => {
   const lobbyDirectory = new LobbyDirectoryDO(new TestDurableObjectState());
 
   await upsertRoom(lobbyDirectory, 1_000);
-  await upsertRoom(lobbyDirectory, 2_000);
+  await upsertRoom(lobbyDirectory, 1_000);
 
-  const removeResponse = await removeRoom(lobbyDirectory, 3_000, {
+  const removeResponse = await removeRoom(lobbyDirectory, 2_000, {
     roomId: "room-1",
     expectedUpdatedAt: 1_000,
   });
@@ -101,11 +101,11 @@ test("conditional remove does not delete a newer lobby summary", async () => {
   const removePayload = await removeResponse.json();
   assert.equal(removePayload.removed, false);
 
-  const listResponse = await listRooms(lobbyDirectory, 3_000);
+  const listResponse = await listRooms(lobbyDirectory, 2_000);
   const listPayload = await listResponse.json();
   assert.equal(listPayload.rooms.length, 1);
   assert.equal(listPayload.rooms[0].roomId, "room-1");
-  assert.equal(listPayload.rooms[0].updatedAt, 2_000);
+  assert.equal(listPayload.rooms[0].updatedAt, 1_001);
 });
 
 test("conditional remove deletes the matching lobby summary", async () => {
@@ -125,4 +125,32 @@ test("conditional remove deletes the matching lobby summary", async () => {
   const listResponse = await listRooms(lobbyDirectory, 2_000);
   const listPayload = await listResponse.json();
   assert.equal(listPayload.rooms.length, 0);
+});
+
+test("conditional remove does not delete a recreated summary from the same millisecond", async () => {
+  const lobbyDirectory = new LobbyDirectoryDO(new TestDurableObjectState());
+
+  await upsertRoom(lobbyDirectory, 1_000);
+
+  const firstRemoveResponse = await removeRoom(lobbyDirectory, 1_000, {
+    roomId: "room-1",
+    expectedUpdatedAt: 1_000,
+  });
+  assert.equal(firstRemoveResponse.status, 200);
+  assert.equal((await firstRemoveResponse.json()).removed, true);
+
+  await upsertRoom(lobbyDirectory, 1_000);
+
+  const delayedRemoveResponse = await removeRoom(lobbyDirectory, 1_001, {
+    roomId: "room-1",
+    expectedUpdatedAt: 1_000,
+  });
+  assert.equal(delayedRemoveResponse.status, 200);
+  assert.equal((await delayedRemoveResponse.json()).removed, false);
+
+  const listResponse = await listRooms(lobbyDirectory, 1_001);
+  const listPayload = await listResponse.json();
+  assert.equal(listPayload.rooms.length, 1);
+  assert.equal(listPayload.rooms[0].roomId, "room-1");
+  assert.equal(listPayload.rooms[0].updatedAt, 1_001);
 });

--- a/apps/worker/src/durable/lobby-directory-object.test.mjs
+++ b/apps/worker/src/durable/lobby-directory-object.test.mjs
@@ -1,0 +1,128 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { LobbyDirectoryDO } from "./lobby-directory-object.ts";
+
+class TestStorage {
+  #records = new Map();
+
+  async get(key) {
+    return this.#records.get(key);
+  }
+
+  async put(key, value) {
+    this.#records.set(key, value);
+  }
+}
+
+class TestDurableObjectState {
+  storage = new TestStorage();
+
+  async blockConcurrencyWhile(callback) {
+    return callback();
+  }
+}
+
+function createSummary(roomId) {
+  return {
+    roomId,
+    roomName: "Lobby Room",
+    ownerUserId: "owner-1",
+    ownerDisplayName: "Owner",
+    mode: "ARENA",
+    playStyle: "SP",
+    levelFilter: "ANY",
+    winMetric: "SCORE",
+    hasJoinCode: false,
+    isPublic: true,
+    currentPlayers: 1,
+    maxPlayers: 2,
+    isFull: false,
+    status: "LOBBY",
+    ttlStartedAt: 1_000,
+    createdAt: 1_000,
+    updatedAt: 1_000,
+  };
+}
+
+async function withMockedNow(now, callback) {
+  const originalNow = Date.now;
+  Date.now = () => now;
+  try {
+    return await callback();
+  } finally {
+    Date.now = originalNow;
+  }
+}
+
+async function upsertRoom(lobbyDirectory, now, roomId = "room-1") {
+  return withMockedNow(now, async () =>
+    lobbyDirectory.fetch(
+      new Request("https://lobby-directory.internal/internal/upsert", {
+        method: "POST",
+        body: JSON.stringify(createSummary(roomId)),
+      }),
+    ),
+  );
+}
+
+async function removeRoom(lobbyDirectory, now, payload) {
+  return withMockedNow(now, async () =>
+    lobbyDirectory.fetch(
+      new Request("https://lobby-directory.internal/internal/remove", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      }),
+    ),
+  );
+}
+
+async function listRooms(lobbyDirectory, now) {
+  return withMockedNow(now, async () =>
+    lobbyDirectory.fetch(
+      new Request("https://lobby-directory.internal/internal/list", {
+        method: "GET",
+      }),
+    ),
+  );
+}
+
+test("conditional remove does not delete a newer lobby summary", async () => {
+  const lobbyDirectory = new LobbyDirectoryDO(new TestDurableObjectState());
+
+  await upsertRoom(lobbyDirectory, 1_000);
+  await upsertRoom(lobbyDirectory, 2_000);
+
+  const removeResponse = await removeRoom(lobbyDirectory, 3_000, {
+    roomId: "room-1",
+    expectedUpdatedAt: 1_000,
+  });
+  assert.equal(removeResponse.status, 200);
+
+  const removePayload = await removeResponse.json();
+  assert.equal(removePayload.removed, false);
+
+  const listResponse = await listRooms(lobbyDirectory, 3_000);
+  const listPayload = await listResponse.json();
+  assert.equal(listPayload.rooms.length, 1);
+  assert.equal(listPayload.rooms[0].roomId, "room-1");
+  assert.equal(listPayload.rooms[0].updatedAt, 2_000);
+});
+
+test("conditional remove deletes the matching lobby summary", async () => {
+  const lobbyDirectory = new LobbyDirectoryDO(new TestDurableObjectState());
+
+  await upsertRoom(lobbyDirectory, 1_000);
+
+  const removeResponse = await removeRoom(lobbyDirectory, 2_000, {
+    roomId: "room-1",
+    expectedUpdatedAt: 1_000,
+  });
+  assert.equal(removeResponse.status, 200);
+
+  const removePayload = await removeResponse.json();
+  assert.equal(removePayload.removed, true);
+
+  const listResponse = await listRooms(lobbyDirectory, 2_000);
+  const listPayload = await listResponse.json();
+  assert.equal(listPayload.rooms.length, 0);
+});

--- a/apps/worker/src/durable/lobby-directory-object.test.mjs
+++ b/apps/worker/src/durable/lobby-directory-object.test.mjs
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { READY_CHECK_TTL_MS } from "@infinitas/shared";
 import { LobbyDirectoryDO } from "./lobby-directory-object.ts";
 
 class TestStorage {
@@ -12,6 +13,11 @@ class TestStorage {
   async put(key, value) {
     this.#records.set(key, value);
   }
+
+  snapshot() {
+    return Object.fromEntries(this.#records.entries());
+  }
+
 }
 
 class TestDurableObjectState {
@@ -153,4 +159,43 @@ test("conditional remove does not delete a recreated summary from the same milli
   assert.equal(listPayload.rooms.length, 1);
   assert.equal(listPayload.rooms[0].roomId, "room-1");
   assert.equal(listPayload.rooms[0].updatedAt, 1_001);
+});
+
+test("restores the monotonic updatedAt counter from legacy per-room storage", async () => {
+  const state = new TestDurableObjectState();
+  await state.storage.put("rooms", {
+    "room-legacy": createSummary("room-legacy"),
+  });
+  await state.storage.put("lastUpdatedAtByRoomId", {
+    "room-legacy": 1_000,
+    "room-old": 2_500,
+  });
+
+  const lobbyDirectory = new LobbyDirectoryDO(state);
+  await upsertRoom(lobbyDirectory, 2_000, "room-new");
+
+  const listResponse = await listRooms(lobbyDirectory, 2_000);
+  const listPayload = await listResponse.json();
+  const roomNew = listPayload.rooms.find((room) => room.roomId === "room-new");
+  assert.equal(roomNew?.updatedAt, 2_501);
+});
+
+test("persisted monotonic counter does not retain per-room tombstones after remove and expiry cleanup", async () => {
+  const state = new TestDurableObjectState();
+  const lobbyDirectory = new LobbyDirectoryDO(state);
+
+  await upsertRoom(lobbyDirectory, 1_000, "room-remove");
+  await upsertRoom(lobbyDirectory, 1_000, "room-expire");
+
+  await removeRoom(lobbyDirectory, 2_000, {
+    roomId: "room-remove",
+    expectedUpdatedAt: 1_000,
+  });
+
+  await listRooms(lobbyDirectory, 1_000 + READY_CHECK_TTL_MS + 1);
+
+  const storage = state.storage.snapshot();
+  assert.equal(storage.rooms["room-remove"], undefined);
+  assert.equal(storage.rooms["room-expire"], undefined);
+  assert.equal(typeof storage.lastUpdatedAtByRoomId, "number");
 });

--- a/apps/worker/src/durable/lobby-directory-object.ts
+++ b/apps/worker/src/durable/lobby-directory-object.ts
@@ -154,40 +154,35 @@ function buildStoredRooms(input: unknown): Map<string, LobbyRoomSummary> {
   return rooms;
 }
 
-function buildStoredLastUpdatedAt(input: unknown): Map<string, number> {
-  if (!isRecord(input)) {
-    return new Map<string, number>();
-  }
+function restoreLastIssuedUpdatedAt(
+  input: unknown,
+  rooms: Map<string, LobbyRoomSummary>,
+): number {
+  let lastIssuedUpdatedAt = Number.NEGATIVE_INFINITY;
 
-  const result = new Map<string, number>();
-  for (const [roomId, rawUpdatedAt] of Object.entries(input)) {
-    if (!isFiniteNumber(rawUpdatedAt)) {
-      continue;
+  if (isFiniteNumber(input)) {
+    lastIssuedUpdatedAt = input;
+  } else if (isRecord(input)) {
+    for (const rawUpdatedAt of Object.values(input)) {
+      if (!isFiniteNumber(rawUpdatedAt)) {
+        continue;
+      }
+
+      lastIssuedUpdatedAt = Math.max(lastIssuedUpdatedAt, rawUpdatedAt);
     }
-
-    result.set(roomId, rawUpdatedAt);
   }
 
-  return result;
+  for (const room of rooms.values()) {
+    lastIssuedUpdatedAt = Math.max(lastIssuedUpdatedAt, room.updatedAt);
+  }
+
+  return lastIssuedUpdatedAt;
 }
 
-function asSerializableRecord(
-  rooms: Map<string, LobbyRoomSummary>,
-): Record<string, LobbyRoomSummary> {
+function asSerializableRecord(rooms: Map<string, LobbyRoomSummary>): Record<string, LobbyRoomSummary> {
   const result: Record<string, LobbyRoomSummary> = {};
   for (const [roomId, room] of rooms.entries()) {
     result[roomId] = room;
-  }
-
-  return result;
-}
-
-function asSerializableLastUpdatedAt(
-  lastUpdatedAtByRoomId: Map<string, number>,
-): Record<string, number> {
-  const result: Record<string, number> = {};
-  for (const [roomId, updatedAt] of lastUpdatedAtByRoomId.entries()) {
-    result[roomId] = updatedAt;
   }
 
   return result;
@@ -213,28 +208,20 @@ function parseRemovePayload(payload: unknown): { roomId: string; expectedUpdated
 
 export class LobbyDirectoryDO {
   private readonly rooms = new Map<string, LobbyRoomSummary>();
-  private readonly lastUpdatedAtByRoomId = new Map<string, number>();
+  private lastIssuedUpdatedAt = Number.NEGATIVE_INFINITY;
   private readonly readyPromise: Promise<void>;
 
   constructor(private readonly state: DurableObjectStateLike) {
     this.readyPromise = this.state.blockConcurrencyWhile(async () => {
       const stored = await this.state.storage.get<Record<string, LobbyRoomSummary>>(ROOMS_STORAGE_KEY);
-      const storedLastUpdatedAt = await this.state.storage.get<Record<string, number>>(LAST_UPDATED_AT_STORAGE_KEY);
+      const storedLastUpdatedAt = await this.state.storage.get<unknown>(LAST_UPDATED_AT_STORAGE_KEY);
 
       const restored = buildStoredRooms(stored);
-      const restoredLastUpdatedAt = buildStoredLastUpdatedAt(storedLastUpdatedAt);
       this.rooms.clear();
-      this.lastUpdatedAtByRoomId.clear();
-      for (const [roomId, updatedAt] of restoredLastUpdatedAt.entries()) {
-        this.lastUpdatedAtByRoomId.set(roomId, updatedAt);
-      }
       for (const [roomId, room] of restored.entries()) {
         this.rooms.set(roomId, room);
-        this.lastUpdatedAtByRoomId.set(
-          roomId,
-          Math.max(this.lastUpdatedAtByRoomId.get(roomId) ?? Number.NEGATIVE_INFINITY, room.updatedAt),
-        );
       }
+      this.lastIssuedUpdatedAt = restoreLastIssuedUpdatedAt(storedLastUpdatedAt, restored);
     });
   }
 
@@ -294,11 +281,8 @@ export class LobbyDirectoryDO {
 
     const now = Date.now();
     this.cleanupExpired(now);
-    const nextUpdatedAt = Math.max(
-      now,
-      (this.lastUpdatedAtByRoomId.get(parsed.roomId) ?? Number.NEGATIVE_INFINITY) + 1,
-    );
-    this.lastUpdatedAtByRoomId.set(parsed.roomId, nextUpdatedAt);
+    const nextUpdatedAt = Math.max(now, this.lastIssuedUpdatedAt + 1);
+    this.lastIssuedUpdatedAt = nextUpdatedAt;
 
     const normalized: LobbyRoomSummary = {
       ...parsed,
@@ -334,6 +318,7 @@ export class LobbyDirectoryDO {
     this.cleanupExpired(now);
     const current = this.rooms.get(parsed.roomId);
     if (current === undefined) {
+      await this.persistRooms();
       return jsonResponse(200, { ok: true, removed: false });
     }
 
@@ -367,7 +352,7 @@ export class LobbyDirectoryDO {
   private async persistRooms(): Promise<void> {
     await Promise.all([
       this.state.storage.put(ROOMS_STORAGE_KEY, asSerializableRecord(this.rooms)),
-      this.state.storage.put(LAST_UPDATED_AT_STORAGE_KEY, asSerializableLastUpdatedAt(this.lastUpdatedAtByRoomId)),
+      this.state.storage.put(LAST_UPDATED_AT_STORAGE_KEY, this.lastIssuedUpdatedAt),
     ]);
   }
 }

--- a/apps/worker/src/durable/lobby-directory-object.ts
+++ b/apps/worker/src/durable/lobby-directory-object.ts
@@ -6,7 +6,6 @@ import {
   PLAY_STYLES,
   READY_CHECK_TTL_MS,
   WIN_METRICS,
-  type LobbyListResponse,
   type LobbyRoomSummary,
 } from "@infinitas/shared";
 import { isRecord } from "../utils/validation";
@@ -22,6 +21,7 @@ interface DurableObjectStateLike {
 }
 
 const ROOMS_STORAGE_KEY = "rooms";
+const LAST_UPDATED_AT_STORAGE_KEY = "lastUpdatedAtByRoomId";
 
 function jsonResponse(status: number, payload: unknown): Response {
   return new Response(JSON.stringify(payload), {
@@ -139,6 +139,10 @@ function buildStoredRooms(input: unknown): Map<string, LobbyRoomSummary> {
   const entries = Object.entries(input);
   const rooms = new Map<string, LobbyRoomSummary>();
   for (const [roomId, rawRoom] of entries) {
+    if (!isRecord(rawRoom)) {
+      continue;
+    }
+
     const parsed = parseLobbyRoomSummary(rawRoom);
     if (parsed === null) {
       continue;
@@ -150,10 +154,40 @@ function buildStoredRooms(input: unknown): Map<string, LobbyRoomSummary> {
   return rooms;
 }
 
-function asSerializableRecord(rooms: Map<string, LobbyRoomSummary>): Record<string, LobbyRoomSummary> {
+function buildStoredLastUpdatedAt(input: unknown): Map<string, number> {
+  if (!isRecord(input)) {
+    return new Map<string, number>();
+  }
+
+  const result = new Map<string, number>();
+  for (const [roomId, rawUpdatedAt] of Object.entries(input)) {
+    if (!isFiniteNumber(rawUpdatedAt)) {
+      continue;
+    }
+
+    result.set(roomId, rawUpdatedAt);
+  }
+
+  return result;
+}
+
+function asSerializableRecord(
+  rooms: Map<string, LobbyRoomSummary>,
+): Record<string, LobbyRoomSummary> {
   const result: Record<string, LobbyRoomSummary> = {};
   for (const [roomId, room] of rooms.entries()) {
     result[roomId] = room;
+  }
+
+  return result;
+}
+
+function asSerializableLastUpdatedAt(
+  lastUpdatedAtByRoomId: Map<string, number>,
+): Record<string, number> {
+  const result: Record<string, number> = {};
+  for (const [roomId, updatedAt] of lastUpdatedAtByRoomId.entries()) {
+    result[roomId] = updatedAt;
   }
 
   return result;
@@ -179,19 +213,27 @@ function parseRemovePayload(payload: unknown): { roomId: string; expectedUpdated
 
 export class LobbyDirectoryDO {
   private readonly rooms = new Map<string, LobbyRoomSummary>();
+  private readonly lastUpdatedAtByRoomId = new Map<string, number>();
   private readonly readyPromise: Promise<void>;
 
   constructor(private readonly state: DurableObjectStateLike) {
     this.readyPromise = this.state.blockConcurrencyWhile(async () => {
       const stored = await this.state.storage.get<Record<string, LobbyRoomSummary>>(ROOMS_STORAGE_KEY);
-      if (stored === undefined) {
-        return;
-      }
+      const storedLastUpdatedAt = await this.state.storage.get<Record<string, number>>(LAST_UPDATED_AT_STORAGE_KEY);
 
       const restored = buildStoredRooms(stored);
+      const restoredLastUpdatedAt = buildStoredLastUpdatedAt(storedLastUpdatedAt);
       this.rooms.clear();
+      this.lastUpdatedAtByRoomId.clear();
+      for (const [roomId, updatedAt] of restoredLastUpdatedAt.entries()) {
+        this.lastUpdatedAtByRoomId.set(roomId, updatedAt);
+      }
       for (const [roomId, room] of restored.entries()) {
         this.rooms.set(roomId, room);
+        this.lastUpdatedAtByRoomId.set(
+          roomId,
+          Math.max(this.lastUpdatedAtByRoomId.get(roomId) ?? Number.NEGATIVE_INFINITY, room.updatedAt),
+        );
       }
     });
   }
@@ -229,7 +271,7 @@ export class LobbyDirectoryDO {
         return left.roomId.localeCompare(right.roomId);
       });
 
-    const response: LobbyListResponse = {
+    const response = {
       rooms,
       serverTime: now,
     };
@@ -252,12 +294,17 @@ export class LobbyDirectoryDO {
 
     const now = Date.now();
     this.cleanupExpired(now);
+    const nextUpdatedAt = Math.max(
+      now,
+      (this.lastUpdatedAtByRoomId.get(parsed.roomId) ?? Number.NEGATIVE_INFINITY) + 1,
+    );
+    this.lastUpdatedAtByRoomId.set(parsed.roomId, nextUpdatedAt);
 
     const normalized: LobbyRoomSummary = {
       ...parsed,
       currentPlayers: Math.max(0, Math.floor(parsed.currentPlayers)),
       isFull: Math.max(0, Math.floor(parsed.currentPlayers)) >= parsed.maxPlayers,
-      updatedAt: now,
+      updatedAt: nextUpdatedAt,
     };
 
     if (isExpired(normalized, now) || !normalized.isPublic) {
@@ -318,6 +365,9 @@ export class LobbyDirectoryDO {
   }
 
   private async persistRooms(): Promise<void> {
-    await this.state.storage.put(ROOMS_STORAGE_KEY, asSerializableRecord(this.rooms));
+    await Promise.all([
+      this.state.storage.put(ROOMS_STORAGE_KEY, asSerializableRecord(this.rooms)),
+      this.state.storage.put(LAST_UPDATED_AT_STORAGE_KEY, asSerializableLastUpdatedAt(this.lastUpdatedAtByRoomId)),
+    ]);
   }
 }

--- a/apps/worker/src/durable/lobby-directory-object.ts
+++ b/apps/worker/src/durable/lobby-directory-object.ts
@@ -159,7 +159,7 @@ function asSerializableRecord(rooms: Map<string, LobbyRoomSummary>): Record<stri
   return result;
 }
 
-function parseRemovePayload(payload: unknown): { roomId: string } | null {
+function parseRemovePayload(payload: unknown): { roomId: string; expectedUpdatedAt?: number } | null {
   if (!isRecord(payload)) {
     return null;
   }
@@ -169,7 +169,12 @@ function parseRemovePayload(payload: unknown): { roomId: string } | null {
     return null;
   }
 
-  return { roomId };
+  const expectedUpdatedAt = payload.expectedUpdatedAt;
+  if (expectedUpdatedAt !== undefined && !isFiniteNumber(expectedUpdatedAt)) {
+    return null;
+  }
+
+  return expectedUpdatedAt === undefined ? { roomId } : { roomId, expectedUpdatedAt };
 }
 
 export class LobbyDirectoryDO {
@@ -280,9 +285,21 @@ export class LobbyDirectoryDO {
 
     const now = Date.now();
     this.cleanupExpired(now);
+    const current = this.rooms.get(parsed.roomId);
+    if (current === undefined) {
+      return jsonResponse(200, { ok: true, removed: false });
+    }
+
+    if (
+      parsed.expectedUpdatedAt !== undefined &&
+      current.updatedAt !== parsed.expectedUpdatedAt
+    ) {
+      return jsonResponse(200, { ok: true, removed: false });
+    }
+
     this.rooms.delete(parsed.roomId);
     await this.persistRooms();
-    return jsonResponse(200, { ok: true });
+    return jsonResponse(200, { ok: true, removed: true });
   }
 
   private cleanupExpired(now: number): boolean {

--- a/apps/worker/src/durable/room-object.test.mjs
+++ b/apps/worker/src/durable/room-object.test.mjs
@@ -463,6 +463,71 @@ test("internal join-status returns recruiting after host recreates room via RETU
   assert.equal(payload.shareable, true);
 });
 
+test("internal lobby-eligibility returns eligible for PUBLIC lobby rooms", async () => {
+  const roomObject = await createRoomObject();
+  const response = await roomObject.fetch(new Request("https://room.internal/internal/lobby-eligibility", { method: "GET" }));
+  assert.equal(response.status, 200);
+
+  const payload = await response.json();
+  assert.equal(payload.eligible, true);
+});
+
+test("internal lobby-eligibility returns false for auto-match rooms", async () => {
+  const roomObject = await createRoomObject();
+  enableAutoMatchRoom(roomObject);
+
+  const response = await roomObject.fetch(new Request("https://room.internal/internal/lobby-eligibility", { method: "GET" }));
+  assert.equal(response.status, 200);
+
+  const payload = await response.json();
+  assert.equal(payload.eligible, false);
+});
+
+test("internal lobby-eligibility returns false when lobby is full", async () => {
+  const roomObject = await createRoomObject();
+  roomObject.roomState.settings.max_players = 2;
+  const hostSocket = new TestSocket();
+  const guestSocket = new TestSocket();
+  await joinPlayer(roomObject, hostSocket, "host", "msg-1");
+  await joinPlayer(roomObject, guestSocket, "guest", "msg-2");
+
+  const response = await roomObject.fetch(new Request("https://room.internal/internal/lobby-eligibility", { method: "GET" }));
+  assert.equal(response.status, 200);
+
+  const payload = await response.json();
+  assert.equal(payload.eligible, false);
+});
+
+test("internal lobby-eligibility returns false after match starts", async () => {
+  const roomObject = await createRoomObject();
+  const hostSocket = new TestSocket();
+  const guestSocket = new TestSocket();
+  await joinPlayer(roomObject, hostSocket, "host", "msg-1");
+  await joinPlayer(roomObject, guestSocket, "guest", "msg-2");
+  roomObject.roomState.setPlayerReady("host", true);
+  roomObject.roomState.setPlayerReady("guest", true);
+  const startResult = roomObject.roomState.startMatch("host", new Date("2026-03-08T00:00:00.000Z"));
+  assert.equal(startResult.ok, true);
+
+  const response = await roomObject.fetch(new Request("https://room.internal/internal/lobby-eligibility", { method: "GET" }));
+  assert.equal(response.status, 200);
+
+  const payload = await response.json();
+  assert.equal(payload.eligible, false);
+});
+
+test("internal lobby-eligibility returns ROOM_STATE_LOST for uninitialized rooms", async () => {
+  const state = new TestDurableObjectState();
+  const roomObject = new RoomDurableObject(state, createEnv());
+  await roomObject.readyPromise;
+
+  const response = await roomObject.fetch(new Request("https://room.internal/internal/lobby-eligibility", { method: "GET" }));
+  assert.equal(response.status, 404);
+
+  const payload = await response.json();
+  assert.equal(payload.error, "ROOM_STATE_LOST");
+});
+
 test("READY_SET with stale generation is rejected", async () => {
   const roomObject = await createRoomObject();
   const hostSocket = new TestSocket();

--- a/apps/worker/src/durable/room-object.ts
+++ b/apps/worker/src/durable/room-object.ts
@@ -954,6 +954,12 @@ export class RoomDurableObject {
       }
       return this.handleInternalJoinStatus();
     }
+    if (url.pathname === "/internal/lobby-eligibility") {
+      if (request.method !== "GET") {
+        return jsonResponse(405, { error: "Method not allowed." });
+      }
+      return this.handleInternalLobbyEligibility();
+    }
     if (url.pathname === "/charts") {
       if (request.method !== "GET") {
         return jsonResponse(405, { error: "Method not allowed." });
@@ -1140,6 +1146,16 @@ export class RoomDurableObject {
     }
 
     return jsonResponse(200, payload);
+  }
+
+  private handleInternalLobbyEligibility(): Response {
+    if (!this.roomState.isInitialized()) {
+      return jsonResponse(404, { error: "ROOM_STATE_LOST" });
+    }
+
+    return jsonResponse(200, {
+      eligible: this.isLobbyEligible(this.roomState.toSnapshot()),
+    });
   }
 
   async webSocketMessage(
@@ -3361,6 +3377,22 @@ export class RoomDurableObject {
     }
 
     return createdAtMs;
+  }
+
+  private isLobbyEligible(snapshot: RoomStateSnapshot): boolean {
+    if (snapshot.settings.visibility !== "PUBLIC" || snapshot.settings.auto_match === true) {
+      return false;
+    }
+
+    if (snapshot.room_state !== "LOBBY") {
+      return false;
+    }
+
+    if (snapshot.players.length >= snapshot.settings.max_players) {
+      return false;
+    }
+
+    return this.buildLobbySummary(snapshot, Date.now()) !== null;
   }
 
   private buildLobbySummary(snapshot: RoomStateSnapshot, nowMs: number): LobbyRoomSummary | null {

--- a/apps/worker/src/routes/lobby.test.mjs
+++ b/apps/worker/src/routes/lobby.test.mjs
@@ -1,0 +1,181 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { handleGetLobby } from "./lobby.ts";
+
+function createJsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+    },
+  });
+}
+
+function createEnv({ eligibilityByRoomId = {}, removeCalls = [], failRemoveFor = new Set() } = {}) {
+  return {
+    ROOM_DO: {
+      idFromName(name) {
+        return { toString: () => name };
+      },
+      get(id) {
+        const roomId = id.toString();
+        return {
+          fetch: async (request) => {
+            const url = new URL(request.url);
+            if (url.pathname === "/internal/lobby-eligibility") {
+              const response = eligibilityByRoomId[roomId];
+              if (response instanceof Error) {
+                throw response;
+              }
+              return response ?? createJsonResponse({ eligible: true });
+            }
+
+            return createJsonResponse({ error: "unexpected room request" }, 500);
+          },
+        };
+      },
+    },
+    LOBBY_DIRECTORY_DO: {
+      idFromName() {
+        return { toString: () => "lobby-directory" };
+      },
+      get() {
+        return {
+          fetch: async (request) => {
+            const url = new URL(request.url);
+            if (url.pathname === "/internal/list") {
+              return createJsonResponse({
+                rooms: [
+                  {
+                    roomId: "room-eligible-false",
+                    roomName: "eligible false",
+                  },
+                  {
+                    roomId: "room-lost",
+                    roomName: "lost",
+                  },
+                  {
+                    roomId: "room-500",
+                    roomName: "server error",
+                  },
+                  {
+                    roomId: "room-transport",
+                    roomName: "transport error",
+                  },
+                ],
+                serverTime: 123,
+              });
+            }
+
+            if (url.pathname === "/internal/remove") {
+              const payload = await request.json();
+              if (failRemoveFor.has(payload.roomId)) {
+                throw new Error("remove failed");
+              }
+              removeCalls.push(payload.roomId);
+              return createJsonResponse({ ok: true });
+            }
+
+            return createJsonResponse({ error: "unexpected lobby request" }, 500);
+          },
+        };
+      },
+    },
+  };
+}
+
+test("handleGetLobby removes stale eligibility failures but keeps response schema intact", async () => {
+  const removeCalls = [];
+  const env = createEnv({
+    removeCalls,
+    eligibilityByRoomId: {
+      "room-eligible-false": createJsonResponse({ eligible: false }),
+      "room-lost": createJsonResponse({ error: "ROOM_STATE_LOST" }, 404),
+      "room-500": createJsonResponse({ error: "boom" }, 500),
+      "room-transport": new Error("socket hang up"),
+    },
+  });
+
+  const response = await handleGetLobby(new Request("https://worker.test/api/lobby", { method: "GET" }), env);
+  assert.equal(response.status, 200);
+
+  const payload = await response.json();
+  assert.deepEqual(payload, {
+    rooms: [
+      {
+        roomId: "room-500",
+        roomName: "server error",
+      },
+      {
+        roomId: "room-transport",
+        roomName: "transport error",
+      },
+    ],
+    serverTime: 123,
+  });
+
+  assert.deepEqual(removeCalls.sort(), ["room-eligible-false", "room-lost"]);
+});
+
+test("handleGetLobby fail-open keeps lobby response when eligibility probes reject", async () => {
+  const env = createEnv({
+    eligibilityByRoomId: {
+      "room-eligible-false": createJsonResponse({ eligible: true }),
+      "room-lost": createJsonResponse({ eligible: true }),
+      "room-500": createJsonResponse({ error: "boom" }, 500),
+      "room-transport": new Error("transport failure"),
+    },
+  });
+
+  const response = await handleGetLobby(new Request("https://worker.test/api/lobby", { method: "GET" }), env);
+  assert.equal(response.status, 200);
+
+  const payload = await response.json();
+  assert.equal(payload.rooms.length, 4);
+  assert.deepEqual(payload.rooms.map((room) => room.roomId), [
+    "room-eligible-false",
+    "room-lost",
+    "room-500",
+    "room-transport",
+  ]);
+});
+
+test("handleGetLobby excludes rooms that probe as stale on the same response", async () => {
+  const removeCalls = [];
+  const env = createEnv({
+    removeCalls,
+    eligibilityByRoomId: {
+      "room-eligible-false": createJsonResponse({ eligible: false }),
+      "room-lost": createJsonResponse({ error: "ROOM_STATE_LOST" }, 404),
+      "room-500": createJsonResponse({ eligible: true }),
+      "room-transport": createJsonResponse({ eligible: true }),
+    },
+  });
+
+  const response = await handleGetLobby(new Request("https://worker.test/api/lobby", { method: "GET" }), env);
+  assert.equal(response.status, 200);
+
+  const payload = await response.json();
+  assert.deepEqual(payload.rooms.map((room) => room.roomId), ["room-500", "room-transport"]);
+  assert.deepEqual(removeCalls.sort(), ["room-eligible-false", "room-lost"]);
+});
+
+test("handleGetLobby keeps stale rooms excluded when cleanup removal fails", async () => {
+  const removeCalls = [];
+  const env = createEnv({
+    removeCalls,
+    failRemoveFor: new Set(["room-eligible-false"]),
+    eligibilityByRoomId: {
+      "room-eligible-false": createJsonResponse({ eligible: false }),
+      "room-lost": createJsonResponse({ eligible: false }),
+      "room-500": createJsonResponse({ eligible: true }),
+      "room-transport": createJsonResponse({ eligible: true }),
+    },
+  });
+
+  const response = await handleGetLobby(new Request("https://worker.test/api/lobby", { method: "GET" }), env);
+  assert.equal(response.status, 200);
+
+  const payload = await response.json();
+  assert.deepEqual(payload.rooms.map((room) => room.roomId), ["room-500", "room-transport"]);
+});

--- a/apps/worker/src/routes/lobby.test.mjs
+++ b/apps/worker/src/routes/lobby.test.mjs
@@ -121,6 +121,7 @@ test("handleGetLobby removes stale eligibility failures but keeps response schem
     ],
   );
   assert.equal(payload.serverTime, 123);
+  assert.ok(payload.rooms.every((room) => !("revision" in room)));
 });
 
 test("handleGetLobby fail-open keeps lobby response when eligibility probes reject", async () => {

--- a/apps/worker/src/routes/lobby.test.mjs
+++ b/apps/worker/src/routes/lobby.test.mjs
@@ -11,6 +11,28 @@ function createJsonResponse(body, status = 200) {
   });
 }
 
+function buildRoom(roomId, roomName, updatedAt) {
+  return {
+    roomId,
+    roomName,
+    ownerUserId: "owner-1",
+    ownerDisplayName: "Owner",
+    mode: "ARENA",
+    playStyle: "SP",
+    levelFilter: "ANY",
+    winMetric: "SCORE",
+    hasJoinCode: false,
+    isPublic: true,
+    currentPlayers: 1,
+    maxPlayers: 2,
+    isFull: false,
+    status: "LOBBY",
+    ttlStartedAt: 100,
+    createdAt: 100,
+    updatedAt,
+  };
+}
+
 function createEnv({ eligibilityByRoomId = {}, removeCalls = [], failRemoveFor = new Set() } = {}) {
   return {
     ROOM_DO: {
@@ -46,22 +68,10 @@ function createEnv({ eligibilityByRoomId = {}, removeCalls = [], failRemoveFor =
             if (url.pathname === "/internal/list") {
               return createJsonResponse({
                 rooms: [
-                  {
-                    roomId: "room-eligible-false",
-                    roomName: "eligible false",
-                  },
-                  {
-                    roomId: "room-lost",
-                    roomName: "lost",
-                  },
-                  {
-                    roomId: "room-500",
-                    roomName: "server error",
-                  },
-                  {
-                    roomId: "room-transport",
-                    roomName: "transport error",
-                  },
+                  buildRoom("room-eligible-false", "eligible false", 101),
+                  buildRoom("room-lost", "lost", 102),
+                  buildRoom("room-500", "server error", 103),
+                  buildRoom("room-transport", "transport error", 104),
                 ],
                 serverTime: 123,
               });
@@ -72,7 +82,7 @@ function createEnv({ eligibilityByRoomId = {}, removeCalls = [], failRemoveFor =
               if (failRemoveFor.has(payload.roomId)) {
                 throw new Error("remove failed");
               }
-              removeCalls.push(payload.roomId);
+              removeCalls.push(payload);
               return createJsonResponse({ ok: true });
             }
 
@@ -100,21 +110,17 @@ test("handleGetLobby removes stale eligibility failures but keeps response schem
   assert.equal(response.status, 200);
 
   const payload = await response.json();
-  assert.deepEqual(payload, {
-    rooms: [
-      {
-        roomId: "room-500",
-        roomName: "server error",
-      },
-      {
-        roomId: "room-transport",
-        roomName: "transport error",
-      },
+  assert.deepEqual(payload.rooms.map((room) => room.roomId), ["room-500", "room-transport"]);
+  assert.deepEqual(
+    removeCalls
+      .sort((left, right) => left.roomId.localeCompare(right.roomId))
+      .map((call) => ({ roomId: call.roomId, expectedUpdatedAt: call.expectedUpdatedAt })),
+    [
+      { roomId: "room-eligible-false", expectedUpdatedAt: 101 },
+      { roomId: "room-lost", expectedUpdatedAt: 102 },
     ],
-    serverTime: 123,
-  });
-
-  assert.deepEqual(removeCalls.sort(), ["room-eligible-false", "room-lost"]);
+  );
+  assert.equal(payload.serverTime, 123);
 });
 
 test("handleGetLobby fail-open keeps lobby response when eligibility probes reject", async () => {
@@ -157,7 +163,15 @@ test("handleGetLobby excludes rooms that probe as stale on the same response", a
 
   const payload = await response.json();
   assert.deepEqual(payload.rooms.map((room) => room.roomId), ["room-500", "room-transport"]);
-  assert.deepEqual(removeCalls.sort(), ["room-eligible-false", "room-lost"]);
+  assert.deepEqual(
+    removeCalls
+      .sort((left, right) => left.roomId.localeCompare(right.roomId))
+      .map((call) => ({ roomId: call.roomId, expectedUpdatedAt: call.expectedUpdatedAt })),
+    [
+      { roomId: "room-eligible-false", expectedUpdatedAt: 101 },
+      { roomId: "room-lost", expectedUpdatedAt: 102 },
+    ],
+  );
 });
 
 test("handleGetLobby keeps stale rooms excluded when cleanup removal fails", async () => {
@@ -178,4 +192,5 @@ test("handleGetLobby keeps stale rooms excluded when cleanup removal fails", asy
 
   const payload = await response.json();
   assert.deepEqual(payload.rooms.map((room) => room.roomId), ["room-500", "room-transport"]);
+  assert.deepEqual(removeCalls, [{ roomId: "room-lost", expectedUpdatedAt: 102 }]);
 });

--- a/apps/worker/src/routes/lobby.ts
+++ b/apps/worker/src/routes/lobby.ts
@@ -47,7 +47,7 @@ export async function handleGetLobby(_request: Request, env: WorkerEnv): Promise
 
         if (result.stale) {
           try {
-            await removeLobbyDirectoryRoom(env, result.room.roomId);
+            await removeLobbyDirectoryRoom(env, result.room.roomId, result.room.updatedAt);
           } catch {
             // Best effort only: stale rooms must stay excluded from this response even if cleanup fails.
           }

--- a/apps/worker/src/routes/lobby.ts
+++ b/apps/worker/src/routes/lobby.ts
@@ -1,11 +1,65 @@
-import { listLobbyDirectoryRooms } from "../services/lobby-directory";
+import {
+  fetchRoomLobbyEligibility,
+  listLobbyDirectoryRooms,
+  removeLobbyDirectoryRoom,
+} from "../services/lobby-directory";
 import type { WorkerEnv } from "../types/env";
 import { badRequest, ok } from "../utils/http";
 
 export async function handleGetLobby(_request: Request, env: WorkerEnv): Promise<Response> {
   try {
     const response = await listLobbyDirectoryRooms(env);
-    return ok(response);
+    const probeResults = await Promise.all(
+      response.rooms.map(async (room) => {
+        try {
+          const eligibilityResponse = await fetchRoomLobbyEligibility(env, room.roomId);
+
+          if (eligibilityResponse.status === 404) {
+            const body = (await eligibilityResponse.json().catch(() => null)) as { error?: unknown } | null;
+            if (body?.error === "ROOM_STATE_LOST") {
+              return { room, keep: false, stale: true };
+            }
+            return { room, keep: true, stale: false };
+          }
+
+          if (!eligibilityResponse.ok) {
+            return { room, keep: true, stale: false };
+          }
+
+          const eligibility = (await eligibilityResponse.json()) as { eligible?: unknown };
+          if (eligibility.eligible === false) {
+            return { room, keep: false, stale: true };
+          }
+          return { room, keep: true, stale: false };
+        } catch {
+          return { room, keep: true, stale: false };
+        }
+      }),
+    );
+
+    const filteredRooms = new Array(response.rooms.length).fill(null);
+    await Promise.all(
+      probeResults.map(async (result, index) => {
+        if (result.keep) {
+          filteredRooms[index] = result.room;
+          return;
+        }
+
+        if (result.stale) {
+          try {
+            await removeLobbyDirectoryRoom(env, result.room.roomId);
+          } catch {
+            // Best effort only: stale rooms must stay excluded from this response even if cleanup fails.
+          }
+        }
+      }),
+    );
+
+    const rooms = filteredRooms.filter((room): room is (typeof response.rooms)[number] => room !== null);
+    return ok({
+      ...response,
+      rooms,
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to fetch lobby list.";
     return badRequest(message);

--- a/apps/worker/src/services/lobby-directory.ts
+++ b/apps/worker/src/services/lobby-directory.ts
@@ -10,6 +10,7 @@ const INTERNAL_ROOM_LOBBY_ELIGIBILITY_URL = "https://room.internal/internal/lobb
 
 interface LobbyRemovePayload {
   roomId: string;
+  expectedUpdatedAt?: number;
 }
 
 function getLobbyDirectoryStub(env: WorkerEnv) {
@@ -65,8 +66,15 @@ export async function upsertLobbyDirectoryRoom(
   );
 }
 
-export async function removeLobbyDirectoryRoom(env: WorkerEnv, roomId: string): Promise<void> {
-  const payload: LobbyRemovePayload = { roomId };
+export async function removeLobbyDirectoryRoom(
+  env: WorkerEnv,
+  roomId: string,
+  expectedUpdatedAt?: number,
+): Promise<void> {
+  const payload: LobbyRemovePayload =
+    expectedUpdatedAt === undefined
+      ? { roomId }
+      : { roomId, expectedUpdatedAt };
 
   await fetchLobbyDirectoryJson<{ ok: true }>(
     env,

--- a/apps/worker/src/services/lobby-directory.ts
+++ b/apps/worker/src/services/lobby-directory.ts
@@ -6,6 +6,7 @@ const JSON_CONTENT_TYPE = "application/json; charset=utf-8";
 const INTERNAL_LOBBY_LIST_URL = "https://lobby-directory.internal/internal/list";
 const INTERNAL_LOBBY_UPSERT_URL = "https://lobby-directory.internal/internal/upsert";
 const INTERNAL_LOBBY_REMOVE_URL = "https://lobby-directory.internal/internal/remove";
+const INTERNAL_ROOM_LOBBY_ELIGIBILITY_URL = "https://room.internal/internal/lobby-eligibility";
 
 interface LobbyRemovePayload {
   roomId: string;
@@ -14,6 +15,11 @@ interface LobbyRemovePayload {
 function getLobbyDirectoryStub(env: WorkerEnv) {
   const doId = env.LOBBY_DIRECTORY_DO.idFromName(LOBBY_DIRECTORY_NAME);
   return env.LOBBY_DIRECTORY_DO.get(doId);
+}
+
+function getRoomStub(env: WorkerEnv, roomId: string) {
+  const doId = env.ROOM_DO.idFromName(roomId);
+  return env.ROOM_DO.get(doId);
 }
 
 async function fetchLobbyDirectoryJson<TResponse>(
@@ -72,5 +78,19 @@ export async function removeLobbyDirectoryRoom(env: WorkerEnv, roomId: string): 
       body: JSON.stringify(payload),
     }),
     "Failed to remove lobby room",
+  );
+}
+
+export async function fetchRoomLobbyEligibility(
+  env: WorkerEnv,
+  roomId: string,
+): Promise<Response> {
+  return getRoomStub(env, roomId).fetch(
+    new Request(INTERNAL_ROOM_LOBBY_ELIGIBILITY_URL, {
+      method: "GET",
+      headers: {
+        "content-type": JSON_CONTENT_TYPE,
+      },
+    }),
   );
 }

--- a/tasks/issue-155-stale-lobby-read-cleanup.md
+++ b/tasks/issue-155-stale-lobby-read-cleanup.md
@@ -1,0 +1,74 @@
+# issue-155-stale-lobby-read-cleanup
+
+## Purpose
+- 既存の誤登録ロビー entry を `GET /api/lobby` の read path で即時除去し、本来一覧に出ない部屋の誤表示時間を最小化する。
+
+## Non-goals
+- visibility モデルの再設計
+- migration / batch cleanup
+- client/shared/WS/FSM 契約変更
+- docs/design の大規模更新
+
+## Fixed decisions
+- cleanup trigger は `GET /api/lobby` read path
+- RoomDO に internal の lobby eligibility 判定エンドポイントを追加する
+- `eligible=false` と `404 ROOM_STATE_LOST` は stale 扱いで remove する
+- `5xx` / 通信失敗は fail-open（表示維持）とする
+- 公開レスポンス schema は不変とする
+
+## Changes
+- `apps/worker/src/services/lobby-directory.ts` にロビー一覧 read path 用の stale cleanup 補助を追加する
+- `apps/worker/src/routes/lobby.ts` で read path cleanup を実行した上で公開ロビー一覧を返す
+- `apps/worker/src/durable/room-object.ts` に internal lobby eligibility 判定エンドポイントを追加する
+- worker 回帰テストを `apps/worker/src/durable/room-object.test.mjs` と `apps/worker/src/routes/lobby.test.mjs` に追加する
+
+## Impact
+- Users/runtime: auto-match 誤登録 entry がロビー一覧に残り続けない
+- Data/compatibility: 公開レスポンス schema 変更なし。既存 directory entry を read path で除去するのみ
+- Cloudflare: Worker/DO の既存資源内で完結。構成変更なし
+
+## Target Layers / Files
+- layer: worker
+- files:
+  - `apps/worker/src/durable/room-object.ts`
+  - `apps/worker/src/services/lobby-directory.ts`
+  - `apps/worker/src/routes/lobby.ts`
+  - `apps/worker/src/durable/room-object.test.mjs`
+  - `apps/worker/src/routes/lobby.test.mjs`
+
+## Validation Plan
+- `npm run test:worker`
+- `npm --workspace @infinitas/worker run typecheck`
+- `npm run lint`
+- `npm --workspace @infinitas/worker exec wrangler deploy --dry-run`
+
+## Rollback Plan
+- read path cleanup と internal eligibility endpoint の差分をまとめて revert し、従来の LobbyDirectory 読み出しのみに戻す
+
+## Commit Split Plan
+1. worker 実装: RoomDO eligibility endpoint + lobby read path cleanup
+2. worker 回帰テスト: durable / route tests
+
+## Phase / Spawn Decision
+- Phase A: `READY`
+- Phase B: `READY`
+- execution profile: `High-Risk`
+- Plan Mode: `YES`
+- Standard Spawn Gate: `NOT_APPLICABLE`
+- High-Risk Spawn Gate: `APPLICABLE`
+
+## Delegation Packet
+- task label: `issue-155-stale-lobby-read-cleanup`
+- objective: `/api/lobby` 読取時に stale entry を即時除去し、誤登録 auto-match 部屋を表示しない
+- in-scope files/layer: worker / `room-object.ts`, `lobby-directory.ts`, `lobby.ts`, `room-object.test.mjs`, `lobby.test.mjs`
+- non-goals: visibility 再設計、batch cleanup、client/shared/docs-design 変更
+- forbidden scope: `apps/client/**`, `apps/web/**`, `packages/shared/**`, `docs/design/**`, lockfile/依存更新
+- expected output: stale entry は read path で remove され、正常な PUBLIC LOBBY 部屋の表示挙動は維持される
+- validation: 上記 Validation Plan を満たす
+- escalation: cross-layer 化、契約変更、CI/依存変更、仕様判断が必要化した場合
+
+## Replan Gate
+- 次のいずれかが発生した場合は Phase C/D を停止し、`WAITING_FOR_HUMAN_DECISION` または `ESCALATION` へ戻す
+  - shared/client/docs-design の更新が必須化した場合
+  - 公開レスポンス schema や WS/FSM 契約変更が必要化した場合
+  - `5xx` fail-open 以外の互換方針見直しが必要化した場合

--- a/tasks/issue-155-stale-lobby-read-cleanup.md
+++ b/tasks/issue-155-stale-lobby-read-cleanup.md
@@ -18,9 +18,11 @@
 
 ## Changes
 - `apps/worker/src/services/lobby-directory.ts` にロビー一覧 read path 用の stale cleanup 補助を追加する
+- `apps/worker/src/durable/lobby-directory-object.ts` に freshness 条件つき remove を追加し、read path cleanup が newer summary を削除しないようにする
 - `apps/worker/src/routes/lobby.ts` で read path cleanup を実行した上で公開ロビー一覧を返す
 - `apps/worker/src/durable/room-object.ts` に internal lobby eligibility 判定エンドポイントを追加する
-- worker 回帰テストを `apps/worker/src/durable/room-object.test.mjs` と `apps/worker/src/routes/lobby.test.mjs` に追加する
+- worker 回帰テストを `apps/worker/src/durable/room-object.test.mjs`、`apps/worker/src/durable/lobby-directory-object.test.mjs`、`apps/worker/src/routes/lobby.test.mjs` に追加する
+- `apps/worker/package.json` の標準 test script に lobby route 回帰テストを組み込む
 
 ## Impact
 - Users/runtime: auto-match 誤登録 entry がロビー一覧に残り続けない
@@ -31,10 +33,13 @@
 - layer: worker
 - files:
   - `apps/worker/src/durable/room-object.ts`
+  - `apps/worker/src/durable/lobby-directory-object.ts`
   - `apps/worker/src/services/lobby-directory.ts`
   - `apps/worker/src/routes/lobby.ts`
   - `apps/worker/src/durable/room-object.test.mjs`
+  - `apps/worker/src/durable/lobby-directory-object.test.mjs`
   - `apps/worker/src/routes/lobby.test.mjs`
+  - `apps/worker/package.json`
 
 ## Validation Plan
 - `npm run test:worker`
@@ -46,8 +51,8 @@
 - read path cleanup と internal eligibility endpoint の差分をまとめて revert し、従来の LobbyDirectory 読み出しのみに戻す
 
 ## Commit Split Plan
-1. worker 実装: RoomDO eligibility endpoint + lobby read path cleanup
-2. worker 回帰テスト: durable / route tests
+1. worker 実装: stale lobby cleanup の freshness 条件つき remove と回帰テスト
+2. worker test harness: 標準 test script への lobby cleanup 回帰組み込み
 
 ## Phase / Spawn Decision
 - Phase A: `READY`
@@ -60,7 +65,7 @@
 ## Delegation Packet
 - task label: `issue-155-stale-lobby-read-cleanup`
 - objective: `/api/lobby` 読取時に stale entry を即時除去し、誤登録 auto-match 部屋を表示しない
-- in-scope files/layer: worker / `room-object.ts`, `lobby-directory.ts`, `lobby.ts`, `room-object.test.mjs`, `lobby.test.mjs`
+- in-scope files/layer: worker / `room-object.ts`, `lobby-directory-object.ts`, `lobby-directory.ts`, `lobby.ts`, `room-object.test.mjs`, `lobby-directory-object.test.mjs`, `lobby.test.mjs`, `package.json`
 - non-goals: visibility 再設計、batch cleanup、client/shared/docs-design 変更
 - forbidden scope: `apps/client/**`, `apps/web/**`, `packages/shared/**`, `docs/design/**`, lockfile/依存更新
 - expected output: stale entry は read path で remove され、正常な PUBLIC LOBBY 部屋の表示挙動は維持される


### PR DESCRIPTION
## Purpose
- Remove stale misregistered lobby entries during `GET /api/lobby` so rooms that should not be listed stop appearing on the same read.
- Keep read-time cleanup from deleting newer lobby summaries when a fresh RoomDO upsert races with stale cleanup.

## Changes
- Add the local Phase B/C execution artifact for Issue #155 in `tasks/issue-155-stale-lobby-read-cleanup.md`.
- Pass `updatedAt` from the lobby read path into stale-entry cleanup and make `LobbyDirectoryDO` remove conditional on freshness.
- Keep stale rooms excluded from the same `/api/lobby` response while preserving fail-open behavior for per-room probe/remove failures.
- Add durable and route regression tests covering freshness-gated removal, `eligible=false`, `404 ROOM_STATE_LOST`, same-response exclusion, and cleanup fail-open behavior.
- Include `src/durable/lobby-directory-object.test.mjs` and `src/routes/lobby.test.mjs` in `apps/worker/package.json` so the standard worker test suite covers this path.

## Non-Changes
- No visibility model redesign.
- No migration or batch cleanup.
- No client/shared/WS/FSM contract change.
- No dependency, lockfile, or `docs/design/**` update.

## Impact
- User impact: stale public lobby misregistrations disappear immediately on lobby reads without hiding newer valid summaries.
- Data impact: no schema migration; stale directory entries can be pruned on read when they still match the probed summary version.
- Compatibility impact: public `LobbyListResponse` schema remains unchanged; cleanup uses worker-internal payload fields only.
- Cloudflare/infra impact: existing Worker, RoomDO, and LobbyDirectoryDO resources only; no new bindings or resources.

## Validation
- `npm run test:worker`: pass
- `npm --workspace @infinitas/worker run typecheck`: pass
- `npm run lint`: pass
- `npm --workspace @infinitas/worker exec wrangler deploy --dry-run`: pass
- `git diff --check`: pass

## Regression Checks
- [x] `eligible=false` stale entries are removed and excluded from the same `/api/lobby` response.
- [x] `404 ROOM_STATE_LOST` stale entries are removed and excluded from the same response.
- [x] Read-time cleanup does not delete a newer lobby summary after a racing upsert.
- [x] RoomDO `5xx`, transport failures, and cleanup-remove failures fail open without breaking `/api/lobby`.
- [x] Standard `npm run test:worker` now exercises the lobby cleanup route and durable-object regressions.
- [x] Valid PUBLIC `LOBBY` rooms remain visible.

## Risk and Rollback
- Risk level: high
- Rollback plan: revert `fix(worker): gate stale lobby cleanup on summary freshness` and `fix(worker): remove stale lobby entries on read` to restore pre-read-cleanup behavior; revert `test(worker): include lobby cleanup checks in default suite` separately if only the suite wiring needs to be undone.
- Compatibility notes: no public schema change; worker-only internal cleanup payload extension.
- Cloudflare resources impact: none beyond existing bindings.
- docs/design updates: not required; the implementation aligns to the existing lobby visibility contract.

## Related
- Issue: #155
- Plan item/task label: `issue-155-stale-lobby-read-cleanup`
