### PR TITLE
test(worker): split rooms route coverage from matchmaking

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "test": "tsx --test src/durable/room-state.test.mjs src/durable/room-object.test.mjs src/durable/lobby-directory-object.test.mjs src/durable/matchmaking-object.test.mjs src/durable/contract-guards.test.mjs src/master/chart-master.test.mjs src/routes/join.test.mjs src/routes/lobby.test.mjs src/routes/matchmaking.test.mjs",
+    "test": "tsx --test src/durable/room-state.test.mjs src/durable/room-object.test.mjs src/durable/lobby-directory-object.test.mjs src/durable/matchmaking-object.test.mjs src/durable/contract-guards.test.mjs src/master/chart-master.test.mjs src/routes/join.test.mjs src/routes/lobby.test.mjs src/routes/matchmaking.test.mjs src/routes/rooms.test.mjs",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "devDependencies": {

--- a/apps/worker/src/routes/matchmaking.test.mjs
+++ b/apps/worker/src/routes/matchmaking.test.mjs
@@ -7,7 +7,6 @@ import {
   handlePostMatchmakingQueue,
   matchMatchmakingQueueTicketPath,
 } from "./matchmaking.ts";
-import { handlePostRooms } from "./rooms.ts";
 
 function createEnv(doFetch) {
   return {
@@ -48,40 +47,6 @@ function createEnv(doFetch) {
     MIN_SUPPORTED_CLIENT_VERSION: "1.2.0",
     ISSUE_TOKEN: "",
     DISCORD_WEBHOOK_URL: "",
-  };
-}
-
-function createRoomsEnv() {
-  const initPayloads = [];
-  const lobbyUpserts = [];
-  const env = createEnv(async () => new Response("{}", { status: 200 }));
-
-  env.ROOM_DO.get = () => ({
-    fetch: async (request) => {
-      const url = new URL(request.url);
-      if (url.pathname === "/internal/init" && request.method === "POST") {
-        initPayloads.push(await request.json());
-        return new Response(JSON.stringify({ ok: true }), { status: 200 });
-      }
-      return new Response(JSON.stringify({ error: "unexpected room request" }), { status: 400 });
-    },
-  });
-
-  env.LOBBY_DIRECTORY_DO.get = () => ({
-    fetch: async (request) => {
-      const url = new URL(request.url);
-      if (url.pathname === "/internal/upsert" && request.method === "POST") {
-        lobbyUpserts.push(await request.json());
-        return new Response(JSON.stringify({ ok: true }), { status: 200 });
-      }
-      return new Response(JSON.stringify({ ok: true }), { status: 200 });
-    },
-  });
-
-  return {
-    env,
-    getInitPayloads: () => initPayloads,
-    getLobbyUpserts: () => lobbyUpserts,
   };
 }
 
@@ -213,54 +178,4 @@ test("handleGetMatchmakingWaitingCount rejects invalid query", async () => {
   assert.equal(called, false);
   const payload = await response.json();
   assert.equal(payload.error?.code, "BAD_REQUEST");
-});
-
-test("handlePostRooms does not upsert lobby for PUBLIC auto-match rooms", async () => {
-  const { env, getInitPayloads, getLobbyUpserts } = createRoomsEnv();
-  const response = await handlePostRooms(
-    new Request("https://example.com/api/rooms", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        visibility: "PUBLIC",
-        auto_match: true,
-        mode: "ARENA",
-        win_metric: "SCORE",
-        play_style: "SP",
-        level_filter: "ANY",
-        max_players: 2,
-        room_comment: "Auto match room",
-      }),
-    }),
-    env,
-  );
-
-  assert.equal(response.status, 201);
-  assert.equal(getInitPayloads().length, 1);
-  assert.equal(getInitPayloads()[0]?.settings.auto_match, true);
-  assert.equal(getLobbyUpserts().length, 0);
-});
-
-test("handlePostRooms keeps lobby upsert for normal PUBLIC rooms", async () => {
-  const { env, getLobbyUpserts } = createRoomsEnv();
-  const response = await handlePostRooms(
-    new Request("https://example.com/api/rooms", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        visibility: "PUBLIC",
-        mode: "ARENA",
-        win_metric: "SCORE",
-        play_style: "SP",
-        level_filter: "ANY",
-        max_players: 2,
-        room_comment: "Public room",
-      }),
-    }),
-    env,
-  );
-
-  assert.equal(response.status, 201);
-  assert.equal(getLobbyUpserts().length, 1);
-  assert.equal(getLobbyUpserts()[0]?.isPublic, true);
 });

