### PR TITLE
refactor(client): make room views controlled-only

### DIFF
--- a/apps/client/src/components/RoomArena.tsx
+++ b/apps/client/src/components/RoomArena.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useRef, type ReactNode } from 'react';
 import { User, CircleCheck as CheckCircle2, Circle, Play, LogOut, MessageSquare, Info, ShieldCheck, Database, Zap, Music, Copy, Check, Clock } from 'lucide-react';
 import { RoomPickDecisionCutIn, RoomSearchModalGate } from '../features/room/presentation-components';
-import { useClipboardFeedback, useResultPhaseTimer } from '../features/room/presentation-hooks';
 import {
     formatCountdown,
     formatRankLabel,
@@ -46,12 +45,6 @@ export interface RoomArenaFinalResultPlayerSummary {
     rank: number | null;
     totalPoints: number;
     isWinner: boolean;
-}
-
-interface RoomProps {
-    onNavigate?: (screen: string) => void;
-    initialStatus?: 'WAITING' | 'SELECTING' | 'PLAYING' | 'RESULT' | 'CLOSED';
-    controlled?: RoomArenaControlledState;
 }
 
 export interface RoomArenaControlledState {
@@ -110,288 +103,118 @@ export interface RoomArenaControlledState {
 }
 
 export function RoomArenaPresentational(props: RoomArenaControlledState) {
-    return <RoomArena controlled={props} />;
+    return <RoomArena {...props} />;
 }
 
-export default function RoomArena({ onNavigate, initialStatus, controlled }: RoomProps) {
-    const [isReadyState, setIsReady] = useState(initialStatus === 'SELECTING' || initialStatus === 'PLAYING' || initialStatus === 'RESULT' || initialStatus === 'CLOSED');
-    const [roomStatusState, setRoomStatus] = useState<'WAITING' | 'SELECTING' | 'PLAYING' | 'RESULT' | 'CLOSED'>(initialStatus || 'WAITING');
-    const [closeReasonState, setCloseReason] = useState<string>('ALL_ROUNDS_COMPLETED');
-    const [roundCountState, setRoundCount] = useState(1);
-    const [historyState, setHistory] = useState<HistoryItem[]>([]);
-    const [playerPicksState, setPlayerPicks] = useState<Record<string, Song | null>>(initialStatus === 'PLAYING' || initialStatus === 'RESULT' ? {
-        '1': { title: 'Technophobia', artist: 'BEMANI Sound Team "Sota Fujimori"', level: '12' },
-        '2': { title: 'Illegal Function Call', artist: 'Umeboshi Chazuke', level: '12' },
-        '3': { title: 'Level 4', artist: 'Yamajet', level: '12' },
-        '4': { title: 'Beyond the Earth', artist: '猫叉Master', level: '12' }
-    } : {});
-    const [showSearchState, setShowSearch] = useState(false);
-    const [showCutInState, setShowCutIn] = useState(false);
-    const [lastPickedSongState, setLastPickedSong] = useState<Song | null>(null);
-    const [lobbyTimerState, setLobbyTimer] = useState(1200); // 20 minutes in seconds
-    const [currentPlayersState, _setCurrentPlayers] = useState(2); // Mock current players
-    const [maxPlayersState, _setMaxPlayers] = useState(4); // Mock room capacity
-    const roomStatus = controlled?.roomStatus ?? roomStatusState;
-    const [resultTimerState] = useResultPhaseTimer(roomStatus === 'RESULT', finalizeRound);
-    const roomIdCopy = useClipboardFeedback();
-    const joinCodeCopy = useClipboardFeedback();
-
-    const roomId = controlled?.roomId ?? "3f8e6f5d-9ba0-4268-936d-a5a2ebfd7ccd";
-    const joinCode = controlled?.joinCode ?? "ARENA123";
-    const roomName = controlled?.roomName ?? 'ARENA ROOM';
-    const battleModeLabel = controlled?.battleModeLabel ?? 'SP / NO LIMIT';
-    const regCount = controlled?.regCount ?? maxPlayersState;
-    const isPrivateRoom = controlled?.isPrivateRoom ?? false;
-
+export default function RoomArena({
+    isReady,
+    roomStatus,
+    closeReason,
+    resultTimer,
+    roundCount,
+    totalRounds,
+    history,
+    playerPicks,
+    showSearch,
+    showCutIn,
+    lastPickedSong,
+    copiedId,
+    copiedCode,
+    lobbyTimer,
+    currentPlayers,
+    maxPlayers,
+    roomName = '',
+    battleModeLabel = '',
+    regCount,
+    isPrivateRoom = false,
+    roomId,
+    joinCode,
+    pickingCountdownSeconds = 0,
+    logs,
+    matchInfoItems,
+    publicSharePanel,
+    playTime,
+    playingPhase,
+    playingCountdownSeconds,
+    playerStatus,
+    playerMetrics,
+    metricLabel,
+    resultSong,
+    resultPlayers,
+    durationLabel,
+    finalResultPlayers,
+    isHost,
+    allPlayers,
+    selectedByName,
+    selfPlayerId,
+    searchModal,
+    disablePrimaryAction,
+    disableLeave,
+    onCopyRoomId,
+    onCopyJoinCode,
+    onOpenSearch,
+    onPrimaryAction,
+    onToggleReady,
+    onSkip,
+    onProceedToResult,
+    onLeaveRoom,
+    onRemakeStage,
+}: RoomArenaControlledState) {
+    const players = allPlayers.slice(0, currentPlayers);
+    const resolvedSelfPlayerId = selfPlayerId ?? (isHost ? '1' : '2');
+    const hasJoinCode = joinCode.trim().length > 0;
+    const maskedJoinCode = hasJoinCode ? maskJoinCode(joinCode) : '';
     const handleCopyRoomId = () => {
-        if (controlled?.onCopyRoomId) {
-            controlled.onCopyRoomId();
-            return;
-        }
-
-        roomIdCopy.copy(roomId);
+        onCopyRoomId?.();
     };
     const handleCopyJoinCode = () => {
-        if (controlled?.onCopyJoinCode) {
-            controlled.onCopyJoinCode();
-            return;
-        }
-
-        joinCodeCopy.copy(joinCode);
+        onCopyJoinCode?.();
     };
-
-    // PLAYING state logic
-    const [playTimeState, setPlayTime] = useState(0);
-    const [playingPhaseState, setPlayingPhase] = useState<'MUSIC_SELECT' | 'PLAY_START' | 'IN_PLAY'>('MUSIC_SELECT');
-    const [playerStatusState, setPlayerStatus] = useState<Record<string, RoomPlayerStatusLabel>>(
-        initialStatus === 'PLAYING' ? {
-            '1': 'PLAYED',
-            '2': 'UNCONFIRMED',
-            '3': 'PLAYED',
-            '4': 'UNCONFIRMED'
-        } : initialStatus === 'RESULT' ? {
-            '1': 'PLAYED',
-            '2': 'PLAYED',
-            '3': 'PLAYED',
-            '4': 'PLAYED'
-        } : {
-            '1': 'UNCONFIRMED',
-            '2': 'UNCONFIRMED',
-            '3': 'UNCONFIRMED',
-            '4': 'UNCONFIRMED'
-        }
-    );
-
-    const isHost = controlled?.isHost ?? true;
-
-    const isReady = controlled?.isReady ?? isReadyState;
-    const closeReason = controlled?.closeReason ?? closeReasonState;
-    const resultTimer = controlled?.resultTimer ?? resultTimerState;
-    const roundCount = controlled?.roundCount ?? roundCountState;
-    const history = controlled?.history ?? historyState;
-    const playerPicks = controlled?.playerPicks ?? playerPicksState;
-    const showSearch = controlled?.showSearch ?? showSearchState;
-    const showCutIn = controlled?.showCutIn ?? showCutInState;
-    const lastPickedSong = controlled?.lastPickedSong ?? lastPickedSongState;
-    const copiedId = controlled?.copiedId ?? roomIdCopy.copied;
-    const copiedCode = controlled?.copiedCode ?? joinCodeCopy.copied;
-    const lobbyTimer = controlled?.lobbyTimer ?? lobbyTimerState;
-    const currentPlayers = controlled?.currentPlayers ?? currentPlayersState;
-    const maxPlayers = controlled?.maxPlayers ?? maxPlayersState;
-    const playTime = controlled?.playTime ?? playTimeState;
-    const playingPhase = controlled?.playingPhase ?? playingPhaseState;
-    const playingCountdownSeconds = controlled?.playingCountdownSeconds ?? (
+    const shortRoomId = roomId.length > 18 ? `${roomId.slice(0, 18)}…` : roomId;
+    const logsViewportRef = useRef<HTMLDivElement | null>(null);
+    const resolvedTotalRounds = totalRounds ?? currentPlayers;
+    const resolvedPlayingCountdownSeconds = playingCountdownSeconds ?? (
         playingPhase === 'MUSIC_SELECT' ? Math.max(0, 45 - playTime) :
             playingPhase === 'PLAY_START' ? Math.max(0, 55 - playTime) :
                 Math.max(0, playTime - 55)
     );
-    const playerStatus = controlled?.playerStatus ?? playerStatusState;
-    const playerMetrics = controlled?.playerMetrics ?? {};
-    const metricLabel = controlled?.metricLabel ?? 'EX SCORE';
-    const resultSong = controlled?.resultSong ?? null;
-    const resultPlayers = controlled?.resultPlayers ?? {};
-    const durationLabel = controlled?.durationLabel ?? '0M 00S';
-    const finalResultPlayers = controlled?.finalResultPlayers ?? {};
-    const logs = controlled?.logs ?? [];
-    const matchInfoItems = controlled?.matchInfoItems ?? [
+    const resolvedPlayerMetrics = playerMetrics ?? {};
+    const resolvedMetricLabel = metricLabel ?? 'EX SCORE';
+    const resolvedResultSong = resultSong ?? null;
+    const resolvedResultPlayers = resultPlayers ?? {};
+    const resolvedDurationLabel = durationLabel ?? '0M 00S';
+    const resolvedFinalResultPlayers = finalResultPlayers ?? {};
+    const resolvedLogs = logs ?? [];
+    const resolvedMatchInfoItems = matchInfoItems ?? [
         { label: 'Mode', value: 'ARENA' },
-        { label: 'Scoring', value: 'EX SCORE' },
+        { label: 'Scoring', value: resolvedMetricLabel },
     ];
-    const publicSharePanel = controlled?.publicSharePanel ?? null;
-
-    const allMockPlayers = controlled?.allPlayers ?? [
-        { id: '1', name: 'PLAYER_ONE (HOST)', isReady: true, isHost: true },
-        { id: '2', name: 'RIVAL_KUN', isReady: true, isHost: false },
-        { id: '3', name: 'IIDX_CHAMP', isReady: isReady, isHost: false },
-        { id: '4', name: 'ARENA_PRO', isReady: true, isHost: false },
-    ];
-
-    const players = allMockPlayers.slice(0, currentPlayers);
-    const selfPlayerId = controlled?.selfPlayerId ?? (isHost ? '1' : '2');
-    const hasJoinCode = joinCode.trim().length > 0;
-    const maskedJoinCode = hasJoinCode ? maskJoinCode(joinCode) : '';
-    const shortRoomId = roomId.length > 18 ? `${roomId.slice(0, 18)}…` : roomId;
-    const logsViewportRef = useRef<HTMLDivElement | null>(null);
-    const pickingCountdownSeconds = controlled?.pickingCountdownSeconds ?? 0;
-    const totalRounds = controlled?.totalRounds ?? currentPlayers;
-
-    useEffect(() => {
-        if (logsViewportRef.current) {
-            logsViewportRef.current.scrollTop = logsViewportRef.current.scrollHeight;
-        }
-    }, [logs]);
-
-    const handleSelectSong = (song: Song) => {
-        setPlayerPicks({ ...playerPicks, '1': song }); // Mock: Always picking for Player 1
-        setShowSearch(false);
-        setLastPickedSong(song);
-        setShowCutIn(true);
-
-        // 演出後にカットインを閉じるが、PLAYING へは遷移させない
-        // ユーザーが意図的に次の確認をするために、SELECTING 状態を維持する
-        setTimeout(() => {
-            setShowCutIn(false);
-            // setRoomStatus('PLAYING'); // <-- ここをコメントアウト
-        }, 3000);
-    };
-
-    // 初期化時・状態遷移時の処理
-    React.useEffect(() => {
-        if (roomStatus === 'SELECTING' && !playerPicks['1']) {
-            setShowSearch(true);
-        }
-        if (roomStatus === 'PLAYING') {
-            if (!playerPicks['1']) {
-                setPlayerPicks({
-                    '1': { id: '1', title: 'Everlasting Message', artist: '削除', level: '12' },
-                    '2': { id: '2', title: 'Stasis', artist: 'dAice', level: '12' },
-                    '3': { id: '3', title: '冥', artist: 'Amuro vs Killer', level: '12' },
-                    '4': { id: '4', title: 'IIDX RED Ending', artist: 'dj TAKA', level: '12' }
-                });
-            }
-            setPlayerStatus({
-                '1': 'PLAYED',
-                '2': 'PLAYED',
-                '3': 'PLAYED',
-                '4': 'PLAYED'
-            });
-        }
-        if (roomStatus === 'WAITING') {
-            setLobbyTimer(1200); // Reset timer when returning to lobby
-        }
-    }, [roomStatus]);
-
-    // Lobby Timer management
-    React.useEffect(() => {
-        if (roomStatus !== 'WAITING') return;
-
-        const interval = setInterval(() => {
-            setLobbyTimer(prev => {
-                if (prev <= 1) {
-                    clearInterval(interval);
-                    setRoomStatus('CLOSED');
-                    setCloseReason('LOBBY_TIMEOUT');
-                    return 0;
-                }
-                return prev - 1;
-            });
-        }, 1000);
-
-        return () => clearInterval(interval);
-    }, [roomStatus]);
-
-    // PLAYING タイム管理
-    React.useEffect(() => {
-        if (roomStatus !== 'PLAYING') return;
-
-        const interval = setInterval(() => {
-            setPlayTime(prev => {
-                const next = prev + 1;
-                if (next < 45) setPlayingPhase('MUSIC_SELECT');
-                else if (next < 55) setPlayingPhase('PLAY_START');
-                else setPlayingPhase('IN_PLAY');
-                return next;
-            });
-        }, 1000);
-
-        return () => clearInterval(interval);
-    }, [roomStatus]);
-
-    const handleSkip = (playerId: string) => {
-        if (controlled?.onSkip) {
-            controlled.onSkip(playerId);
-            return;
-        }
-
-        setPlayerStatus(prev => ({ ...prev, [playerId]: 'SKIPPED' }));
-    };
-
-    function finalizeRound() {
-        const currentSong = playerPicks['1'] || { title: 'Unknown', artist: 'Unknown', level: '?' };
-
-        const mockScores: Record<string, number> = {
-            '1': Math.floor(Math.random() * 2000) + 1500,
-            '2': Math.floor(Math.random() * 2000) + 1500,
-            '3': Math.floor(Math.random() * 2000) + 1500,
-            '4': Math.floor(Math.random() * 2000) + 1500
-        };
-
-        // Find winner
-        let maxScore = -1;
-        let winner = 'DRAW';
-        Object.entries(mockScores).forEach(([pid, score]) => {
-            if (score > maxScore) {
-                maxScore = score;
-                winner = pid;
-            }
-        });
-
-        const newItem: HistoryItem = {
-            round: roundCount,
-            song: currentSong,
-            scores: mockScores,
-            winnerId: winner
-        };
-
-        setHistory(prev => [newItem, ...prev]);
-
-        if (roundCount < 4) {
-            setRoundCount(prev => prev + 1);
-            setRoomStatus('PLAYING');
-            setPlayTime(0);
-            setPlayerStatus({
-                '1': 'UNCONFIRMED',
-                '2': 'UNCONFIRMED',
-                '3': 'UNCONFIRMED',
-                '4': 'UNCONFIRMED'
-            });
-        } else {
-            setRoundCount(1);
-            setRoomStatus('CLOSED');
-            setCloseReason('ALL_ROUNDS_COMPLETED');
-        }
-    }
-
-    const handleProceedToResult = () => {
-        if (controlled?.onProceedToResult) {
-            controlled.onProceedToResult();
-            return;
-        }
-
-        setRoomStatus('RESULT');
-    };
-    const currentRoundPlayer = players[roundCount - 1] ?? players[0];
-    const selectedByName = controlled?.selectedByName ?? currentRoundPlayer?.name ?? 'PLAYER_ONE';
+    const resolvedPublicSharePanel = publicSharePanel ?? null;
+    const currentRoundPlayer = players[roundCount - 1] ?? players[0] ?? null;
+    const resolvedSelectedByName = selectedByName ?? currentRoundPlayer?.name ?? '';
     const currentRoundSong = currentRoundPlayer ? playerPicks[currentRoundPlayer.id] ?? null : null;
     const currentRoundTitle = currentRoundSong?.title ?? 'Unknown Track';
     const currentRoundVersion = resolveSongVersionLabel(currentRoundSong?.version);
     const currentRoundPlayStyle = currentRoundSong?.playStyle ?? '-';
     const currentRoundDifficulty = currentRoundSong?.difficulty ?? '-';
     const currentRoundLevel = currentRoundSong?.level ?? '?';
-    const resultSongVersion = resolveSongVersionLabel(resultSong?.version);
-    const resultSongPlayStyle = resultSong?.playStyle ?? '-';
-    const resultSongDifficulty = resultSong?.difficulty ?? '-';
-    const resultSongLevel = resultSong?.level ?? '?';
+    const resultSongVersion = resolveSongVersionLabel(resolvedResultSong?.version);
+    const resultSongPlayStyle = resolvedResultSong?.playStyle ?? '-';
+    const resultSongDifficulty = resolvedResultSong?.difficulty ?? '-';
+    const resultSongLevel = resolvedResultSong?.level ?? '?';
+    const primaryDisabled = disablePrimaryAction ?? (
+        isHost
+            ? roomStatus !== 'WAITING' || !players.every((player) => player.isReady)
+            : roomStatus === 'SELECTING'
+    );
+    const leaveDisabled = disableLeave ?? (roomStatus === 'SELECTING' || roomStatus === 'PLAYING');
+    const resolvedRegCount = regCount ?? maxPlayers;
+
+    useEffect(() => {
+        if (logsViewportRef.current) {
+            logsViewportRef.current.scrollTop = logsViewportRef.current.scrollHeight;
+        }
+    }, [resolvedLogs]);
 
     return (
         <div className="flex h-screen w-screen bg-[#1a1a1b] text-white font-sans overflow-hidden">
@@ -399,10 +222,10 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
             {showCutIn ? <RoomPickDecisionCutIn song={lastPickedSong} /> : null}
 
             <RoomSearchModalGate
-                modal={controlled?.searchModal}
+                modal={searchModal}
                 isOpen={showSearch}
-                onClose={() => setShowSearch(false)}
-                onSelect={handleSelectSong}
+                onClose={() => undefined}
+                onSelect={() => undefined}
             />
 
             {/* メインエリア */}
@@ -421,7 +244,7 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
                                         playingPhase === 'PLAY_START' ? 'PLAY START' : 'IN PLAY'}
                                 </div>
                                 <div className="flex flex-col">
-                                    <span className="text-4xl font-black italic tracking-tighter font-mono">{playingCountdownSeconds}</span>
+                                    <span className="text-4xl font-black italic tracking-tighter font-mono">{resolvedPlayingCountdownSeconds}</span>
                                     <span className="text-[10px] font-black text-gray-500 uppercase tracking-widest">Countdown</span>
                                 </div>
                             </div>
@@ -442,13 +265,13 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
                                     <span className={`${getDifficultyBadgeClass(currentRoundDifficulty)} rounded-full px-3 py-1 text-[11px] tracking-[0.2em]`}>{getDifficultyBadgeLabel(currentRoundDifficulty)}</span>
                                     <span className="text-cyan-500">Lv{currentRoundLevel}</span>
                                 </div>
-                                <p className="text-xs font-bold text-gray-400 uppercase tracking-widest">Selected By {selectedByName}</p>
+                                <p className="text-xs font-bold text-gray-400 uppercase tracking-widest">Selected By {resolvedSelectedByName}</p>
                             </div>
 
                             <div className="flex items-center gap-4">
                                 <div className="text-right">
                                     <p className="text-[10px] font-black text-cyan-500 uppercase tracking-widest mb-1 italic text-shadow-glow">Stage</p>
-                                    <h2 className="text-2xl font-black italic tracking-tighter text-white">ROUND {roundCount} / {totalRounds}</h2>
+                                    <h2 className="text-2xl font-black italic tracking-tighter text-white">ROUND {roundCount} / {resolvedTotalRounds}</h2>
                                 </div>
                                 <div className="w-12 h-12 bg-white/5 border border-white/10 rounded-xl flex items-center justify-center text-cyan-500">
                                     <Zap size={24} />
@@ -484,8 +307,8 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
                                     <div className="flex items-center gap-4">
                                         {playerStatus[p.id] === 'UNCONFIRMED' && (
                                             <>
-                                                {p.id === selfPlayerId ? (
-                                                    <button onClick={() => handleSkip(p.id)} className="flex-1 bg-white/5 hover:bg-white/10 border border-white/10 py-3 rounded-xl font-black italic text-sm transition-all">SKIP ROUND</button>
+                                                {p.id === resolvedSelfPlayerId ? (
+                                                    <button onClick={() => onSkip?.(p.id)} className="flex-1 bg-white/5 hover:bg-white/10 border border-white/10 py-3 rounded-xl font-black italic text-sm transition-all">SKIP ROUND</button>
                                                 ) : (
                                                     <div className="flex-1 h-12 bg-white/5 rounded-xl border border-white/5 flex items-center justify-center">
                                                         <span className="text-[10px] font-black text-gray-700 uppercase animate-pulse">Waiting for result...</span>
@@ -495,9 +318,9 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
                                         )}
                                         {playerStatus[p.id] === 'PLAYED' && (
                                             <div className="flex items-center gap-2">
-                                                <span className="text-sm font-bold text-gray-500 uppercase">{metricLabel}:</span>
+                                                <span className="text-sm font-bold text-gray-500 uppercase">{resolvedMetricLabel}:</span>
                                                 <span className="text-3xl font-black italic text-white tracking-widest">
-                                                    {playerMetrics[p.id] ?? '-'}
+                                                    {resolvedPlayerMetrics[p.id] ?? '-'}
                                                 </span>
                                             </div>
                                         )}
@@ -510,7 +333,7 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
                         {isHost && playingPhase === 'IN_PLAY' && playTime >= (240 + 55) && (
                             <div className="mt-8 flex justify-center">
                                 <button
-                                    onClick={handleProceedToResult}
+                                    onClick={() => onProceedToResult?.()}
                                     className="px-12 py-3 bg-red-600/10 hover:bg-red-600 border border-red-500/30 text-red-500 hover:text-white rounded-full font-black italic tracking-widest text-xs transition-all uppercase"
                                 >
                                     Force Finalize Match
@@ -536,8 +359,8 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
                                             </span>
                                         )}
                                     </div>
-                                    <h2 className={`max-w-[56rem] text-6xl font-black italic tracking-tighter text-white leading-tight whitespace-normal ${resultSong?.title && resultSong.title.length > 45 ? 'line-clamp-2 break-all' : 'break-all'}`}>
-                                        {resultSong?.title || 'Unknown Track'}
+                                    <h2 className={`max-w-[56rem] text-6xl font-black italic tracking-tighter text-white leading-tight whitespace-normal ${resolvedResultSong?.title && resolvedResultSong.title.length > 45 ? 'line-clamp-2 break-all' : 'break-all'}`}>
+                                        {resolvedResultSong?.title || 'Unknown Track'}
                                     </h2>
                                 </div>
                                 <div className="mt-3 flex flex-wrap items-center gap-3 text-lg font-black italic tracking-[0.2em] text-gray-300">
@@ -560,7 +383,7 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
 
                         <div className="flex-1 grid grid-cols-4 gap-8 mb-12">
                             {players.map((p) => {
-                                const summary = resultPlayers[p.id];
+                                const summary = resolvedResultPlayers[p.id];
                                 const rank = summary?.rank ?? null;
                                 const isWinner = summary?.isWinner ?? false;
 
@@ -589,7 +412,7 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
                                                 </div>
 
                                                 <div className="flex flex-col items-center">
-                                                    <span className="text-[10px] font-black text-gray-600 uppercase tracking-widest mb-1 font-mono">{metricLabel}</span>
+                                                    <span className="text-[10px] font-black text-gray-600 uppercase tracking-widest mb-1 font-mono">{resolvedMetricLabel}</span>
                                                     <div className={`text-4xl font-black italic tracking-tighter ${isWinner ? 'text-cyan-400' : 'text-white'}`}>
                                                         {summary?.metricValue ?? '-'}
                                                     </div>
@@ -624,7 +447,7 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
                                     <div className="w-[1px] h-12 bg-white/10" />
                                     <div className="text-left font-sans">
                                         <p className="text-xs font-black text-gray-500 uppercase">Duration</p>
-                                        <p className="text-2xl font-black italic tracking-tighter text-cyan-400">{durationLabel}</p>
+                                        <p className="text-2xl font-black italic tracking-tighter text-cyan-400">{resolvedDurationLabel}</p>
                                     </div>
                                 </div>
                             </div>
@@ -633,7 +456,7 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
                         <div className="flex-1 flex flex-col justify-center gap-8 relative px-10">
                             <div className="grid grid-cols-4 gap-8">
                                 {players.map((p) => {
-                                    const summary = finalResultPlayers[p.id];
+                                    const summary = resolvedFinalResultPlayers[p.id];
                                     const rank = summary?.rank ?? null;
                                     const isWinner = summary?.isWinner ?? false;
                                     return (
@@ -659,27 +482,15 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
                         <footer className="mt-12 flex justify-center gap-8 relative z-10">
                             <button
                                 onClick={() => {
-                                    if (controlled?.onLeaveRoom) {
-                                        controlled.onLeaveRoom();
-                                        return;
-                                    }
-
-                                    onNavigate?.('BROWSER');
+                                    onLeaveRoom?.();
                                 }}
                                 className="px-12 py-4 bg-cyan-500 hover:bg-cyan-400 text-black font-black italic text-2xl rounded-2xl transition-all active:scale-95 shadow-[0_0_60px_rgba(6,182,212,0.4)] uppercase tracking-tighter"
                             >
                                 Return to Lobby
                             </button>
-                            {isHost && (controlled?.onRemakeStage !== undefined || controlled === undefined) ? (
+                            {isHost && onRemakeStage !== undefined ? (
                                 <button
-                                    onClick={() => {
-                                        if (controlled?.onRemakeStage) {
-                                            controlled.onRemakeStage();
-                                            return;
-                                        }
-
-                                        setRoomStatus('WAITING');
-                                    }}
+                                    onClick={() => onRemakeStage?.()}
                                     className="px-10 py-4 bg-white/5 hover:bg-white/10 text-white font-black italic text-base rounded-2xl transition-all border-2 border-white/10 uppercase tracking-tighter"
                                 >
                                     Remake Room
@@ -746,7 +557,7 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
                                         </span>
                                         <div className="w-1 h-1 rounded-full bg-gray-600" />
                                         <span className="text-[10px] font-black text-gray-400 uppercase tracking-wider">
-                                            REG: {regCount} ROUNDS
+                                            REG: {resolvedRegCount} ROUNDS
                                         </span>
                                     </div>
                                 </div>
@@ -802,15 +613,14 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
                 }
                 <div className="grid grid-cols-2 grid-rows-2 gap-3 flex-1 overflow-hidden">
                     {[...Array(4)].map((_, idx) => {
-                        const p = allMockPlayers[idx] ?? { id: String(idx + 1), name: `PLAYER_${idx + 1}`, isReady: false, isHost: false };
-                        const isJoined = idx < currentPlayers;
+                        const p = players[idx] ?? null;
                         const isSlotAvailable = idx < maxPlayers;
-                        const pickedSong = playerPicks[p.id];
+                        const pickedSong = p ? playerPicks[p.id] : null;
                         const hasPicked = !!pickedSong;
                         const colors = ['border-cyan-500 shadow-cyan-500/20', 'border-amber-500 shadow-amber-500/20', 'border-crimson-500 shadow-crimson-500/20', 'border-purple-500 shadow-purple-500/20'];
                         const personalColor = colors[idx] || 'border-cyan-500';
 
-                        if (isJoined) {
+                        if (p) {
                             return (
                                 <div
                                     key={idx}
@@ -868,14 +678,7 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
                                     <div className="absolute right-4 bottom-2 text-6xl font-black italic text-white/[0.03] select-none pointer-events-none">0{idx + 1}</div>
                                     {idx === 0 && roomStatus === 'SELECTING' && !hasPicked && (
                                         <button
-                                            onClick={() => {
-                                                if (controlled?.onOpenSearch) {
-                                                    controlled.onOpenSearch();
-                                                    return;
-                                                }
-
-                                                setShowSearch(true);
-                                            }}
+                                            onClick={() => onOpenSearch?.()}
                                             className="absolute inset-0 bg-cyan-500/10 hover:bg-cyan-500/20 flex items-center justify-center group transition-all rounded-2xl"
                                         >
                                             <div className="bg-cyan-500 text-black px-6 py-2 rounded-full font-black italic tracking-widest scale-90 group-hover:scale-100 transition-transform shadow-xl">SELECT MUSIC</div>
@@ -923,9 +726,9 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
                             <span className="text-[10px] font-black uppercase tracking-widest">Chat / Logs</span>
                         </div>
                         <div ref={logsViewportRef} className="flex-1 text-sm overflow-y-auto custom-scrollbar pr-2 h-0 space-y-1">
-                            {logs.length === 0 ? (
+                            {resolvedLogs.length === 0 ? (
                                 <p className="text-gray-500 italic">System: 全員の準備完了を待っています...</p>
-                            ) : logs.map((entry) => (
+                            ) : resolvedLogs.map((entry) => (
                                 <p
                                     key={entry.id}
                                     className={entry.tone === 'accent' ? 'text-cyan-400/90 font-bold' : 'text-gray-300'}
@@ -938,18 +741,9 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
 
                     {isHost ? (
                         <button
-                            onClick={() => {
-                                if (controlled?.onPrimaryAction) {
-                                    controlled.onPrimaryAction();
-                                    return;
-                                }
-
-                                if (roomStatus === 'WAITING' && players.every(p => p.isReady)) {
-                                    setRoomStatus('SELECTING');
-                                }
-                            }}
-                            disabled={controlled?.disablePrimaryAction ?? (roomStatus !== 'WAITING' || !players.every(p => p.isReady))}
-                            className={`w-72 font-black text-lg italic tracking-tighter rounded-xl flex items-center justify-center gap-3 transition-all active:scale-95 shadow-[0_0_30px_rgba(6,182,212,0.3)] ${(controlled?.disablePrimaryAction ?? (roomStatus !== 'WAITING' || !players.every(p => p.isReady)))
+                            onClick={() => onPrimaryAction?.()}
+                            disabled={primaryDisabled}
+                            className={`w-72 font-black text-lg italic tracking-tighter rounded-xl flex items-center justify-center gap-3 transition-all active:scale-95 shadow-[0_0_30px_rgba(6,182,212,0.3)] ${primaryDisabled
                                 ? 'bg-gray-800 text-gray-600 cursor-not-allowed opacity-50'
                                 : 'bg-cyan-500 hover:bg-cyan-400 text-black shadow-cyan-500/50'
                                 }`}
@@ -958,19 +752,12 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
                         </button>
                     ) : (
                         <button
-                            onClick={() => {
-                                if (controlled?.onToggleReady) {
-                                    controlled.onToggleReady();
-                                    return;
-                                }
-
-                                setIsReady(!isReady);
-                            }}
-                            disabled={controlled?.disablePrimaryAction ?? (roomStatus === 'SELECTING')}
+                            onClick={() => onToggleReady?.()}
+                            disabled={primaryDisabled}
                             className={`w-72 font-black text-lg italic tracking-tighter rounded-xl flex items-center justify-center gap-3 transition-all active:scale-95 ${isReady
                                 ? 'bg-transparent border-2 border-cyan-500 text-cyan-500 hover:bg-cyan-500/10'
                                 : 'bg-white text-black hover:bg-gray-200 shadow-xl'
-                                } ${(controlled?.disablePrimaryAction ?? (roomStatus === 'SELECTING')) ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                } ${primaryDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
                         >
                             {isReady ? 'CANCEL READY' : 'READY UP'}
                         </button>
@@ -1017,18 +804,18 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
                     </div>
                 </section>
 
-                {publicSharePanel ? (
+                {resolvedPublicSharePanel ? (
                     <section className="pt-6 border-t border-white/5">
-                        {publicSharePanel}
+                        {resolvedPublicSharePanel}
                     </section>
                 ) : null}
 
-                <section className={publicSharePanel ? "pt-6" : "pt-6 border-t border-white/5"}>
+                <section className={resolvedPublicSharePanel ? "pt-6" : "pt-6 border-t border-white/5"}>
                     <h3 className="text-[10px] font-black text-gray-500 uppercase tracking-widest mb-4 flex items-center gap-2">
                         <Info size={14} /> Match Info
                     </h3>
                     <div className="grid grid-cols-2 gap-2">
-                        {matchInfoItems.map((item) => (
+                        {resolvedMatchInfoItems.map((item) => (
                             <div key={item.label} className="bg-[#1e1e1e] p-2 rounded-lg border border-white/5">
                                 <span className="block text-[8px] text-gray-600 font-bold uppercase">{item.label}</span>
                                 <span className="text-[11px] font-bold text-cyan-400">{item.value}</span>
@@ -1052,16 +839,9 @@ export default function RoomArena({ onNavigate, initialStatus, controlled }: Roo
                 ) : null}
 
                 <button
-                    onClick={() => {
-                        if (controlled?.onLeaveRoom) {
-                            controlled.onLeaveRoom();
-                            return;
-                        }
-
-                        onNavigate?.('BROWSER');
-                    }}
-                    disabled={controlled?.disableLeave ?? (roomStatus === 'SELECTING' || roomStatus === 'PLAYING')}
-                    className={`flex items-center justify-center gap-2 transition-colors text-xs font-bold py-2 mt-auto ${(controlled?.disableLeave ?? (roomStatus === 'SELECTING' || roomStatus === 'PLAYING'))
+                    onClick={() => onLeaveRoom?.()}
+                    disabled={leaveDisabled}
+                    className={`flex items-center justify-center gap-2 transition-colors text-xs font-bold py-2 mt-auto ${leaveDisabled
                         ? 'text-gray-800 cursor-not-allowed'
                         : 'text-gray-600 hover:text-red-400'
                         }`}

--- a/apps/client/src/components/RoomArena.tsx
+++ b/apps/client/src/components/RoomArena.tsx
@@ -15,6 +15,7 @@ import { resolveSongVersionLabel } from './SongSearchModalView';
 
 export type Song = RoomSong;
 export type HistoryItem = RoomHistoryItem;
+export type RoomSearchModalContent = Exclude<ReactNode, null | undefined | boolean>;
 
 export interface RoomArenaPlayer {
     id: string;
@@ -88,7 +89,7 @@ export interface RoomArenaControlledState {
     allPlayers: RoomArenaPlayer[];
     selectedByName?: string | null;
     selfPlayerId?: string;
-    searchModal?: ReactNode;
+    searchModal: RoomSearchModalContent;
     disablePrimaryAction?: boolean;
     disableLeave?: boolean;
     onCopyRoomId?: () => void;

--- a/apps/client/src/components/RoomBPL.tsx
+++ b/apps/client/src/components/RoomBPL.tsx
@@ -1,10 +1,9 @@
-import React, { useState, useEffect, type ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import {
     User, CheckCircle2, Circle, LogOut,
     Database, Swords, Music, Copy, Check, Clock
 } from 'lucide-react';
 import { RoomPickDecisionCutIn, RoomSearchModalGate } from '../features/room/presentation-components';
-import { useClipboardFeedback, useResultPhaseTimer } from '../features/room/presentation-hooks';
 import {
     formatCountdown,
     formatOrdinal,
@@ -30,12 +29,6 @@ export interface ResultPhasePlayerSummary {
 export interface FinalResultPlayerSummary {
     totalPoints: number;
     isWinner: boolean;
-}
-
-interface RoomBPLProps {
-    onNavigate?: (screen: string) => void;
-    initialStatus?: 'WAITING' | 'SELECTING' | 'PLAYING' | 'RESULT' | 'CLOSED';
-    controlled?: RoomBPLControlledState;
 }
 
 export interface RoomBPLPlayer {
@@ -92,7 +85,7 @@ export interface RoomBPLControlledState {
 }
 
 export function RoomBPLPresentational(props: RoomBPLControlledState) {
-    return <RoomBPL controlled={props} />;
+    return <RoomBPL {...props} />;
 }
 
 const BPL_MUSIC_SELECT_SECONDS = 45;
@@ -101,97 +94,68 @@ const BPL_PLAY_BEGIN_SECONDS = BPL_MUSIC_SELECT_SECONDS + BPL_PLAY_START_SECONDS
 const BPL_STAGE_COUNT = 4;
 const BPL_REGULATION_LABEL = `${BPL_STAGE_COUNT} STAGES`;
 
-export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomBPLProps) {
-    const [roomStatusState, setRoomStatus] = useState<'WAITING' | 'SELECTING' | 'PLAYING' | 'RESULT' | 'CLOSED'>(initialStatus || 'WAITING');
-    const [isReadyState, setIsReady] = useState(initialStatus === 'SELECTING' || initialStatus === 'PLAYING' || initialStatus === 'RESULT' || initialStatus === 'CLOSED');
-    const [closeReasonState, setCloseReason] = useState<string>('ALL_ROUNDS_COMPLETED');
-    const [currentTurnState, setCurrentTurn] = useState(0); // 0: 1P, 1: 2P
-    const [roundCountState, setRoundCount] = useState(1);
-    const [picksState, setPicks] = useState<(Song | null)[]>(Array.from({ length: BPL_STAGE_COUNT }, () => null));
-    const [historyState, setHistory] = useState<HistoryItem[]>([]);
-    const [showSearchState, setShowSearch] = useState(false);
-    const [lastPickedSongState, setLastPickedSong] = useState<Song | null>(null);
-    const [showCutInState, setShowCutIn] = useState(false);
-    const [lobbyTimerState, setLobbyTimer] = useState(1200); // 20 minutes in seconds
-    const roomStatus = controlled?.roomStatus ?? roomStatusState;
-    const [resultTimerState] = useResultPhaseTimer(roomStatus === 'RESULT', finalizeRound);
-    const roomIdCopy = useClipboardFeedback();
-    const joinCodeCopy = useClipboardFeedback();
-
-    const roomId = controlled?.roomId ?? "";
-    const joinCode = controlled?.joinCode ?? "";
-    const battleModeLabel = controlled?.battleModeLabel ?? "";
+export default function RoomBPL({
+    roomStatus,
+    isReady,
+    closeReason,
+    resultTimer,
+    currentTurn,
+    roundCount,
+    picks,
+    history,
+    showSearch,
+    lastPickedSong,
+    showCutIn,
+    copiedId,
+    copiedCode,
+    lobbyTimer,
+    roomId,
+    joinCode,
+    battleModeLabel = '',
+    playTime,
+    playingPhase,
+    playingCountdownSeconds,
+    playerStatus,
+    playerMetrics,
+    metricLabel,
+    resultPlayers,
+    resultRegulationLabel,
+    finalResultPlayers,
+    finalWinningPlayerName,
+    isHost,
+    players,
+    roundPickerNames,
+    selfPlayerId,
+    disablePrimaryAction,
+    disableLeave,
+    searchModal,
+    onCopyRoomId,
+    onCopyJoinCode,
+    onOpenSearch,
+    onPrimaryAction,
+    onSkip,
+    onProceedToResult,
+    onLeaveRoom,
+    onRemakeStage,
+}: RoomBPLControlledState) {
     const hasJoinCode = joinCode.trim().length > 0;
     const maskedJoinCode = hasJoinCode ? maskJoinCode(joinCode) : '';
-
     const handleCopyRoomId = () => {
-        if (controlled?.onCopyRoomId) {
-            controlled.onCopyRoomId();
-            return;
-        }
-
-        roomIdCopy.copy(roomId);
+        onCopyRoomId?.();
     };
     const handleCopyJoinCode = () => {
-        if (controlled?.onCopyJoinCode) {
-            controlled.onCopyJoinCode();
-            return;
-        }
-
-        joinCodeCopy.copy(joinCode);
+        onCopyJoinCode?.();
     };
-
-    // PLAYING state logic
-    const [playTimeState, setPlayTime] = useState(0);
-    const [playingPhaseState, setPlayingPhase] = useState<'MUSIC_SELECT' | 'PLAY_START' | 'IN_PLAY'>('MUSIC_SELECT');
-    const [playerStatusState, setPlayerStatus] = useState<Record<string, RoomPlayerStatusLabel>>(
-        initialStatus === 'PLAYING' ? {
-            '1': 'PLAYED',
-            '2': 'UNCONFIRMED'
-        } : initialStatus === 'RESULT' ? {
-            '1': 'PLAYED',
-            '2': 'PLAYED'
-        } : {
-            '1': 'UNCONFIRMED',
-            '2': 'UNCONFIRMED'
-        }
-    );
-
-    // 初期化時にSELECTINGならモーダルを開く
-    useEffect(() => {
-        if (initialStatus === 'SELECTING') {
-            setShowSearch(true);
-        }
-    }, [initialStatus]);
-
-    const isHost = controlled?.isHost ?? true;
-
-    const isReady = controlled?.isReady ?? isReadyState;
-    const closeReason = controlled?.closeReason ?? closeReasonState;
-    const resultTimer = controlled?.resultTimer ?? resultTimerState;
-    const currentTurn = controlled?.currentTurn ?? currentTurnState;
-    const roundCount = controlled?.roundCount ?? roundCountState;
-    const picks = controlled?.picks ?? picksState;
-    const history = controlled?.history ?? historyState;
-    const showSearch = controlled?.showSearch ?? showSearchState;
-    const lastPickedSong = controlled?.lastPickedSong ?? lastPickedSongState;
-    const showCutIn = controlled?.showCutIn ?? showCutInState;
-    const copiedId = controlled?.copiedId ?? roomIdCopy.copied;
-    const copiedCode = controlled?.copiedCode ?? joinCodeCopy.copied;
-    const lobbyTimer = controlled?.lobbyTimer ?? lobbyTimerState;
-    const playTime = controlled?.playTime ?? playTimeState;
-    const playingPhase = controlled?.playingPhase ?? playingPhaseState;
-    const playingCountdownSeconds = controlled?.playingCountdownSeconds ?? (
+    const resolvedPlayingCountdownSeconds = playingCountdownSeconds ?? (
         playingPhase === 'MUSIC_SELECT' ? Math.max(0, BPL_MUSIC_SELECT_SECONDS - playTime) :
             playingPhase === 'PLAY_START' ? Math.max(0, BPL_PLAY_BEGIN_SECONDS - playTime) :
                 Math.max(0, playTime - BPL_PLAY_BEGIN_SECONDS)
     );
-    const playerStatus = controlled?.playerStatus ?? playerStatusState;
-    const playerMetrics = controlled?.playerMetrics ?? {};
-    const metricLabel = controlled?.metricLabel ?? 'EX SCORE';
-    const resultPlayers = controlled?.resultPlayers ?? {};
-    const resultRegulationLabel = controlled?.resultRegulationLabel ?? BPL_REGULATION_LABEL;
-    const finalResultPlayers = controlled?.finalResultPlayers ?? {};
+    const resolvedPlayerMetrics = playerMetrics ?? {};
+    const resolvedMetricLabel = metricLabel ?? 'EX SCORE';
+    const resolvedResultPlayers = resultPlayers ?? {};
+    const resolvedResultRegulationLabel = resultRegulationLabel ?? BPL_REGULATION_LABEL;
+    const resolvedFinalResultPlayers = finalResultPlayers ?? {};
     const totalStages = Math.max(1, picks.length);
     const currentPlayingSong = picks[roundCount - 1] || picks[totalStages - 1] || null;
     const currentResultSong = picks[roundCount - 1] || picks[totalStages - 1] || null;
@@ -204,148 +168,17 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
     const currentResultSongDifficulty = currentResultSong?.difficulty ?? 'A';
     const currentResultSongLevel = currentResultSong?.level ?? '12';
 
-    const players = controlled?.players ?? [
-        { id: '1', name: 'HOST', isReady: true, isHost: true, side: 'LEFT' },
-        { id: '2', name: 'GUEST', isReady: isReady, isHost: false, side: 'RIGHT' },
-    ];
-    const selfPlayerId = controlled?.selfPlayerId ?? (isHost ? '1' : '2');
-    const finalWinningPlayerName = controlled?.finalWinningPlayerName ?? players[0]?.name ?? '';
-
-    const handleStartMatch = () => {
-        if (controlled?.onPrimaryAction) {
-            controlled.onPrimaryAction();
-            return;
-        }
-
-        if (players.every(p => p.isReady)) {
-            setRoomStatus('SELECTING');
-            setCurrentTurn(0);
-        }
-    };
-
-    const handleSelectSong = (song: Song) => {
-        const newPicks = [...picks];
-        newPicks[currentTurn] = song;
-        setPicks(newPicks);
-        setShowSearch(false);
-        setLastPickedSong(song);
-        setShowCutIn(true);
-
-        // 3秒後にカットインを消し、次のターンへ（あるいは終了）
-        setTimeout(() => {
-            setShowCutIn(false);
-            const nextTurn = currentTurn + 1;
-            if (nextTurn < totalStages) {
-                setCurrentTurn(nextTurn);
-            } else {
-                // 両者の選曲が完了したら PLAYING へ
-                setRoomStatus('PLAYING');
-                setPlayTime(0);
-                setPlayingPhase('MUSIC_SELECT');
-            }
-        }, 3000);
-    };
-
-    // Lobby Timer management
-    useEffect(() => {
-        if (roomStatus !== 'WAITING') return;
-
-        const interval = setInterval(() => {
-            setLobbyTimer(prev => {
-                if (prev <= 1) {
-                    clearInterval(interval);
-                    setRoomStatus('CLOSED');
-                    setCloseReason('LOBBY_TIMEOUT');
-                    return 0;
-                }
-                return prev - 1;
-            });
-        }, 1000);
-
-        return () => clearInterval(interval);
-    }, [roomStatus]);
-
-    // PLAYING タイム管理
-    useEffect(() => {
-        if (roomStatus !== 'PLAYING') return;
-
-        const interval = setInterval(() => {
-            setPlayTime(prev => {
-                const next = prev + 1;
-
-                // フェーズ遷移
-                if (next < BPL_MUSIC_SELECT_SECONDS) setPlayingPhase('MUSIC_SELECT');
-                else if (next < BPL_PLAY_BEGIN_SECONDS) setPlayingPhase('PLAY_START');
-                else setPlayingPhase('IN_PLAY');
-
-                return next;
-            });
-        }, 1000);
-
-        return () => clearInterval(interval);
-    }, [roomStatus]);
-
-    const handleSkip = (playerId: string) => {
-        if (controlled?.onSkip) {
-            controlled.onSkip(playerId);
-            return;
-        }
-
-        setPlayerStatus(prev => ({ ...prev, [playerId]: 'SKIPPED' }));
-    };
-
-    function finalizeRound() {
-        const currentSong = picks[roundCount - 1] || picks[2];
-        if (!currentSong) return;
-
-        const mockScores: Record<string, number> = {
-            '1': Math.floor(Math.random() * 2000) + 1000,
-            '2': Math.floor(Math.random() * 2000) + 1000
-        };
-
-        const leftScore = mockScores['1'] ?? 0;
-        const rightScore = mockScores['2'] ?? 0;
-        const winnerId = leftScore > rightScore ? '1' : leftScore < rightScore ? '2' : 'DRAW';
-
-        const newItem: HistoryItem = {
-            round: roundCount,
-            song: currentSong,
-            scores: mockScores,
-            winnerId
-        };
-
-        setHistory(prev => [newItem, ...prev]);
-
-        if (roundCount < totalStages) {
-            setRoundCount(prev => prev + 1);
-            setRoomStatus('PLAYING');
-            setPlayTime(0);
-            setPlayerStatus({ '1': 'UNCONFIRMED', '2': 'UNCONFIRMED' });
-            setCurrentTurn(prev => (prev + 1) % 2); // ターン交代
-        } else {
-            setRoundCount(1);
-            setRoomStatus('CLOSED');
-            setCloseReason('ALL_ROUNDS_COMPLETED');
-        }
-    }
-
-    const handleProceedToResult = () => {
-        if (controlled?.onProceedToResult) {
-            controlled.onProceedToResult();
-            return;
-        }
-
-        setRoomStatus('RESULT');
-    };
-
-    const _currentSong = picks[0]; // TODO: 本来はラウンドに応じた曲を表示
-    const leftPlayer = players[0] ?? { id: '1', name: 'HOST', isReady: false, isHost: true, side: 'LEFT' as const };
-    const rightPlayer = players[1] ?? { id: '2', name: 'GUEST', isReady: false, isHost: false, side: 'RIGHT' as const };
-    const roundPickerNames = controlled?.roundPickerNames ?? Array.from(
+    const resolvedSelfPlayerId = selfPlayerId ?? (isHost ? '1' : '2');
+    const resolvedFinalWinningPlayerName = finalWinningPlayerName ?? players[0]?.name ?? '';
+    const primaryDisabled = disablePrimaryAction ?? false;
+    const leaveDisabled = disableLeave ?? (roomStatus === 'SELECTING' || roomStatus === 'PLAYING');
+    const leftPlayer = players[0] ?? { id: '1', name: '-', isReady: false, isHost: true, side: 'LEFT' as const };
+    const rightPlayer = players[1] ?? { id: '2', name: '-', isReady: false, isHost: false, side: 'RIGHT' as const };
+    const resolvedRoundPickerNames = roundPickerNames ?? Array.from(
         { length: totalStages },
         (_, index) => (index % 2 === 0 ? leftPlayer.name : rightPlayer.name),
     );
-    const currentRoundPickerName = roundPickerNames[roundCount - 1] ?? null;
+    const currentRoundPickerName = resolvedRoundPickerNames[roundCount - 1] ?? null;
 
     return (
         <div className="flex h-screen w-screen bg-[#0f0f10] text-white font-sans overflow-hidden">
@@ -353,10 +186,10 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
             {showCutIn ? <RoomPickDecisionCutIn song={lastPickedSong} /> : null}
 
             <RoomSearchModalGate
-                modal={controlled?.searchModal}
+                modal={searchModal}
                 isOpen={showSearch}
-                onClose={() => setShowSearch(false)}
-                onSelect={handleSelectSong}
+                onClose={() => undefined}
+                onSelect={() => undefined}
             />
 
             {/* メイン対峙エリア */}
@@ -415,7 +248,7 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
                         <div className="h-10 w-[1px] bg-white/10"></div>
                         <div className="text-left">
                             <p className="text-[10px] font-black text-gray-500 uppercase tracking-[0.3em]">Regulation</p>
-                            <h2 className="text-2xl font-black italic tracking-tighter text-gray-300 whitespace-nowrap">{resultRegulationLabel}</h2>
+                            <h2 className="text-2xl font-black italic tracking-tighter text-gray-300 whitespace-nowrap">{resolvedResultRegulationLabel}</h2>
                         </div>
                     </div>
                 </header>
@@ -456,14 +289,7 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
                         )}
                         {roomStatus === 'SELECTING' && currentTurn % 2 === 0 && (
                             <button
-                                onClick={() => {
-                                    if (controlled?.onOpenSearch) {
-                                        controlled.onOpenSearch();
-                                        return;
-                                    }
-
-                                    setShowSearch(true);
-                                }}
+                                onClick={() => onOpenSearch?.()}
                                 className="bg-cyan-500 text-black py-4 rounded-2xl font-black italic text-xl shadow-lg shadow-cyan-500/20 hover:scale-105 transition-transform active:scale-95"
                             >
                                 SELECT MUSIC
@@ -522,10 +348,10 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
                     >
                         {picks.map((pick, index) => {
                             const isHostTurn = index % 2 === 0;
-                            const fallbackLabel = roundPickerNames[index] === 'SYSTEM RANDOM'
+                            const fallbackLabel = resolvedRoundPickerNames[index] === 'SYSTEM RANDOM'
                                 ? 'SYSTEM RANDOM'
-                                : roundPickerNames[index]
-                                    ? `${roundPickerNames[index]}'S PICK`
+                                : resolvedRoundPickerNames[index]
+                                    ? `${resolvedRoundPickerNames[index]}'S PICK`
                                     : `${formatOrdinal(index + 1).toUpperCase()} PICK`;
                             return (
                                 <div
@@ -554,24 +380,14 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
                         })}
                         <div className="bg-white/5 rounded-2xl p-4 flex items-center justify-center">
                             <button
-                                onClick={() => {
-                                    if (controlled?.onPrimaryAction) {
-                                        controlled.onPrimaryAction();
-                                        return;
-                                    }
-
-                                    if (roomStatus === 'WAITING') {
-                                        if (isHost) handleStartMatch();
-                                        else setIsReady(!isReady);
-                                    }
-                                }}
-                                disabled={controlled?.disablePrimaryAction ?? false}
+                                onClick={() => onPrimaryAction?.()}
+                                disabled={primaryDisabled}
                                 className={`w-full h-full rounded-xl font-black italic text-xl transition-all active:scale-95 ${roomStatus === 'SELECTING'
                                     ? 'bg-gray-800 text-gray-600 cursor-not-allowed'
-                                    : ((controlled?.disablePrimaryAction ?? false)
+                                    : (primaryDisabled
                                         ? 'bg-gray-800 text-gray-500 cursor-not-allowed'
                                         : (isHost
-                                        ? (players.every(p => p.isReady) ? 'bg-cyan-500 text-black shadow-lg shadow-cyan-500/20 shadow-cyan-500/50' : 'bg-gray-800 text-gray-500 cursor-not-allowed')
+                                        ? 'bg-cyan-500 text-black shadow-lg shadow-cyan-500/20 shadow-cyan-500/50'
                                         : (isReady ? 'border-2 border-amber-500 text-amber-500' : 'bg-white text-black shadow-xl'))
                                         )
                                     }`}
@@ -636,7 +452,7 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
                                     </span>
                                     <div className="flex items-baseline gap-1">
                                         <span className="text-8xl font-black italic tracking-tighter font-mono">
-                                            {playingCountdownSeconds}
+                                            {resolvedPlayingCountdownSeconds}
                                         </span>
                                         <span className="text-2xl font-black text-gray-600 uppercase">sec</span>
                                     </div>
@@ -695,10 +511,10 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
                                     <div className="flex gap-4">
                                         {playerStatus[p.id] === 'UNCONFIRMED' && (
                                             <>
-                                                {p.id === selfPlayerId ? (
+                                                {p.id === resolvedSelfPlayerId ? (
                                                     <>
                                                         <button
-                                                            onClick={() => handleSkip(p.id)}
+                                                            onClick={() => onSkip?.(p.id)}
                                                             className="flex-1 bg-white/10 hover:bg-white/20 text-white py-3 rounded-2xl font-black italic tracking-widest transition-all text-sm"
                                                         >
                                                             SKIP
@@ -715,7 +531,7 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
                                             <div className="flex-1 flex flex-col items-center">
                                                 <span className="text-[8px] font-black text-green-500 uppercase tracking-[0.3em] mb-1">Match Statistics</span>
                                                 <div className="text-4xl font-black italic tracking-tighter text-white">
-                                                    {playerMetrics[p.id] ?? '-'} <span className="text-lg text-gray-500 font-sans">{metricLabel}</span>
+                                                    {resolvedPlayerMetrics[p.id] ?? '-'} <span className="text-lg text-gray-500 font-sans">{resolvedMetricLabel}</span>
                                                 </div>
                                             </div>
                                         )}
@@ -729,7 +545,7 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
                             <div className="mt-4 flex justify-center">
                                 <button
                                     className="bg-red-600/20 hover:bg-red-600 text-red-500 hover:text-white px-10 py-3 rounded-full border-2 border-red-500/30 text-xs font-black italic tracking-[0.3em] transition-all uppercase shadow-lg shadow-red-600/20"
-                                    onClick={handleProceedToResult}
+                                    onClick={() => onProceedToResult?.()}
                                 >
                                     FORCE FINALIZE MATCH
                                 </button>
@@ -786,14 +602,14 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
                                         <div className="w-[1px] h-10 bg-white/10" />
                                         <div className="text-left">
                                             <p className="text-[10px] font-black text-gray-500 uppercase">Regulation</p>
-                                            <p className="text-xl font-black italic tracking-tighter text-amber-400">{resultRegulationLabel}</p>
+                                            <p className="text-xl font-black italic tracking-tighter text-amber-400">{resolvedResultRegulationLabel}</p>
                                         </div>
                                     </div>
                                 </div>
                             </header>
                             <div className="flex-1 flex gap-6 items-center px-4 relative">
                                 {players.map((p) => {
-                                    const resultPlayer = resultPlayers[p.id];
+                                    const resultPlayer = resolvedResultPlayers[p.id];
                                     const isWinner = resultPlayer?.outcome === 'WINNER';
                                     const isDraw = resultPlayer?.outcome === 'DRAW';
                                     return (
@@ -816,7 +632,7 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
                                                 <p className="text-base font-bold text-gray-400 uppercase tracking-widest">{p.name}</p>
                                             </div>
                                             <div className="flex flex-col items-center">
-                                                <span className="text-[10px] font-black text-gray-500 uppercase tracking-widest">{metricLabel}</span>
+                                                <span className="text-[10px] font-black text-gray-500 uppercase tracking-widest">{resolvedMetricLabel}</span>
                                                 <span className={`text-5xl font-black italic leading-none ${isWinner || isDraw ? 'text-white' : 'text-gray-700'}`}>
                                                     {resultPlayer?.metricValue ?? '-'}
                                                 </span>
@@ -863,14 +679,14 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
                                     <p className="text-[10px] font-black text-cyan-500 uppercase tracking-[0.5em] mb-2">Official League Record</p>
                                     <div className="bg-white/5 px-6 py-4 rounded-2xl border border-white/10 backdrop-blur-3xl shadow-2xl">
                                         <p className="text-[10px] font-black text-gray-500 uppercase tracking-widest mb-1">Winning Player</p>
-                                        <p className="text-3xl font-black italic tracking-tighter text-cyan-400">{finalWinningPlayerName || '-'}</p>
+                                        <p className="text-3xl font-black italic tracking-tighter text-cyan-400">{resolvedFinalWinningPlayerName || '-'}</p>
                                     </div>
                                 </div>
                             </header>
 
                             <div className="flex-1 flex gap-12 items-center px-10 relative">
                                 {players.map((p) => {
-                                    const finalResultPlayer = finalResultPlayers[p.id];
+                                    const finalResultPlayer = resolvedFinalResultPlayers[p.id];
                                     const totalPts = finalResultPlayer?.totalPoints ?? 0;
                                     const isWinner = finalResultPlayer?.isWinner ?? false;
                                     return (
@@ -894,28 +710,14 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
 
                             <footer className="mt-12 flex justify-center gap-8 relative z-10">
                                 <button
-                                    onClick={() => {
-                                        if (controlled?.onLeaveRoom) {
-                                            controlled.onLeaveRoom();
-                                            return;
-                                        }
-
-                                        onNavigate?.('BROWSER');
-                                    }}
+                                    onClick={() => onLeaveRoom?.()}
                                     className="px-12 py-4 bg-cyan-500 hover:bg-cyan-400 text-black font-black italic text-xl rounded-2xl transition-all active:scale-95 shadow-[0_0_40px_rgba(6,182,212,0.3)] uppercase tracking-tighter"
                                 >
                                     Leave Arena
                                 </button>
-                                {isHost && (controlled?.onRemakeStage !== undefined || controlled === undefined) && (
+                                {isHost && onRemakeStage !== undefined && (
                                     <button
-                                        onClick={() => {
-                                            if (controlled?.onRemakeStage) {
-                                                controlled.onRemakeStage();
-                                                return;
-                                            }
-
-                                            setRoomStatus('WAITING');
-                                        }}
+                                        onClick={() => onRemakeStage?.()}
                                         className="px-10 py-4 bg-white/5 hover:bg-white/10 text-white font-black italic text-base rounded-2xl transition-all border-2 border-white/10 uppercase tracking-tighter backdrop-blur-xl"
                                     >
                                         Remake Stage
@@ -950,7 +752,7 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
                                         <div key={idx} className="bg-white/5 border border-white/10 rounded-xl p-3 hover:border-cyan-500/50 transition-all group animate-in slide-in-from-right duration-500">
                                             <div className="flex justify-between items-start mb-2">
                                                 <span className="text-[9px] font-black text-cyan-500 uppercase tracking-tighter italic">RD {item.round}</span>
-                                                <span className="text-[9px] font-black text-gray-500 uppercase">{metricLabel}</span>
+                                                <span className="text-[9px] font-black text-gray-500 uppercase">{resolvedMetricLabel}</span>
                                             </div>
                                             <div className="mb-2">
                                                 <h4 className="font-bold text-xs text-white truncate group-hover:text-cyan-400 transition-colors italic">{item.song.title}</h4>
@@ -973,16 +775,9 @@ export default function RoomBPL({ onNavigate, initialStatus, controlled }: RoomB
                         </div>
 
                         <button
-                            onClick={() => {
-                                if (controlled?.onLeaveRoom) {
-                                    controlled.onLeaveRoom();
-                                    return;
-                                }
-
-                                onNavigate?.('BROWSER');
-                            }}
-                            disabled={controlled?.disableLeave ?? (roomStatus === 'SELECTING' || roomStatus === 'PLAYING')}
-                            className={`flex items-center justify-center gap-2 transition-colors text-xs font-bold py-2 mt-auto ${(controlled?.disableLeave ?? (roomStatus === 'SELECTING' || roomStatus === 'PLAYING'))
+                            onClick={() => onLeaveRoom?.()}
+                            disabled={leaveDisabled}
+                            className={`flex items-center justify-center gap-2 transition-colors text-xs font-bold py-2 mt-auto ${leaveDisabled
                                 ? 'text-gray-800 cursor-not-allowed'
                                 : 'text-gray-600 hover:text-red-400'
                                 }`}

--- a/apps/client/src/components/RoomBPL.tsx
+++ b/apps/client/src/components/RoomBPL.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from 'react';
 import {
     User, CheckCircle2, Circle, LogOut,
     Database, Swords, Music, Copy, Check, Clock
@@ -15,6 +14,7 @@ import {
     type RoomSong
 } from '../features/room/presentation-shared';
 import { resolveSongVersionLabel } from './SongSearchModalView';
+import type { RoomSearchModalContent } from './RoomArena';
 
 export type Song = RoomSong;
 export type HistoryItem = RoomHistoryItem;
@@ -73,7 +73,7 @@ export interface RoomBPLControlledState {
     selfPlayerId?: string;
     disablePrimaryAction?: boolean;
     disableLeave?: boolean;
-    searchModal?: ReactNode;
+    searchModal: RoomSearchModalContent;
     onCopyRoomId?: () => void;
     onCopyJoinCode?: () => void;
     onOpenSearch?: () => void;

--- a/apps/client/src/features/room/room-page-compose.ts
+++ b/apps/client/src/features/room/room-page-compose.ts
@@ -29,7 +29,7 @@ export type RoomPageSharedComposeInput = {
   playingCountdownSeconds: number | null;
   isHost: boolean;
   selfPlayerId: string;
-  searchModal: ReactNode;
+  searchModal: RoomArenaControlledState["searchModal"];
   disablePrimaryAction: boolean;
   disableLeave: boolean;
   onCopyRoomId: () => void;
@@ -108,7 +108,7 @@ function buildSharedControlledProps(input: RoomPageSharedComposeInput) {
   return {
     ...shared,
     ...(input.selfPlayerId === undefined ? {} : { selfPlayerId: input.selfPlayerId }),
-    ...(input.searchModal === undefined ? {} : { searchModal: input.searchModal }),
+    searchModal: input.searchModal,
     ...(input.disablePrimaryAction === undefined ? {} : { disablePrimaryAction: input.disablePrimaryAction }),
     ...(input.disableLeave === undefined ? {} : { disableLeave: input.disableLeave }),
     ...(input.onCopyRoomId === undefined ? {} : { onCopyRoomId: input.onCopyRoomId }),


### PR DESCRIPTION
## Purpose
- Remove the dual-mode (`initialStatus` / `controlled`) room presentation surface for Issue #163 and keep `RoomArena` / `RoomBPL` driven by controlled props only.
- Preserve the existing WAITING / SELECTING / PLAYING / RESULT / CLOSED experience while consolidating action and mock progression ownership in `RoomPage`.

## Changes
- Refactor `apps/client/src/components/RoomArena.tsx` to accept controlled props only and remove component-local mock state, timers, fallback mutations, and dual-mode entrypoints.
- Refactor `apps/client/src/components/RoomBPL.tsx` to accept controlled props only and remove component-local mock progression, timers, fallback mutations, and dual-mode entrypoints.
- Keep callbacks such as copy/search/skip/proceed/leave/remake delegated to the controlled surface so `RoomPage` remains the owner of room presentation behavior.

## Non-Changes
- No `apps/worker/**`, `packages/shared/**`, or `docs/design/**` changes.
- No `RoomPage` state semantics change, no standalone dev harness addition, and no dependency / lockfile / workflow changes.

## Impact
- User impact: room UI keeps the same visible states and actions while removing component-owned mock behavior.
- Data impact: none.
- Compatibility impact: repo-local client component API cleanup only; no worker/shared/public contract change.
- Cloudflare/infra impact: none.

## Validation
- Commands run:
  - `npm ci`: pass
  - `npm run check:agents`: pass
  - `npm run lint`: pass
  - `npm run typecheck`: pass
  - `npm run build:client`: pass
  - `npm run test:client-stats`: pass
  - `npm run test:worker`: pass
  - `npm --workspace @infinitas/client run test`: pass
- Notes:
  - PR CI on `pull_request` uses the reusable `quick` profile (`check:agents`, `lint`, `typecheck`, `test:client-stats`, `test:worker`); this branch also ran `build:client` because `QUALITY.md` requires client build success for client changes.
  - `apps/client/tsconfig.json` excludes `src/**/*.test.ts`, so workspace typecheck alone is not treated as sufficient evidence for touched UI behavior.
  - No new or changed test files were added. `npm --workspace @infinitas/client run test` was kept as a compensating command for room presentation regression coverage.

## Regression Checks
- [x] ARENA and BPL `WAITING / SELECTING / PLAYING / RESULT / CLOSED` parity confirmed through `RoomPage` visual scenario verification.
- [x] Repo callsites no longer use `initialStatus` or `controlled=` dual-mode room props.
- [x] Host/non-host action ownership remains delegated through controlled callbacks instead of component-local fallback mutations.

## Risk and Rollback
- Risk level: normal
- Rollback plan: revert commit `6884a5a` to restore the previous dual-mode component behavior while keeping unrelated work untouched.

## Related
- Issue: #163
- Plan item/task label: `issue-163-room-pure-view-controlled-only`