### PR TITLE
refactor(client): extract RoomPage compose builders

### DIFF
--- a/apps/client/src/features/room/room-page-compose.test.ts
+++ b/apps/client/src/features/room/room-page-compose.test.ts
@@ -132,6 +132,7 @@ test("buildArenaControlledProps forwards shared and ARENA-specific props", () =>
     playingPhase: "PLAY_START",
     playingCountdownSeconds: 9,
     isHost: true,
+    selfPlayerId: "1",
     searchModal: "modal",
     disablePrimaryAction: false,
     disableLeave: true,
@@ -189,6 +190,7 @@ test("buildArenaControlledProps forwards shared and ARENA-specific props", () =>
   assert.equal(controlled.playingPhase, "PLAY_START");
   assert.equal(controlled.playingCountdownSeconds, 9);
   assert.equal(controlled.isHost, true);
+  assert.equal(controlled.selfPlayerId, "1");
   assert.equal(controlled.searchModal, "modal");
   assert.equal(controlled.disablePrimaryAction, false);
   assert.equal(controlled.disableLeave, true);

--- a/apps/client/src/features/room/room-page-compose.test.ts
+++ b/apps/client/src/features/room/room-page-compose.test.ts
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildArenaControlledProps,
+  buildBplControlledProps,
+} from "./room-page-compose";
+
+test("buildBplControlledProps forwards shared and BPL-specific props", () => {
+  const onPrimaryAction = () => undefined;
+  const onSkip = () => undefined;
+  const onProceedToResult = () => undefined;
+  const onLeaveRoom = () => undefined;
+
+  const controlled = buildBplControlledProps({
+    roomStatus: "PLAYING",
+    isReady: true,
+    closeReason: "ALL_ROUNDS_COMPLETED",
+    resultTimer: 7,
+    showSearch: true,
+    showCutIn: false,
+    lastPickedSong: { title: "Song", artist: "Artist", level: "12" },
+    copiedId: true,
+    copiedCode: false,
+    lobbyTimer: 99,
+    roomId: "room-1",
+    joinCode: "join-1",
+    playTime: 42,
+    playingPhase: "IN_PLAY",
+    playingCountdownSeconds: 13,
+    isHost: false,
+    selfPlayerId: "player-2",
+    searchModal: "search modal",
+    disablePrimaryAction: true,
+    disableLeave: false,
+    onCopyRoomId: () => undefined,
+    onCopyJoinCode: () => undefined,
+    onPrimaryAction,
+    onSkip,
+    onProceedToResult,
+    onLeaveRoom,
+    currentTurn: 1,
+    roundCount: 3,
+    picks: [{ title: "Pick", artist: "Artist", level: "11" }],
+    history: [{ roundIndex: 1 }],
+    playerStatus: { "1": "PLAYED" },
+    playerMetrics: { "1": 123 },
+    metricLabel: "EX SCORE",
+    resultPlayers: { "1": { metricValue: 123, stagePoints: 10, totalPoints: 20, outcome: "WINNER" } },
+    resultRegulationLabel: "4 STAGES",
+    finalResultPlayers: { "1": { totalPoints: 20, isWinner: true } },
+    finalWinningPlayerName: "HOST",
+    players: [{ id: "1", name: "HOST", isReady: true, isHost: true, side: "LEFT" }],
+    roundPickerNames: ["HOST"],
+    battleModeLabel: "SP / NO LIMIT",
+  });
+
+  assert.equal(controlled.roomStatus, "PLAYING");
+  assert.equal(controlled.isReady, true);
+  assert.equal(controlled.closeReason, "ALL_ROUNDS_COMPLETED");
+  assert.equal(controlled.resultTimer, 7);
+  assert.equal(controlled.showSearch, true);
+  assert.equal(controlled.showCutIn, false);
+  assert.deepEqual(controlled.lastPickedSong, { title: "Song", artist: "Artist", level: "12" });
+  assert.equal(controlled.copiedId, true);
+  assert.equal(controlled.copiedCode, false);
+  assert.equal(controlled.lobbyTimer, 99);
+  assert.equal(controlled.roomId, "room-1");
+  assert.equal(controlled.joinCode, "join-1");
+  assert.equal(controlled.playTime, 42);
+  assert.equal(controlled.playingPhase, "IN_PLAY");
+  assert.equal(controlled.playingCountdownSeconds, 13);
+  assert.equal(controlled.isHost, false);
+  assert.equal(controlled.selfPlayerId, "player-2");
+  assert.equal(controlled.searchModal, "search modal");
+  assert.equal(controlled.disablePrimaryAction, true);
+  assert.equal(controlled.disableLeave, false);
+  assert.equal(controlled.onPrimaryAction, onPrimaryAction);
+  assert.equal(controlled.onSkip, onSkip);
+  assert.equal(controlled.onProceedToResult, onProceedToResult);
+  assert.equal(controlled.onLeaveRoom, onLeaveRoom);
+  assert.equal(controlled.currentTurn, 1);
+  assert.equal(controlled.roundCount, 3);
+  assert.deepEqual(controlled.picks, [{ title: "Pick", artist: "Artist", level: "11" }]);
+  assert.deepEqual(controlled.history, [{ roundIndex: 1 }]);
+  assert.deepEqual(controlled.playerStatus, { "1": "PLAYED" });
+  assert.deepEqual(controlled.playerMetrics, { "1": 123 });
+  assert.equal(controlled.metricLabel, "EX SCORE");
+  assert.deepEqual(controlled.resultPlayers, { "1": { metricValue: 123, stagePoints: 10, totalPoints: 20, outcome: "WINNER" } });
+  assert.equal(controlled.resultRegulationLabel, "4 STAGES");
+  assert.deepEqual(controlled.finalResultPlayers, { "1": { totalPoints: 20, isWinner: true } });
+  assert.equal(controlled.finalWinningPlayerName, "HOST");
+  assert.deepEqual(controlled.players, [{ id: "1", name: "HOST", isReady: true, isHost: true, side: "LEFT" }]);
+  assert.deepEqual(controlled.roundPickerNames, ["HOST"]);
+  assert.equal(controlled.battleModeLabel, "SP / NO LIMIT");
+});
+
+test("buildArenaControlledProps forwards shared and ARENA-specific props", () => {
+  const onPrimaryAction = () => undefined;
+  const onSkip = () => undefined;
+  const onProceedToResult = () => undefined;
+  const onLeaveRoom = () => undefined;
+  const onRemakeStage = () => undefined;
+
+  const controlled = buildArenaControlledProps({
+    roomStatus: "RESULT",
+    isReady: false,
+    closeReason: "ALL_ROUNDS_COMPLETED",
+    resultTimer: 5,
+    showSearch: false,
+    showCutIn: true,
+    lastPickedSong: null,
+    copiedId: false,
+    copiedCode: true,
+    lobbyTimer: 88,
+    roomId: "arena-room",
+    joinCode: "arena-join",
+    playTime: 11,
+    playingPhase: "PLAY_START",
+    playingCountdownSeconds: 9,
+    isHost: true,
+    searchModal: "modal",
+    disablePrimaryAction: false,
+    disableLeave: true,
+    onCopyRoomId: () => undefined,
+    onCopyJoinCode: () => undefined,
+    onPrimaryAction,
+    onSkip,
+    onProceedToResult,
+    onLeaveRoom,
+    onRemakeStage,
+    roundCount: 4,
+    history: [{ roundIndex: 2 }],
+    playerPicks: { "1": { title: "Arena Song", artist: "Artist", level: "12" } },
+    currentPlayers: 2,
+    maxPlayers: 4,
+    roomName: "ARENA ROOM",
+    battleModeLabel: "SP / NO LIMIT",
+    regCount: 4,
+    isPrivateRoom: true,
+    logs: [{ id: "log-1", text: "joined" }],
+    matchInfoItems: [{ label: "Mode", value: "ARENA" }],
+    publicSharePanel: "share panel",
+    playerStatus: { "1": "PLAYED" },
+    playerMetrics: { "1": 777 },
+    metricLabel: "EX SCORE",
+    resultSong: { title: "Result Song", artist: "Artist", level: "12" },
+    resultPlayers: { "1": { rank: 1, stagePoints: 10, metricValue: 777, isWinner: true } },
+    durationLabel: "1M 00S",
+    finalResultPlayers: { "1": { rank: 1, totalPoints: 888, isWinner: true } },
+    totalRounds: 4,
+    allPlayers: [{ id: "1", name: "HOST", isReady: true, isHost: true }],
+    selectedByName: "HOST",
+  });
+
+  assert.equal(controlled.roomStatus, "RESULT");
+  assert.equal(controlled.isReady, false);
+  assert.equal(controlled.closeReason, "ALL_ROUNDS_COMPLETED");
+  assert.equal(controlled.resultTimer, 5);
+  assert.equal(controlled.showSearch, false);
+  assert.equal(controlled.showCutIn, true);
+  assert.equal(controlled.lastPickedSong, null);
+  assert.equal(controlled.copiedId, false);
+  assert.equal(controlled.copiedCode, true);
+  assert.equal(controlled.lobbyTimer, 88);
+  assert.equal(controlled.roomId, "arena-room");
+  assert.equal(controlled.joinCode, "arena-join");
+  assert.equal(controlled.playTime, 11);
+  assert.equal(controlled.playingPhase, "PLAY_START");
+  assert.equal(controlled.playingCountdownSeconds, 9);
+  assert.equal(controlled.isHost, true);
+  assert.equal(controlled.searchModal, "modal");
+  assert.equal(controlled.disablePrimaryAction, false);
+  assert.equal(controlled.disableLeave, true);
+  assert.equal(controlled.onPrimaryAction, onPrimaryAction);
+  assert.equal(controlled.onSkip, onSkip);
+  assert.equal(controlled.onProceedToResult, onProceedToResult);
+  assert.equal(controlled.onLeaveRoom, onLeaveRoom);
+  assert.equal(controlled.onRemakeStage, onRemakeStage);
+  assert.equal(controlled.roundCount, 4);
+  assert.deepEqual(controlled.history, [{ roundIndex: 2 }]);
+  assert.deepEqual(controlled.playerPicks, { "1": { title: "Arena Song", artist: "Artist", level: "12" } });
+  assert.equal(controlled.currentPlayers, 2);
+  assert.equal(controlled.maxPlayers, 4);
+  assert.equal(controlled.roomName, "ARENA ROOM");
+  assert.equal(controlled.battleModeLabel, "SP / NO LIMIT");
+  assert.equal(controlled.regCount, 4);
+  assert.equal(controlled.isPrivateRoom, true);
+  assert.deepEqual(controlled.logs, [{ id: "log-1", text: "joined" }]);
+  assert.deepEqual(controlled.matchInfoItems, [{ label: "Mode", value: "ARENA" }]);
+  assert.equal(controlled.publicSharePanel, "share panel");
+  assert.deepEqual(controlled.playerStatus, { "1": "PLAYED" });
+  assert.deepEqual(controlled.playerMetrics, { "1": 777 });
+  assert.equal(controlled.metricLabel, "EX SCORE");
+  assert.deepEqual(controlled.resultSong, { title: "Result Song", artist: "Artist", level: "12" });
+  assert.deepEqual(controlled.resultPlayers, { "1": { rank: 1, stagePoints: 10, metricValue: 777, isWinner: true } });
+  assert.equal(controlled.durationLabel, "1M 00S");
+  assert.deepEqual(controlled.finalResultPlayers, { "1": { rank: 1, totalPoints: 888, isWinner: true } });
+  assert.equal(controlled.totalRounds, 4);
+  assert.deepEqual(controlled.allPlayers, [{ id: "1", name: "HOST", isReady: true, isHost: true }]);
+  assert.equal(controlled.selectedByName, "HOST");
+});

--- a/apps/client/src/features/room/room-page-compose.test.ts
+++ b/apps/client/src/features/room/room-page-compose.test.ts
@@ -41,7 +41,14 @@ test("buildBplControlledProps forwards shared and BPL-specific props", () => {
     currentTurn: 1,
     roundCount: 3,
     picks: [{ title: "Pick", artist: "Artist", level: "11" }],
-    history: [{ roundIndex: 1 }],
+    history: [
+      {
+        round: 1,
+        song: { title: "History Song", artist: "Artist", level: "10" },
+        scores: { "1": 1000, "2": 900 },
+        winnerId: "1",
+      },
+    ],
     playerStatus: { "1": "PLAYED" },
     playerMetrics: { "1": 123 },
     metricLabel: "EX SCORE",
@@ -81,7 +88,14 @@ test("buildBplControlledProps forwards shared and BPL-specific props", () => {
   assert.equal(controlled.currentTurn, 1);
   assert.equal(controlled.roundCount, 3);
   assert.deepEqual(controlled.picks, [{ title: "Pick", artist: "Artist", level: "11" }]);
-  assert.deepEqual(controlled.history, [{ roundIndex: 1 }]);
+  assert.deepEqual(controlled.history, [
+    {
+      round: 1,
+      song: { title: "History Song", artist: "Artist", level: "10" },
+      scores: { "1": 1000, "2": 900 },
+      winnerId: "1",
+    },
+  ]);
   assert.deepEqual(controlled.playerStatus, { "1": "PLAYED" });
   assert.deepEqual(controlled.playerMetrics, { "1": 123 });
   assert.equal(controlled.metricLabel, "EX SCORE");
@@ -129,7 +143,14 @@ test("buildArenaControlledProps forwards shared and ARENA-specific props", () =>
     onLeaveRoom,
     onRemakeStage,
     roundCount: 4,
-    history: [{ roundIndex: 2 }],
+    history: [
+      {
+        round: 2,
+        song: { title: "Arena History Song", artist: "Artist", level: "11" },
+        scores: { "1": 1200, "2": 1100, "3": 1000, "4": 900 },
+        winnerId: "1",
+      },
+    ],
     playerPicks: { "1": { title: "Arena Song", artist: "Artist", level: "12" } },
     currentPlayers: 2,
     maxPlayers: 4,
@@ -177,7 +198,14 @@ test("buildArenaControlledProps forwards shared and ARENA-specific props", () =>
   assert.equal(controlled.onLeaveRoom, onLeaveRoom);
   assert.equal(controlled.onRemakeStage, onRemakeStage);
   assert.equal(controlled.roundCount, 4);
-  assert.deepEqual(controlled.history, [{ roundIndex: 2 }]);
+  assert.deepEqual(controlled.history, [
+    {
+      round: 2,
+      song: { title: "Arena History Song", artist: "Artist", level: "11" },
+      scores: { "1": 1200, "2": 1100, "3": 1000, "4": 900 },
+      winnerId: "1",
+    },
+  ]);
   assert.deepEqual(controlled.playerPicks, { "1": { title: "Arena Song", artist: "Artist", level: "12" } });
   assert.equal(controlled.currentPlayers, 2);
   assert.equal(controlled.maxPlayers, 4);

--- a/apps/client/src/features/room/room-page-compose.ts
+++ b/apps/client/src/features/room/room-page-compose.ts
@@ -1,0 +1,186 @@
+import type { ReactNode } from "react";
+import type {
+  RoomArenaControlledState,
+  RoomArenaLogEntry,
+  RoomArenaMatchInfoItem,
+  RoomArenaPlayer,
+} from "../../components/RoomArena";
+import type {
+  RoomBPLControlledState,
+  RoomBPLPlayer,
+} from "../../components/RoomBPL";
+import type { RoomSong } from "./presentation-shared";
+
+export type RoomPageSharedComposeInput = {
+  roomStatus: RoomArenaControlledState["roomStatus"];
+  isReady: boolean;
+  closeReason: string;
+  resultTimer: number;
+  showSearch: boolean;
+  showCutIn: boolean;
+  lastPickedSong: RoomSong | null;
+  copiedId: boolean;
+  copiedCode: boolean;
+  lobbyTimer: number;
+  roomId: string;
+  joinCode: string;
+  playTime: number;
+  playingPhase: RoomArenaControlledState["playingPhase"];
+  playingCountdownSeconds: number | null;
+  isHost: boolean;
+  selfPlayerId: string;
+  searchModal: ReactNode;
+  disablePrimaryAction: boolean;
+  disableLeave: boolean;
+  onCopyRoomId: () => void;
+  onCopyJoinCode: () => void;
+  onPrimaryAction: () => void;
+  onSkip: (playerId: string) => void;
+  onProceedToResult: () => void;
+  onLeaveRoom: () => void;
+  onRemakeStage?: () => void;
+};
+
+export type RoomPageBplComposeInput = RoomPageSharedComposeInput & {
+  currentTurn: number;
+  roundCount: number;
+  picks: (RoomSong | null)[];
+  history: RoomBPLControlledState["history"];
+  playerStatus: RoomBPLControlledState["playerStatus"];
+  playerMetrics?: RoomBPLControlledState["playerMetrics"];
+  metricLabel?: string;
+  resultPlayers?: RoomBPLControlledState["resultPlayers"];
+  resultRegulationLabel?: string;
+  finalResultPlayers?: RoomBPLControlledState["finalResultPlayers"];
+  finalWinningPlayerName?: string;
+  players: RoomBPLPlayer[];
+  roundPickerNames?: RoomBPLControlledState["roundPickerNames"];
+  battleModeLabel?: string;
+};
+
+export type RoomPageArenaComposeInput = RoomPageSharedComposeInput & {
+  roundCount: number;
+  history: RoomArenaControlledState["history"];
+  playerPicks: RoomArenaControlledState["playerPicks"];
+  currentPlayers: number;
+  maxPlayers: number;
+  roomName?: string;
+  battleModeLabel?: string;
+  regCount?: number;
+  isPrivateRoom?: boolean;
+  pickingCountdownSeconds?: number | null;
+  logs?: RoomArenaLogEntry[];
+  matchInfoItems?: RoomArenaMatchInfoItem[];
+  publicSharePanel?: ReactNode;
+  playerStatus: RoomArenaControlledState["playerStatus"];
+  playerMetrics?: RoomArenaControlledState["playerMetrics"];
+  metricLabel?: string;
+  resultSong?: RoomArenaControlledState["resultSong"];
+  resultPlayers?: RoomArenaControlledState["resultPlayers"];
+  durationLabel?: string;
+  finalResultPlayers?: RoomArenaControlledState["finalResultPlayers"];
+  totalRounds?: number;
+  allPlayers: RoomArenaPlayer[];
+  selectedByName?: string | null;
+  onToggleReady?: () => void;
+};
+
+function buildSharedControlledProps(input: RoomPageSharedComposeInput) {
+  const shared = {
+    roomStatus: input.roomStatus,
+    isReady: input.isReady,
+    closeReason: input.closeReason,
+    resultTimer: input.resultTimer,
+    showSearch: input.showSearch,
+    showCutIn: input.showCutIn,
+    lastPickedSong: input.lastPickedSong,
+    copiedId: input.copiedId,
+    copiedCode: input.copiedCode,
+    lobbyTimer: input.lobbyTimer,
+    roomId: input.roomId,
+    joinCode: input.joinCode,
+    playTime: input.playTime,
+    playingPhase: input.playingPhase,
+    playingCountdownSeconds: input.playingCountdownSeconds,
+    isHost: input.isHost,
+  };
+
+  return {
+    ...shared,
+    ...(input.selfPlayerId === undefined ? {} : { selfPlayerId: input.selfPlayerId }),
+    ...(input.searchModal === undefined ? {} : { searchModal: input.searchModal }),
+    ...(input.disablePrimaryAction === undefined ? {} : { disablePrimaryAction: input.disablePrimaryAction }),
+    ...(input.disableLeave === undefined ? {} : { disableLeave: input.disableLeave }),
+    ...(input.onCopyRoomId === undefined ? {} : { onCopyRoomId: input.onCopyRoomId }),
+    ...(input.onCopyJoinCode === undefined ? {} : { onCopyJoinCode: input.onCopyJoinCode }),
+    ...(input.onPrimaryAction === undefined ? {} : { onPrimaryAction: input.onPrimaryAction }),
+    ...(input.onSkip === undefined ? {} : { onSkip: input.onSkip }),
+    ...(input.onProceedToResult === undefined ? {} : { onProceedToResult: input.onProceedToResult }),
+    ...(input.onLeaveRoom === undefined ? {} : { onLeaveRoom: input.onLeaveRoom }),
+    ...(input.onRemakeStage === undefined ? {} : { onRemakeStage: input.onRemakeStage }),
+  };
+}
+
+export function buildBplControlledProps(
+  input: RoomPageBplComposeInput,
+): RoomBPLControlledState {
+  const controlled = {
+    ...buildSharedControlledProps(input),
+    currentTurn: input.currentTurn,
+    roundCount: input.roundCount,
+    picks: input.picks,
+    history: input.history,
+    playerStatus: input.playerStatus,
+    players: input.players,
+  };
+
+  return {
+    ...controlled,
+    ...(input.playerMetrics === undefined ? {} : { playerMetrics: input.playerMetrics }),
+    ...(input.metricLabel === undefined ? {} : { metricLabel: input.metricLabel }),
+    ...(input.resultPlayers === undefined ? {} : { resultPlayers: input.resultPlayers }),
+    ...(input.resultRegulationLabel === undefined ? {} : { resultRegulationLabel: input.resultRegulationLabel }),
+    ...(input.finalResultPlayers === undefined ? {} : { finalResultPlayers: input.finalResultPlayers }),
+    ...(input.finalWinningPlayerName === undefined ? {} : { finalWinningPlayerName: input.finalWinningPlayerName }),
+    ...(input.roundPickerNames === undefined ? {} : { roundPickerNames: input.roundPickerNames }),
+    ...(input.battleModeLabel === undefined ? {} : { battleModeLabel: input.battleModeLabel }),
+  };
+}
+
+export function buildArenaControlledProps(
+  input: RoomPageArenaComposeInput,
+): RoomArenaControlledState {
+  const controlled = {
+    ...buildSharedControlledProps(input),
+    roundCount: input.roundCount,
+    history: input.history,
+    playerPicks: input.playerPicks,
+    currentPlayers: input.currentPlayers,
+    maxPlayers: input.maxPlayers,
+    playerStatus: input.playerStatus,
+    allPlayers: input.allPlayers,
+  };
+
+  return {
+    ...controlled,
+    ...(input.roomName === undefined ? {} : { roomName: input.roomName }),
+    ...(input.battleModeLabel === undefined ? {} : { battleModeLabel: input.battleModeLabel }),
+    ...(input.regCount === undefined ? {} : { regCount: input.regCount }),
+    ...(input.isPrivateRoom === undefined ? {} : { isPrivateRoom: input.isPrivateRoom }),
+    ...(input.pickingCountdownSeconds === undefined
+      ? {}
+      : { pickingCountdownSeconds: input.pickingCountdownSeconds }),
+    ...(input.logs === undefined ? {} : { logs: input.logs }),
+    ...(input.matchInfoItems === undefined ? {} : { matchInfoItems: input.matchInfoItems }),
+    ...(input.publicSharePanel === undefined ? {} : { publicSharePanel: input.publicSharePanel }),
+    ...(input.playerMetrics === undefined ? {} : { playerMetrics: input.playerMetrics }),
+    ...(input.metricLabel === undefined ? {} : { metricLabel: input.metricLabel }),
+    ...(input.resultSong === undefined ? {} : { resultSong: input.resultSong }),
+    ...(input.resultPlayers === undefined ? {} : { resultPlayers: input.resultPlayers }),
+    ...(input.durationLabel === undefined ? {} : { durationLabel: input.durationLabel }),
+    ...(input.finalResultPlayers === undefined ? {} : { finalResultPlayers: input.finalResultPlayers }),
+    ...(input.totalRounds === undefined ? {} : { totalRounds: input.totalRounds }),
+    ...(input.selectedByName === undefined ? {} : { selectedByName: input.selectedByName }),
+    ...(input.onToggleReady === undefined ? {} : { onToggleReady: input.onToggleReady }),
+  };
+}

--- a/apps/client/src/pages/RoomPage.tsx
+++ b/apps/client/src/pages/RoomPage.tsx
@@ -49,6 +49,10 @@ import {
   type RoomBPLPlayer,
 } from "../components/RoomBPL";
 import {
+  buildArenaControlledProps,
+  buildBplControlledProps,
+} from "../features/room/room-page-compose";
+import {
   resolveSongVersionDbValue,
   resolveSongVersionLabel,
   SongSearchModalView,
@@ -2680,7 +2684,7 @@ export function RoomPage() {
             : historyRounds.length > 0
               ? historyRounds[historyRounds.length - 1]!.roundIndex + 1
               : 1;
-      const controlledProps: RoomBPLControlledState = {
+      const controlledProps: RoomBPLControlledState = buildBplControlledProps({
         roomStatus: bplRoomStatus,
         isReady: isHost ? true : me?.ready ?? false,
         closeReason: snapshot.close_reason ?? "ALL_ROUNDS_COMPLETED",
@@ -2690,39 +2694,25 @@ export function RoomPage() {
               ? finalMatchResultCountdownSeconds ?? BPL_RESULT_PHASE_SECONDS
               : bplLeadInSeconds
             : resultCountdown ?? BPL_RESULT_PHASE_SECONDS,
-        currentTurn: activeBplPickIndex ?? 0,
-        roundCount: bplRoundCount,
-        picks: bplPicks,
-        history: bplHistory,
         showSearch: showPickerModal,
-        lastPickedSong: lastMockPickedSong,
         showCutIn: ownPickCutInChart !== null,
+        lastPickedSong: lastMockPickedSong,
         copiedId: copiedRoomId,
         copiedCode: copiedJoinCode,
         lobbyTimer: getRemainingSeconds(getIsoTimeMs(snapshot.timers.ready_check_deadline), clockNowMs) ?? 0,
         roomId: roomIdLabel,
         joinCode: joinCodeLabel,
-        battleModeLabel: formatRegulationLabel(snapshot.settings.play_style, snapshot.settings.level_filter),
         playTime: playElapsedSeconds,
         playingPhase: mockPlayingPhase,
         playingCountdownSeconds: playingCountdown?.remainingSeconds ?? null,
-        playerStatus: bplPlayerStatus,
-        playerMetrics: bplPlayerMetrics,
-        metricLabel: bplMetricLabel,
-        resultPlayers: bplResultPlayers,
-        resultRegulationLabel: getBplStageLabel(snapshot.settings.mode),
-        finalResultPlayers: bplFinalResultPlayers,
-        finalWinningPlayerName: bplWinningPlayerName,
         isHost,
-        players: bplPlayers,
-        roundPickerNames: bplRoundPickerNames,
         selfPlayerId: selfMockPlayerId ?? (isHost ? "1" : "2"),
+        searchModal: pickerModal,
         disablePrimaryAction:
           snapshot.room_state !== "LOBBY" ||
           snapshot.settings.auto_match === true ||
           (isHost && lobbyStartIssues.length > 0),
         disableLeave: leaveRoomDisabled,
-        searchModal: pickerModal,
         onCopyRoomId: () => roomIdCopy.copy(roomIdLabel),
         onCopyJoinCode: () => joinCodeCopy.copy(joinCodeLabel),
         onPrimaryAction: onPrimaryRoomAction,
@@ -2734,7 +2724,21 @@ export function RoomPage() {
         },
         onLeaveRoom: requestLeaveRoom,
         ...(snapshot.settings.auto_match === true ? {} : { onRemakeStage: onReturnToLobby }),
-      };
+        currentTurn: activeBplPickIndex ?? 0,
+        roundCount: bplRoundCount,
+        picks: bplPicks,
+        history: bplHistory,
+        battleModeLabel: formatRegulationLabel(snapshot.settings.play_style, snapshot.settings.level_filter),
+        playerStatus: bplPlayerStatus,
+        playerMetrics: bplPlayerMetrics,
+        metricLabel: bplMetricLabel,
+        resultPlayers: bplResultPlayers,
+        resultRegulationLabel: getBplStageLabel(snapshot.settings.mode),
+        finalResultPlayers: bplFinalResultPlayers,
+        finalWinningPlayerName: bplWinningPlayerName,
+        players: bplPlayers,
+        roundPickerNames: bplRoundPickerNames,
+      });
 
       return <RoomBPLPresentational {...controlledProps} />;
     }
@@ -2761,7 +2765,7 @@ export function RoomPage() {
           : historyRounds.length > 0
             ? historyRounds[historyRounds.length - 1]!.roundIndex + 1
             : 1;
-    const controlledProps: RoomArenaControlledState = {
+    const controlledProps: RoomArenaControlledState = buildArenaControlledProps({
       roomStatus: arenaRoomStatus,
       isReady: isHost ? true : me?.ready ?? false,
       closeReason: snapshot.close_reason ?? "ALL_ROUNDS_COMPLETED",
@@ -2771,41 +2775,18 @@ export function RoomPage() {
             ? finalMatchResultCountdownSeconds ?? ARENA_RESULT_PHASE_SECONDS
             : arenaLeadInSeconds
           : resultCountdown ?? ARENA_RESULT_PHASE_SECONDS,
-      roundCount: arenaRoundCount,
-      history: arenaHistory,
-      playerPicks: arenaPicks,
       showSearch: showPickerModal,
       showCutIn: ownPickCutInChart !== null,
       lastPickedSong: lastMockPickedSong,
       copiedId: copiedRoomId,
       copiedCode: copiedJoinCode,
       lobbyTimer: getRemainingSeconds(getIsoTimeMs(snapshot.timers.ready_check_deadline), clockNowMs) ?? 0,
-      currentPlayers: snapshot.players.length,
-      maxPlayers: snapshot.settings.max_players,
-      roomName: arenaRoomName,
-      battleModeLabel: arenaBattleModeLabel,
-      regCount: arenaRegCount,
-      isPrivateRoom: snapshot.settings.visibility === "PRIVATE",
       roomId: roomIdLabel,
       joinCode: joinCodeLabel,
-      pickingCountdownSeconds: pickingCountdown ?? 0,
-      logs: arenaLobbyLogs,
-      matchInfoItems: arenaMatchInfoItems,
-      publicSharePanel,
       playTime: playElapsedSeconds,
       playingPhase: mockPlayingPhase,
       playingCountdownSeconds: playingCountdown?.remainingSeconds ?? null,
-      playerStatus: arenaPlayerStatus,
-      playerMetrics: arenaPlayerMetrics,
-      metricLabel: arenaMetricLabel,
-      resultSong: arenaResultSong,
-      resultPlayers: arenaResultPlayers,
-      durationLabel: arenaFinalDurationLabel,
-      finalResultPlayers: arenaFinalResultPlayers,
-      totalRounds: arenaTotalRounds,
       isHost,
-      allPlayers: arenaPlayers,
-      selectedByName: arenaCurrentRoundPickerName,
       selfPlayerId: selfMockPlayerId ?? (isHost ? "1" : "2"),
       searchModal: pickerModal,
       disablePrimaryAction:
@@ -2816,7 +2797,6 @@ export function RoomPage() {
       onCopyRoomId: () => roomIdCopy.copy(roomIdLabel),
       onCopyJoinCode: () => joinCodeCopy.copy(joinCodeLabel),
       onPrimaryAction: onPrimaryRoomAction,
-      onToggleReady: onPrimaryRoomAction,
       onSkip: onMockSkip,
       onProceedToResult: () => {
         if (currentRound) {
@@ -2825,7 +2805,31 @@ export function RoomPage() {
       },
       onLeaveRoom: requestLeaveRoom,
       ...(snapshot.settings.auto_match === true ? {} : { onRemakeStage: onReturnToLobby }),
-    };
+      roundCount: arenaRoundCount,
+      history: arenaHistory,
+      playerPicks: arenaPicks,
+      currentPlayers: snapshot.players.length,
+      maxPlayers: snapshot.settings.max_players,
+      roomName: arenaRoomName,
+      battleModeLabel: arenaBattleModeLabel,
+      regCount: arenaRegCount,
+      isPrivateRoom: snapshot.settings.visibility === "PRIVATE",
+      pickingCountdownSeconds: pickingCountdown ?? 0,
+      logs: arenaLobbyLogs,
+      matchInfoItems: arenaMatchInfoItems,
+      publicSharePanel,
+      playerStatus: arenaPlayerStatus,
+      playerMetrics: arenaPlayerMetrics,
+      metricLabel: arenaMetricLabel,
+      resultSong: arenaResultSong,
+      resultPlayers: arenaResultPlayers,
+      durationLabel: arenaFinalDurationLabel,
+      finalResultPlayers: arenaFinalResultPlayers,
+      totalRounds: arenaTotalRounds,
+      allPlayers: arenaPlayers,
+      selectedByName: arenaCurrentRoundPickerName,
+      onToggleReady: onPrimaryRoomAction,
+    });
 
     return <RoomArenaPresentational {...controlledProps} />;
   })();

--- a/tasks/issue-160-roompage-compose-builder.md
+++ b/tasks/issue-160-roompage-compose-builder.md
@@ -1,0 +1,73 @@
+# issue-160-roompage-compose-builder
+
+## Purpose
+- `RoomPage` に残る ARENA/BPL の non-contract-sensitive compose props 組み立てを helper / builder へ寄せ、差分ズレ回帰リスクを下げる。
+- `roomStatus` / `roundCount` / `resultTimer` の既存意味を変えずに、client-only の reviewable な整理へ留める。
+
+## Non-goals
+- `roomStatus` / `roundCount` / `resultTimer` / `CloseReason` の意味変更や共通化
+- `RoomArena.tsx` / `RoomBPL.tsx` の presentational contract 変更
+- worker/shared/docs-design/依存更新
+- UI デザイン変更
+
+## Fixed decisions
+- `roomStatus` / `resultTimer` / `roundCount` は引き続き `RoomPage.tsx` で導出し、builder へ opaque input として渡す
+- 共通化対象は non-contract-sensitive compose 領域のみに限定する
+- 新規 helper は `apps/client/src/features/room/room-page-compose.ts` に置く
+- テストは `apps/client/src/features/room/room-page-compose.test.ts` を追加し、workspace script は増やさない
+
+## Changes
+- `apps/client/src/features/room/room-page-compose.ts` を追加し、ARENA/BPL 共通の compose 入力から shared props を組み立てる internal helper と `buildArenaControlledProps` / `buildBplControlledProps` を実装する
+- `apps/client/src/pages/RoomPage.tsx` で ARENA/BPL の controlled props 組み立てに builder を使い、mode 固有 payload のみを inline に残す
+- `apps/client/src/features/room/room-page-compose.test.ts` を追加し、copy flags / lobbyTimer / action wiring / optional `onRemakeStage` を中心に builder の回帰を固定する
+
+## Impact
+- Users/runtime: 表示・操作挙動は維持したまま、`RoomPage` の重複 compose ロジックを縮小する
+- Data/compatibility: 変更なし
+- Cloudflare: 影響なし
+
+## Target Layers / Files
+- layer: client
+- files:
+  - `apps/client/src/pages/RoomPage.tsx`
+  - `apps/client/src/features/room/room-page-compose.ts`
+  - `apps/client/src/features/room/room-page-compose.test.ts`
+
+## Validation Plan
+- `npm --workspace @infinitas/client run typecheck`
+- `npm run lint`
+- `npm --workspace @infinitas/client exec tsx --test src/features/room/room-page-compose.test.ts src/features/room/presentation-shared.test.ts`
+- `npm --workspace @infinitas/client exec tsx --test src/dev/visual-scenarios.test.ts`
+- ARENA/BPL visual scenario で `WAITING / SELECTING / PLAYING / RESULT / CLOSED` の copy feedback / lobby timer / disable flags / action wiring parity を確認する
+
+## Rollback Plan
+- `room-page-compose.ts` 導入差分をまとめて revert し、`RoomPage.tsx` 内の従来 compose 実装へ戻す
+
+## Commit Split Plan
+1. `tasks` artifact と builder / test 追加
+2. `RoomPage.tsx` の builder 適用
+3. validation only
+
+## Phase / Spawn Decision
+- Phase A: `READY`
+- Phase B: `READY`
+- execution profile: `Standard`
+- Plan Mode: `NO`
+- Standard Spawn Gate: `APPLICABLE`
+- High-Risk Spawn Gate: `NOT_APPLICABLE`
+
+## Delegation Packet
+- task label: `issue-160-roompage-compose-builder`
+- objective: `RoomPage` の ARENA/BPL non-contract-sensitive compose props を builder へ抽出し、現行挙動を維持する
+- in-scope files/layer: client / `RoomPage.tsx`, `room-page-compose.ts`, `room-page-compose.test.ts`
+- non-goals: contract-sensitive derivation 変更、presentational contract 変更、worker/shared/docs-design/依存更新
+- forbidden scope: `apps/worker/**`, `packages/shared/**`, `docs/design/**`, `apps/client/src/components/RoomArena.tsx`, `apps/client/src/components/RoomBPL.tsx`, lockfile/依存更新
+- expected output: `RoomPage.tsx` の shared compose 部が builder 利用へ置換され、mode 固有差分のみ inline に残る
+- validation: 上記 Validation Plan を満たす
+- escalation: `roomStatus` / `roundCount` / `resultTimer` / `CloseReason` の意味変更、cross-layer 化、controlled prop contract 拡張、仕様判断が必要化した場合
+
+## Replan Gate
+- 次のいずれかが発生した場合は Phase C/D を停止し、`WAITING_FOR_HUMAN_DECISION` または `ESCALATION` に戻す
+  - contract-sensitive derivation の意味変更が必要になった場合
+  - `apps/worker` / `packages/shared` / `docs/design/*` の更新が必要になった場合
+  - presentational contract 拡張なしでは parity を維持できない場合


### PR DESCRIPTION
## Purpose
- Reduce duplicated non-contract-sensitive controlled-prop assembly in `RoomPage` for ARENA/BPL.
- Keep `roomStatus`, `roundCount`, `resultTimer`, and `CloseReason` semantics unchanged while moving shared compose wiring into dedicated builders.

## Changes
- Add `apps/client/src/features/room/room-page-compose.ts` with `buildBplControlledProps` / `buildArenaControlledProps` and a shared compose helper.
- Add `apps/client/src/features/room/room-page-compose.test.ts` to pin builder forwarding behavior.
- Update `apps/client/src/pages/RoomPage.tsx` to use the new builders while leaving mode-specific and contract-adjacent derivation inline.
- Materialize `tasks/issue-160-roompage-compose-builder.md` as the execution-boundary artifact for Issue #160.

## Non-Changes
- No changes to `apps/client/src/components/RoomArena.tsx` or `apps/client/src/components/RoomBPL.tsx`.
- No worker/shared/docs-design changes.
- No semantic changes to `roomStatus`, `roundCount`, `resultTimer`, or `CloseReason`.

## Impact
- User impact: none expected beyond internal refactor; ARENA/BPL behavior should remain unchanged.
- Data impact: none.
- Compatibility impact: none.
- Cloudflare/infra impact: none.

## Validation
- Commands run:
  - `npm --workspace @infinitas/client run typecheck`: pass
  - `npm run lint`: pass
  - `npm --workspace @infinitas/client exec tsx --test src/features/room/room-page-compose.test.ts src/features/room/presentation-shared.test.ts`: pass
  - `npm --workspace @infinitas/client exec tsx --test src/dev/visual-scenarios.test.ts`: pass
- Notes:
  - `npm exec tsx --test ...` emits npm warnings about `--test` parsing, but the tests themselves passed.
  - Manual visual parity was checked via headless Edge screenshots and DOM dumps for BPL / ARENA / CLOSED scenarios covering `WAITING / SELECTING / PLAYING / RESULT / CLOSED`.

## Regression Checks
- [x] BPL lobby / picking / playing / final result visual scenarios render as expected.
- [x] Arena lobby / picking / playing / result visual scenarios render as expected.
- [x] Closed room scenario renders as expected.
- [x] Room ID / Join Code copy controls remain present.
- [x] Lobby timer and key disabled states remain present in rendered output.

## Risk and Rollback
- Risk level: normal
- Rollback plan: revert `9369300` and `6f2c8ca` to restore the prior inline `RoomPage` compose logic and remove the task artifact.

## Related
- Issue: #160
- Plan item/task label: `issue-160-roompage-compose-builder`