--- a/apps/worker/src/routes/rooms.test.mjs
+++ b/apps/worker/src/routes/rooms.test.mjs
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { handlePostRooms } from "./rooms.ts";
+
+function createEnv() {
+  return {
+    MATCHMAKING_DO: {
+      idFromName(name) {
+        return { toString: () => name };
+      },
+      get() {
+        return {
+          fetch: async () => new Response("{}", { status: 200 }),
+        };
+      },
+    },
+    ROOM_DO: {
+      idFromName(name) {
+        return { toString: () => name };
+      },
+      get() {
+        return { fetch: async () => new Response("{}", { status: 200 }) };
+      },
+    },
+    LOBBY_DIRECTORY_DO: {
+      idFromName(name) {
+        return { toString: () => name };
+      },
+      get() {
+        return { fetch: async () => new Response("{}", { status: 200 }) };
+      },
+    },
+    FEEDBACK_KV: {
+      get: async () => null,
+      put: async () => {},
+    },
+    APP_DOWNLOAD_URL: "",
+    REPO_OWNER_GITHUB: "tts1374",
+    REPO_NAME_GITHUB: "infinitas_arena",
+    APP_ENV: "test",
+    MIN_SUPPORTED_CLIENT_VERSION: "1.2.0",
+    ISSUE_TOKEN: "",
+    DISCORD_WEBHOOK_URL: "",
+  };
+}
+
+function createRoomsEnv() {
+  const initPayloads = [];
+  const lobbyUpserts = [];
+  const env = createEnv();
+
+  env.ROOM_DO.get = () => ({
+    fetch: async (request) => {
+      const url = new URL(request.url);
+      if (url.pathname === "/internal/init" && request.method === "POST") {
+        initPayloads.push(await request.json());
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "unexpected room request" }), { status: 400 });
+    },
+  });
+
+  env.LOBBY_DIRECTORY_DO.get = () => ({
+    fetch: async (request) => {
+      const url = new URL(request.url);
+      if (url.pathname === "/internal/upsert" && request.method === "POST") {
+        lobbyUpserts.push(await request.json());
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    },
+  });
+
+  return {
+    env,
+    getInitPayloads: () => initPayloads,
+    getLobbyUpserts: () => lobbyUpserts,
+  };
+}
+
+test("handlePostRooms does not upsert lobby when visibility is PUBLIC and auto_match is true", async () => {
+  const { env, getInitPayloads, getLobbyUpserts } = createRoomsEnv();
+  const response = await handlePostRooms(
+    new Request("https://example.com/api/rooms", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        visibility: "PUBLIC",
+        auto_match: true,
+        mode: "ARENA",
+        win_metric: "SCORE",
+        play_style: "SP",
+        level_filter: "ANY",
+        max_players: 2,
+        room_comment: "Auto match room",
+      }),
+    }),
+    env,
+  );
+
+  assert.equal(response.status, 201);
+  assert.equal(getInitPayloads().length, 1);
+  assert.equal(getInitPayloads()[0]?.settings.auto_match, true);
+  assert.equal(getLobbyUpserts().length, 0);
+});
+
+test("handlePostRooms keeps lobby upsert when visibility is PUBLIC without auto_match", async () => {
+  const { env, getLobbyUpserts } = createRoomsEnv();
+  const response = await handlePostRooms(
+    new Request("https://example.com/api/rooms", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        visibility: "PUBLIC",
+        mode: "ARENA",
+        win_metric: "SCORE",
+        play_style: "SP",
+        level_filter: "ANY",
+        max_players: 2,
+        room_comment: "Public room",
+      }),
+    }),
+    env,
+  );
+
+  assert.equal(response.status, 201);
+  assert.equal(getLobbyUpserts().length, 1);
+  assert.equal(getLobbyUpserts()[0]?.isPublic, true);
+});

