### PR TITLE
refactor(client): unify difficulty presentation metadata

### DIFF
--- a/apps/client/src/components/SongSearchModalView.tsx
+++ b/apps/client/src/components/SongSearchModalView.tsx
@@ -1,13 +1,9 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Search, Music, ChevronDown, ChevronRight } from 'lucide-react';
-
-export const DIFFICULTIES = [
-    { id: 'B', name: 'BEGINNER', color: 'bg-green-500' },
-    { id: 'N', name: 'NORMAL', color: 'bg-blue-500' },
-    { id: 'H', name: 'HYPER', color: 'bg-yellow-500' },
-    { id: 'A', name: 'ANOTHER', color: 'bg-red-500' },
-    { id: 'L', name: 'LEGGENDARIA', color: 'bg-purple-600' },
-] as const;
+import {
+    DIFFICULTY_PRESENTATIONS,
+    resolveDifficultyPresentation,
+} from '../features/room/presentation-shared';
 
 export const LEVELS = Array.from({ length: 12 }, (_, i) => i + 1);
 
@@ -97,6 +93,10 @@ const VERSION_LABEL_LOOKUP = new Map<string, string>(
 const VERSION_DB_VALUE_BY_LABEL = new Map<string, string>(
     Object.entries(VERSION_LABEL_BY_DB_VALUE).map(([dbValue, label]) => [label.toUpperCase(), dbValue]),
 );
+
+function getSongDifficultyPresentation(difficulty: string | null | undefined) {
+    return resolveDifficultyPresentation(difficulty);
+}
 
 export function resolveSongVersionLabel(version: string | null | undefined): string | null {
     if (typeof version !== 'string') {
@@ -338,16 +338,16 @@ export function SongSearchModalView({
                         <div>
                             <span className="text-[10px] font-black text-gray-500 uppercase tracking-widest mb-1.5 block">Difficulty</span>
                             <div className="flex gap-2">
-                                {DIFFICULTIES.map(diff => (
+                                {DIFFICULTY_PRESENTATIONS.map(diff => (
                                     <button
-                                        key={diff.id}
-                                        onClick={() => onToggleDiff(diff.id)}
-                                        className={`flex-1 py-1.5 rounded-lg font-black italic text-xs transition-all border-2 ${selectedDiff === diff.id
-                                            ? `${diff.color} border-white text-white scale-105 shadow-lg`
+                                        key={diff.shortLabel}
+                                        onClick={() => onToggleDiff(diff.shortLabel)}
+                                        className={`flex-1 py-1.5 rounded-lg font-black italic text-xs transition-all border-2 ${selectedDiff === diff.shortLabel
+                                            ? `${diff.colorClass} border-white text-white scale-105 shadow-lg`
                                             : `bg-white/5 border-transparent text-gray-500 hover:bg-white/10`
                                             }`}
                                     >
-                                        {diff.id}
+                                        {diff.shortLabel}
                                     </button>
                                 ))}
                             </div>
@@ -376,40 +376,43 @@ export function SongSearchModalView({
                 <div ref={listViewportRef} className="flex-1 overflow-y-auto p-4 space-y-2 custom-scrollbar">
                     {displayedSongs.length > 0 ? (
                         <>
-                            {displayedSongs.map(song => (
-                                <button
-                                    key={song.id ?? `${song.title}:${song.difficulty}:${song.level}`}
-                                    onClick={() => onSelect(song)}
-                                    className="w-full group bg-white/5 hover:bg-white/10 border border-white/5 hover:border-cyan-500/50 rounded-xl p-4 flex items-center gap-4 transition-all text-left"
-                                >
-                                    <div className="w-16 h-16 bg-[#252526] rounded-lg flex-shrink-0 relative overflow-hidden flex items-center justify-center border border-white/5">
-                                        <Music size={24} className="text-gray-700" />
-                                        <div className={`absolute bottom-0 right-0 left-0 h-1 ${DIFFICULTIES.find(d => d.id === song.difficulty)?.color ?? 'bg-slate-500'
-                                            }`} />
-                                    </div>
-
-                                    <div className="flex-1 overflow-hidden">
-                                        <div className="flex items-center gap-2 mb-1">
-                                            <span className={`text-[10px] font-black px-1.5 py-0.5 rounded text-white ${DIFFICULTIES.find(d => d.id === song.difficulty)?.color ?? 'bg-slate-500'
-                                                }`}>
-                                                {song.difficulty}
-                                            </span>
-                                            <span className="text-[10px] font-black text-cyan-500 tracking-widest uppercase">{song.genre ?? '-'}</span>
+                            {displayedSongs.map(song => {
+                                const difficultyPresentation = getSongDifficultyPresentation(song.difficulty);
+                                return (
+                                    <button
+                                        key={song.id ?? `${song.title}:${song.difficulty}:${song.level}`}
+                                        onClick={() => onSelect(song)}
+                                        className="w-full group bg-white/5 hover:bg-white/10 border border-white/5 hover:border-cyan-500/50 rounded-xl p-4 flex items-center gap-4 transition-all text-left"
+                                    >
+                                        <div className="w-16 h-16 bg-[#252526] rounded-lg flex-shrink-0 relative overflow-hidden flex items-center justify-center border border-white/5">
+                                            <Music size={24} className="text-gray-700" />
+                                            <div className={`absolute bottom-0 right-0 left-0 h-1 ${difficultyPresentation?.colorClass ?? 'bg-slate-500'
+                                                }`} />
                                         </div>
-                                        <h3 className="text-lg font-black italic tracking-tighter truncate leading-tight text-white group-hover:text-cyan-400 transition-colors">
-                                            {song.title}
-                                        </h3>
-                                        <p className="text-xs font-bold text-gray-400 truncate group-hover:text-gray-300 transition-colors">{song.artist}</p>
-                                    </div>
 
-                                    <div className="text-right">
-                                        <div className="text-2xl font-black italic tracking-tighter text-gray-500 group-hover:text-white transition-colors">
-                                            Lv{song.level}
+                                        <div className="flex-1 overflow-hidden">
+                                            <div className="flex items-center gap-2 mb-1">
+                                                <span className={`text-[10px] font-black px-1.5 py-0.5 rounded text-white ${difficultyPresentation?.colorClass ?? 'bg-slate-500'
+                                                    }`}>
+                                                    {difficultyPresentation?.shortLabel ?? song.difficulty}
+                                                </span>
+                                                <span className="text-[10px] font-black text-cyan-500 tracking-widest uppercase">{song.genre ?? '-'}</span>
+                                            </div>
+                                            <h3 className="text-lg font-black italic tracking-tighter truncate leading-tight text-white group-hover:text-cyan-400 transition-colors">
+                                                {song.title}
+                                            </h3>
+                                            <p className="text-xs font-bold text-gray-400 truncate group-hover:text-gray-300 transition-colors">{song.artist}</p>
                                         </div>
-                                        <ChevronRight size={16} className="text-gray-700 group-hover:text-cyan-500 ml-auto transition-colors" />
-                                    </div>
-                                </button>
-                            ))}
+
+                                        <div className="text-right">
+                                            <div className="text-2xl font-black italic tracking-tighter text-gray-500 group-hover:text-white transition-colors">
+                                                Lv{song.level}
+                                            </div>
+                                            <ChevronRight size={16} className="text-gray-700 group-hover:text-cyan-500 ml-auto transition-colors" />
+                                        </div>
+                                    </button>
+                                );
+                            })}
                             {hasMore || isLoadingMore ? (
                                 <div ref={loadMoreRef} className="flex items-center justify-center py-4 text-[10px] font-black uppercase tracking-[0.2em] text-gray-500">
                                     {isLoadingMore ? 'Loading More...' : 'Scroll To Load More'}

--- a/apps/client/src/features/room/presentation-shared.test.ts
+++ b/apps/client/src/features/room/presentation-shared.test.ts
@@ -1,14 +1,20 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  DIFFICULTY_PRESENTATIONS,
   buildPresentationPlayerMaps,
   formatCountdown,
   formatOrdinal,
   formatRankLabel,
   getDifficultyBadgeClass,
   getDifficultyBadgeLabel,
+  getDifficultyFromShortLabel,
+  getDifficultyPresentation,
+  getDifficultyPresentationByShortLabel,
+  getDifficultyShortLabel,
   maskJoinCode,
   normalizeRoomPlayerStatus,
+  resolveDifficultyPresentation,
 } from "./presentation-shared";
 
 test("maskJoinCode preserves length", () => {
@@ -36,9 +42,31 @@ test("formatRankLabel supports null ranks", () => {
   assert.equal(formatRankLabel(4), "4th");
 });
 
-test("difficulty badge helpers map known labels", () => {
+test("difficulty presentation helpers share a single canonical mapping", () => {
+  assert.equal(DIFFICULTY_PRESENTATIONS.length, 5);
+  assert.deepEqual(
+    DIFFICULTY_PRESENTATIONS.map((presentation) => [
+      presentation.difficulty,
+      presentation.shortLabel,
+    ]),
+    [
+      ["BEGINNER", "B"],
+      ["NORMAL", "N"],
+      ["HYPER", "H"],
+      ["ANOTHER", "A"],
+      ["LEGGENDARIA", "L"],
+    ],
+  );
+  assert.equal(getDifficultyPresentation("ANOTHER")?.shortLabel, "A");
+  assert.equal(getDifficultyPresentationByShortLabel("L")?.difficulty, "LEGGENDARIA");
+  assert.equal(resolveDifficultyPresentation("H")?.difficulty, "HYPER");
+  assert.equal(getDifficultyShortLabel("LEGGENDARIA"), "L");
+  assert.equal(getDifficultyFromShortLabel("B"), "BEGINNER");
   assert.equal(getDifficultyBadgeLabel("A"), "ANOTHER");
   assert.match(getDifficultyBadgeClass("A"), /bg-red-600/);
+  assert.equal(getDifficultyBadgeLabel("UNKNOWN"), "UNKNOWN");
+  assert.equal(getDifficultyShortLabel("UNKNOWN"), "-");
+  assert.equal(getDifficultyFromShortLabel("UNKNOWN"), null);
 });
 
 test("normalizeRoomPlayerStatus falls back to UNCONFIRMED", () => {

--- a/apps/client/src/features/room/presentation-shared.ts
+++ b/apps/client/src/features/room/presentation-shared.ts
@@ -1,3 +1,5 @@
+import type { ChartDifficulty } from "@infinitas/shared";
+
 export type RoomSong = {
   id?: string | number;
   title: string;
@@ -22,6 +24,62 @@ export type RoomPlayerStatusSnapshot = {
   label: string | null | undefined;
   metric: number | null | undefined;
 };
+
+export type DifficultyShortLabel = "B" | "N" | "H" | "A" | "L";
+
+export type DifficultyPresentation = {
+  difficulty: ChartDifficulty;
+  shortLabel: DifficultyShortLabel;
+  colorClass: string;
+  textClass: string;
+  badgeClass: string;
+};
+
+export const DIFFICULTY_PRESENTATIONS: readonly DifficultyPresentation[] = [
+  {
+    difficulty: "BEGINNER",
+    shortLabel: "B",
+    colorClass: "bg-green-500",
+    textClass: "text-green-400",
+    badgeClass: "bg-green-500 text-black shadow-[0_0_18px_rgba(34,197,94,0.35)]",
+  },
+  {
+    difficulty: "NORMAL",
+    shortLabel: "N",
+    colorClass: "bg-blue-500",
+    textClass: "text-blue-400",
+    badgeClass: "bg-blue-500 text-white shadow-[0_0_18px_rgba(59,130,246,0.35)]",
+  },
+  {
+    difficulty: "HYPER",
+    shortLabel: "H",
+    colorClass: "bg-yellow-500",
+    textClass: "text-yellow-400",
+    badgeClass: "bg-yellow-400 text-black shadow-[0_0_20px_rgba(250,204,21,0.45)]",
+  },
+  {
+    difficulty: "ANOTHER",
+    shortLabel: "A",
+    colorClass: "bg-red-500",
+    textClass: "text-red-400",
+    badgeClass: "bg-red-600 text-white shadow-[0_0_20px_rgba(220,38,38,0.4)]",
+  },
+  {
+    difficulty: "LEGGENDARIA",
+    shortLabel: "L",
+    colorClass: "bg-purple-600",
+    textClass: "text-purple-400",
+    badgeClass: "bg-purple-600 text-white shadow-[0_0_20px_rgba(147,51,234,0.4)]",
+  },
+];
+
+const DIFFICULTY_PRESENTATION_BY_DIFFICULTY = new Map<string, DifficultyPresentation>(
+  DIFFICULTY_PRESENTATIONS.map((presentation) => [presentation.difficulty, presentation]),
+);
+
+const DIFFICULTY_PRESENTATION_BY_SHORT_LABEL = new Map<string, DifficultyPresentation>(
+  DIFFICULTY_PRESENTATIONS.map((presentation) => [presentation.shortLabel, presentation]),
+);
 
 export function maskJoinCode(joinCode: string): string {
   return "*".repeat(joinCode.length);
@@ -54,38 +112,47 @@ export function formatRankLabel(rank: number | null): string {
   return rank === null ? "-" : formatOrdinal(rank);
 }
 
+export function getDifficultyPresentation(
+  difficulty: string | null | undefined,
+): DifficultyPresentation | null {
+  return difficulty === null || difficulty === undefined
+    ? null
+    : DIFFICULTY_PRESENTATION_BY_DIFFICULTY.get(difficulty) ?? null;
+}
+
+export function getDifficultyPresentationByShortLabel(
+  shortLabel: string | null | undefined,
+): DifficultyPresentation | null {
+  return shortLabel === null || shortLabel === undefined
+    ? null
+    : DIFFICULTY_PRESENTATION_BY_SHORT_LABEL.get(shortLabel) ?? null;
+}
+
+export function resolveDifficultyPresentation(
+  value: string | null | undefined,
+): DifficultyPresentation | null {
+  return (
+    getDifficultyPresentation(value) ??
+    getDifficultyPresentationByShortLabel(value)
+  );
+}
+
+export function getDifficultyShortLabel(difficulty: string | null | undefined): string {
+  return resolveDifficultyPresentation(difficulty)?.shortLabel ?? "-";
+}
+
+export function getDifficultyFromShortLabel(
+  shortLabel: string | null | undefined,
+): ChartDifficulty | null {
+  return getDifficultyPresentationByShortLabel(shortLabel)?.difficulty ?? null;
+}
+
 export function getDifficultyBadgeClass(difficulty: string | null | undefined): string {
-  switch (difficulty) {
-    case "B":
-      return "bg-green-500 text-black shadow-[0_0_18px_rgba(34,197,94,0.35)]";
-    case "N":
-      return "bg-blue-500 text-white shadow-[0_0_18px_rgba(59,130,246,0.35)]";
-    case "H":
-      return "bg-yellow-400 text-black shadow-[0_0_20px_rgba(250,204,21,0.45)]";
-    case "A":
-      return "bg-red-600 text-white shadow-[0_0_20px_rgba(220,38,38,0.4)]";
-    case "L":
-      return "bg-purple-600 text-white shadow-[0_0_20px_rgba(147,51,234,0.4)]";
-    default:
-      return "bg-gray-600 text-white";
-  }
+  return resolveDifficultyPresentation(difficulty)?.badgeClass ?? "bg-gray-600 text-white";
 }
 
 export function getDifficultyBadgeLabel(difficulty: string | null | undefined): string {
-  switch (difficulty) {
-    case "B":
-      return "BEGINNER";
-    case "N":
-      return "NORMAL";
-    case "H":
-      return "HYPER";
-    case "A":
-      return "ANOTHER";
-    case "L":
-      return "LEGGENDARIA";
-    default:
-      return difficulty ?? "-";
-  }
+  return resolveDifficultyPresentation(difficulty)?.difficulty ?? difficulty ?? "-";
 }
 
 export function normalizeRoomPlayerStatus(

--- a/apps/client/src/pages/RoomPage.tsx
+++ b/apps/client/src/pages/RoomPage.tsx
@@ -62,6 +62,8 @@ import { useClipboardFeedback } from "../features/room/presentation-hooks";
 import {
   buildPresentationPlayerMaps,
   formatCountdown,
+  getDifficultyFromShortLabel,
+  getDifficultyShortLabel,
   type RoomHistoryItem,
   type RoomSong,
 } from "../features/room/presentation-shared";
@@ -80,12 +82,6 @@ import { openExternalUrl } from "../services/tauri-bridge";
 import { roomStore, useRoomStore, type RoomConnectionStatus } from "../stores/room-store";
 import { isVoicePlaybackEnabled, useSettingsStore } from "../stores/settings-store";
 import { formatDateTime, stringifyJson } from "../utils/format";
-
-type DifficultyPresentation = {
-  shortLabel: string;
-  colorClass: string;
-  textClass: string;
-};
 
 type DisplayExpectedKey = {
   play_style: string;
@@ -247,25 +243,8 @@ function getPlayingCountdown(round: CurrentRoundSnapshot, nowMs: number): {
   };
 }
 
-function getDifficultyPresentation(difficulty: string | null | undefined): DifficultyPresentation {
-  switch (difficulty) {
-    case "BEGINNER":
-      return { shortLabel: "B", colorClass: "bg-green-500", textClass: "text-green-400" };
-    case "NORMAL":
-      return { shortLabel: "N", colorClass: "bg-blue-500", textClass: "text-blue-400" };
-    case "HYPER":
-      return { shortLabel: "H", colorClass: "bg-yellow-500", textClass: "text-yellow-400" };
-    case "ANOTHER":
-      return { shortLabel: "A", colorClass: "bg-red-500", textClass: "text-red-400" };
-    case "LEGGENDARIA":
-      return { shortLabel: "L", colorClass: "bg-purple-600", textClass: "text-purple-400" };
-    default:
-      return { shortLabel: "-", colorClass: "bg-slate-500", textClass: "text-slate-400" };
-  }
-}
-
 function getDifficultyId(difficulty: string | null | undefined): string {
-  return getDifficultyPresentation(difficulty).shortLabel;
+  return getDifficultyShortLabel(difficulty);
 }
 
 function describeAutoRematchBlockReason(reason: string | null | undefined): string {
@@ -286,20 +265,7 @@ function describeAutoRematchBlockReason(reason: string | null | undefined): stri
 }
 
 function getDifficultyFromId(difficultyId: string | null): (typeof CHART_DIFFICULTIES)[number] | null {
-  switch (difficultyId) {
-    case "B":
-      return "BEGINNER";
-    case "N":
-      return "NORMAL";
-    case "H":
-      return "HYPER";
-    case "A":
-      return "ANOTHER";
-    case "L":
-      return "LEGGENDARIA";
-    default:
-      return null;
-  }
+  return getDifficultyFromShortLabel(difficultyId);
 }
 
 function formatSongKeyTitle(
@@ -307,7 +273,7 @@ function formatSongKeyTitle(
   playStyle: string | null | undefined,
   difficulty: string | null | undefined,
 ): string {
-  return `${titleSearchKey}(${playStyle ?? "SP"}${getDifficultyPresentation(difficulty).shortLabel})`;
+  return `${titleSearchKey}(${playStyle ?? "SP"}${getDifficultyShortLabel(difficulty)})`;
 }
 
 function getExpectedKeyCacheKey(expectedKey: DisplayExpectedKey | null | undefined): string | null {

--- a/tasks/issue-161-difficulty-presentation-single-source.md
+++ b/tasks/issue-161-difficulty-presentation-single-source.md
@@ -1,0 +1,80 @@
+# issue-161-difficulty-presentation-single-source
+
+## Purpose
+- client 内で difficulty presentation の正本を 1 つにまとめ、Room UI と search modal が同じ定義を参照するようにする。
+- 既存の difficulty 値契約は維持したまま、presentation helper / 定数の重複だけを整理する。
+
+## Non-goals
+- difficulty 値そのものの契約変更
+- `packages/shared/**` / `apps/worker/**` / `docs/design/**` 更新
+- 検索条件や Room 表示仕様の再設計
+- CI workflow / lockfile / dependency 変更
+
+## Fixed decisions
+- canonical source は `apps/client/src/features/room/presentation-shared.ts` に置く
+- 既存 export の `getDifficultyBadgeLabel` / `getDifficultyBadgeClass` は維持し、canonical metadata を参照する wrapper にする
+- `apps/client/src/pages/RoomPage.tsx` は local difficulty switch を廃止し、shared lookup で short id と class を得る
+- `apps/client/src/components/SongSearchModalView.tsx` は local `DIFFICULTIES` を廃止し、shared metadata を filter button / list chip に使う
+- `apps/client/src/components/RoomArena.tsx` / `apps/client/src/components/RoomBPL.tsx` は直接編集しない
+
+## Changes
+- `apps/client/src/features/room/presentation-shared.ts` に canonical difficulty metadata と lookup helper を追加する
+- `apps/client/src/pages/RoomPage.tsx` の local difficulty switch / id conversion を shared helper 利用へ寄せる
+- `apps/client/src/components/SongSearchModalView.tsx` の local `DIFFICULTIES` を shared metadata 参照へ置換する
+- `apps/client/src/features/room/presentation-shared.test.ts` を更新し、mapping と fallback を固定する
+
+## Impact
+- Users/runtime: 表示・検索挙動は維持したまま、difficulty presentation の参照元を一本化する
+- Data/compatibility: 変更なし
+- Cloudflare: 影響なし
+
+## Target Layers / Files
+- layer: client
+- files:
+  - `apps/client/src/features/room/presentation-shared.ts`
+  - `apps/client/src/features/room/presentation-shared.test.ts`
+  - `apps/client/src/pages/RoomPage.tsx`
+  - `apps/client/src/components/SongSearchModalView.tsx`
+
+## Validation Plan
+- `npm run lint`
+- `npm run typecheck`
+- `npm --workspace @infinitas/client exec tsx --test src/features/room/presentation-shared.test.ts`
+
+## Validation Surface Note
+- CI reusable validate の基準面は root `lint` + root `typecheck` のため、workspace-only typecheck ではなく root command を採用する
+- touched test file は `apps/client/tsconfig.json` で除外され、`.github/workflows/validate-reusable.yml` でも未実行のため、explicit local test command を追加面として残す
+- CI workflow 自体を広げる変更は今回 scope 外とする
+
+## Rollback Plan
+- canonical metadata 導入差分をまとめて revert し、`RoomPage.tsx` / `SongSearchModalView.tsx` の従来ローカル定義へ戻す
+
+## Commit Split Plan
+1. task artifact と canonical difficulty helper / test 更新
+2. `RoomPage.tsx` / `SongSearchModalView.tsx` の shared 参照化
+3. validation only
+
+## Phase / Spawn Decision
+- Phase A: `READY`
+- Phase B: `READY`
+- execution profile: `Standard`
+- Plan Mode: `NO`
+- Standard Spawn Gate: `APPLICABLE`
+- High-Risk Spawn Gate: `NOT_APPLICABLE`
+- No-delegate reason: client 単層 / 単一 bounded task / non-contract-sensitive で、Standard Spawn Gate 上 non-spawn acceptable
+
+## Delegation Packet
+- task label: `issue-161-difficulty-presentation-single-source`
+- objective: difficulty presentation の正本を client 内で一本化し、Room UI と search modal の参照元を揃える
+- in-scope files/layer: client / `presentation-shared.ts`, `presentation-shared.test.ts`, `RoomPage.tsx`, `SongSearchModalView.tsx`
+- non-goals: difficulty 値 contract 変更、shared/worker/schema 変更、UI redesign、CI/依存更新
+- forbidden scope: `packages/shared/**`, `apps/worker/**`, `docs/design/**`, `.github/workflows/**`, lockfile/依存更新
+- expected output: canonical metadata 1 箇所から Room UI / search modal / existing badge helper が difficulty 表示情報を取得し、既存挙動を維持する
+- validation: 上記 Validation Plan を満たす
+- escalation: difficulty 値 contract 変更、cross-layer 化、CI/workflow 変更、仕様判断が必要化した場合
+
+## Replan Gate
+- canonical 化のために difficulty 値 contract や `CHART_DIFFICULTIES` の意味変更が必要になった場合
+- `packages/shared/**` / `apps/worker/**` / `docs/design/**` 更新が必要になった場合
+- 既存 fallback 挙動維持ができず、表示仕様の再決定が必要になった場合
+- required validation を満たすために CI/workflow 変更が必須になった場合


### PR DESCRIPTION
## Purpose
- Unify client-side difficulty presentation metadata so Room UI and the song search modal read from the same source of truth.
- Remove duplicated short-label and color mapping without changing the underlying difficulty contract.

## Changes
- Centralize difficulty presentation metadata and lookup helpers in `apps/client/src/features/room/presentation-shared.ts`.
- Update `RoomPage.tsx` to use shared helpers for short-label conversion and chart-key formatting.
- Update `SongSearchModalView.tsx` to use shared metadata for difficulty filters and list chips.
- Expand `presentation-shared.test.ts` and add the bounded task artifact for Issue #161.

## Non-Changes
- No difficulty value contract changes.
- No `packages/shared/**`, `apps/worker/**`, `docs/design/**`, CI workflow, or dependency updates.
- No search behavior redesign or Room UI redesign.

## Impact
- User impact: Room UI and search modal now share the same difficulty presentation mapping with no intended behavior change.
- Data impact: none.
- Compatibility impact: none.
- Cloudflare/infra impact: none.

## Validation
- Commands run:
  - `npm run lint`: pass
  - `npm run typecheck`: pass
  - `npm run build:client`: pass
  - `npm --workspace @infinitas/client run test`: pass
- Notes:
  - `apps/client/tsconfig.json` excludes `src/**/*.test.ts`, and the reusable CI workflow does not execute the touched helper test file. I ran the workspace client test script as a compensating command so the changed test file is executed explicitly.
  - CI quick profile also runs repo-wide `test:client-stats` and `test:worker`, but those surfaces do not cover the touched files for this bounded client-only change.

## Regression Checks
- [x] RoomPage difficulty short-label conversion still matches existing chart-key formatting paths.
- [x] Search modal difficulty filter chips and song list chips use the same color/label mapping.
- [x] Unknown or null difficulty values keep existing fallback behavior.

## Risk and Rollback
- Risk level: normal
- Rollback plan: revert this commit to restore the previous local difficulty definitions in `RoomPage.tsx` and `SongSearchModalView.tsx`.

## Related
- Issue: #161
- Plan item/task label: `issue-161-difficulty-presentation-single-source`