--- a/tasks/issue-156-route-test-split.md
+++ b/tasks/issue-156-route-test-split.md
@@ -1,0 +1,72 @@
+# issue-156-route-test-split
+
+## Purpose
+- `handlePostRooms` の lobby 可視性回帰ケースを route 責務ごとに分離し、失敗時の原因切り分けを早くする。
+- production behavior を変えずに worker route test の保守性を上げる。
+
+## Non-goals
+- 本番ロジック変更
+- visibility モデル再設計
+- client/shared/docs-design/CI/依存更新
+
+## Fixed decisions
+- file naming は `<route-module>.test.mjs`
+- test title は `<handler> <observable behavior> <condition>`
+- 既存 2 ケースの assertion は等価維持
+  - `PUBLIC + auto_match=true` は upsert しない
+  - 通常 `PUBLIC` は upsert を維持
+
+## Changes
+- `apps/worker/src/routes/matchmaking.test.mjs` から `handlePostRooms` の lobby 可視性 2 ケースと rooms 用 helper を分離する
+- `apps/worker/src/routes/rooms.test.mjs` を追加し、`handlePostRooms` の可視性回帰を移す
+- `apps/worker/package.json` の worker test 対象へ `src/routes/rooms.test.mjs` を追加する
+- route/observable behavior 単位で test title を整理する
+
+## Impact
+- Users/runtime: production behavior 変更なし
+- Data/compatibility: 変更なし
+- Cloudflare: 既存 worker test 実行のみで、構成変更なし
+
+## Target Layers / Files
+- layer: worker
+- files:
+  - `apps/worker/src/routes/matchmaking.test.mjs`
+  - `apps/worker/src/routes/rooms.test.mjs`
+  - `apps/worker/package.json`
+
+## Validation Plan
+- `npm run test:worker`
+- `npm --workspace @infinitas/worker run typecheck`
+- `npm run lint`
+- `npm --workspace @infinitas/worker exec wrangler deploy --dry-run`
+
+## Rollback Plan
+- test split 差分をまとめて revert し、従来の `matchmaking.test.mjs` へ戻す
+
+## Commit Split Plan
+1. worker route test split
+2. validation only
+
+## Phase / Spawn Decision
+- Phase A: `READY`
+- Phase B: `READY`
+- execution profile: `Standard`
+- Plan Mode: `NO`
+- Standard Spawn Gate: `APPLICABLE`
+- High-Risk Spawn Gate: `NOT_APPLICABLE`
+
+## Delegation Packet
+- task label: `issue-156-route-test-split`
+- objective: `handlePostRooms` の lobby 可視性回帰を `rooms.test.mjs` へ分離し、route 単位で失敗箇所を判別可能にする
+- in-scope files/layer: worker / `matchmaking.test.mjs`, `rooms.test.mjs`, `package.json`
+- non-goals: 本番ロジック変更、visibility 再設計、cross-layer 変更
+- forbidden scope: `apps/client/**`, `apps/web/**`, `packages/shared/**`, `docs/design/**`, lockfile/依存更新
+- expected output: `matchmaking.test.mjs` から `handlePostRooms` 依存が消え、`rooms.test.mjs` に等価 assertion の 2 ケースが移り、標準 worker test 対象に含まれる
+- validation: 上記 Validation Plan を満たす
+- escalation: contract-sensitive 化、cross-layer 化、CI/依存変更、仕様判断が必要化した場合
+
+## Replan Gate
+- 次のいずれかが発生した場合は Phase C/D を停止し、`WAITING_FOR_HUMAN_DECISION` または `ESCALATION` に戻す
+  - 本番ロジックや公開挙動差分が必要になった場合
+  - worker 単層を超える変更が必須になった場合
+  - CI/依存/契約変更が必要になった場合


### PR DESCRIPTION
## Purpose
- Split the `handlePostRooms` lobby-visibility regression coverage out of `matchmaking.test.mjs` so route-level failures are easier to attribute for Issue #156.
- Preserve production behavior while improving worker route-test maintainability.

## Changes
- Add the Issue #156 execution-boundary artifact in `tasks/issue-156-route-test-split.md`.
- Move the two `handlePostRooms` lobby-visibility regression cases from `apps/worker/src/routes/matchmaking.test.mjs` into new `apps/worker/src/routes/rooms.test.mjs`.
- Add `src/routes/rooms.test.mjs` to the default worker test suite in `apps/worker/package.json`.

## Non-Changes
- No production worker logic changes.
- No visibility model redesign, cross-layer changes, docs/design changes, CI changes, or dependency updates.

## Impact
- User impact: none.
- Data impact: none.
- Compatibility impact: none.
- Cloudflare/infra impact: none.

## Validation
- Commands run:
  - `npm --workspace @infinitas/worker run typecheck`: pass
  - `npm run lint`: pass
  - `npm run test:worker`: pass
  - `npm --workspace @infinitas/worker exec wrangler deploy --dry-run`: pass
  - `git diff --check`: pass
- Notes:
  - No required checks were skipped.

## Regression Checks
- [x] `handlePostRooms` does not upsert lobby when `visibility=PUBLIC` and `auto_match=true`.
- [x] `handlePostRooms` keeps lobby upsert for normal `PUBLIC` rooms.
- [x] The default worker route test suite includes the new `rooms.test.mjs` coverage.

## Risk and Rollback
- Risk level: normal
- Rollback plan: revert `eab0e5b` and `919df0d`, or revert this PR, to restore the previous single-file route test layout.

## Related
- Issue: #156
- Plan item/task label: `issue-156-route-test-split`