### PR TITLE
Fix authoritative picking countdown display

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -7,7 +7,7 @@
     "dev": "vite --host 0.0.0.0 --port 1420",
     "build": "vite build",
     "build:test": "vite build --mode test",
-    "test": "tsx --test src/dev/visual-scenarios.test.ts src/features/room/presentation-shared.test.ts src/pages/auto-match-waiting-count-polling.test.ts src/services/worker-api-client.test.ts",
+    "test": "tsx --test src/dev/visual-scenarios.test.ts src/features/room/picking-countdown-display.test.tsx src/features/room/picking-countdown.test.ts src/features/room/presentation-shared.test.ts src/pages/auto-match-waiting-count-polling.test.ts src/services/worker-api-client.test.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",

--- a/apps/client/src/components/RoomArena.tsx
+++ b/apps/client/src/components/RoomArena.tsx
@@ -130,7 +130,7 @@ export default function RoomArena({
     isPrivateRoom = false,
     roomId,
     joinCode,
-    pickingCountdownSeconds = 0,
+    pickingCountdownSeconds = null,
     logs,
     matchInfoItems,
     publicSharePanel,

--- a/apps/client/src/components/SongSearchModalView.tsx
+++ b/apps/client/src/components/SongSearchModalView.tsx
@@ -140,7 +140,7 @@ export interface SongSearchModalViewProps {
     selectedDiff: string | null;
     selectedLevel: number | null;
     selectedVersion: string | null;
-    timeLeft: number;
+    timeLeft: number | null;
     displayedSongs: SongSearchModalSong[];
     totalSongs: number;
     hasMore?: boolean;
@@ -260,16 +260,18 @@ export function SongSearchModalView({
                             </div>
                         </div>
 
-                        <div className={`flex flex-col items-end px-6 py-2 rounded-xl border-2 transition-all ${timeLeft <= 10 ? 'border-red-500 bg-red-500/10 shadow-[0_0_20px_rgba(239,68,68,0.2)] animate-pulse' :
-                            timeLeft <= 30 ? 'border-amber-500 bg-amber-500/10' :
+                        <div className={`flex flex-col items-end px-6 py-2 rounded-xl border-2 transition-all ${timeLeft !== null && timeLeft <= 10 ? 'border-red-500 bg-red-500/10 shadow-[0_0_20px_rgba(239,68,68,0.2)] animate-pulse' :
+                            timeLeft !== null && timeLeft <= 30 ? 'border-amber-500 bg-amber-500/10' :
                                 'border-cyan-500/30 bg-cyan-500/5'
                             }`}>
                             <span className="text-[10px] font-black text-gray-500 uppercase tracking-widest leading-none mb-1">Time Left</span>
-                            <span className={`text-3xl font-mono font-black italic tracking-tighter leading-none ${timeLeft <= 10 ? 'text-red-500' :
-                                timeLeft <= 30 ? 'text-amber-500' :
+                            <span className={`text-3xl font-mono font-black italic tracking-tighter leading-none ${timeLeft !== null && timeLeft <= 10 ? 'text-red-500' :
+                                timeLeft !== null && timeLeft <= 30 ? 'text-amber-500' :
                                     'text-cyan-400'
                                 }`}>
-                                {Math.floor(timeLeft / 60)}:{(timeLeft % 60).toString().padStart(2, '0')}
+                                {timeLeft === null
+                                    ? "--:--"
+                                    : `${Math.floor(timeLeft / 60)}:${(timeLeft % 60).toString().padStart(2, '0')}`}
                             </span>
                         </div>
                     </div>

--- a/apps/client/src/features/room/picking-countdown-display.test.tsx
+++ b/apps/client/src/features/room/picking-countdown-display.test.tsx
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import RoomArena from "../../components/RoomArena";
+import { SongSearchModalView } from "../../components/SongSearchModalView";
+
+test("SongSearchModalView renders a null authoritative countdown as unavailable", () => {
+  const markup = renderToStaticMarkup(
+    <SongSearchModalView
+      isOpen={true}
+      search=""
+      selectedDiff={null}
+      selectedLevel={null}
+      selectedVersion={null}
+      timeLeft={null}
+      displayedSongs={[]}
+      totalSongs={0}
+      onSearchChange={() => undefined}
+      onToggleDiff={() => undefined}
+      onToggleLevel={() => undefined}
+      onToggleVersion={() => undefined}
+      onSelect={() => undefined}
+    />,
+  );
+
+  assert.match(markup, /Time Left/);
+  assert.match(markup, /--:--/);
+});
+
+test("RoomArena selection display renders a null picking countdown as unavailable", () => {
+  const markup = renderToStaticMarkup(
+    <RoomArena
+      isReady={false}
+      roomStatus="SELECTING"
+      closeReason=""
+      resultTimer={0}
+      roundCount={1}
+      history={[]}
+      playerPicks={{}}
+      showSearch={false}
+      showCutIn={false}
+      lastPickedSong={null}
+      copiedId={false}
+      copiedCode={false}
+      lobbyTimer={0}
+      currentPlayers={2}
+      maxPlayers={4}
+      roomId="room-1"
+      joinCode=""
+      pickingCountdownSeconds={null}
+      playTime={0}
+      playingPhase="MUSIC_SELECT"
+      playingCountdownSeconds={45}
+      playerStatus={{ "1": "UNCONFIRMED", "2": "UNCONFIRMED" }}
+      isHost={true}
+      allPlayers={[
+        { id: "1", name: "HOST", isReady: true, isHost: true },
+        { id: "2", name: "GUEST", isReady: true, isHost: false },
+      ]}
+      searchModal="search modal"
+    />,
+  );
+
+  assert.match(markup, /Time Remaining/);
+  assert.match(markup, /--:--/);
+});

--- a/apps/client/src/features/room/picking-countdown.test.ts
+++ b/apps/client/src/features/room/picking-countdown.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ROUND_MUSIC_SELECT_SECONDS } from "@infinitas/shared";
+import { getAuthoritativePickingCountdownSeconds } from "./picking-countdown";
+
+test("getAuthoritativePickingCountdownSeconds derives the same countdown from the same deadline", () => {
+  const nowMs = Date.parse("2026-03-08T00:00:50.000Z");
+  const deadline = "2026-03-08T00:02:00.000Z";
+
+  const selfCountdown = getAuthoritativePickingCountdownSeconds(deadline, nowMs);
+  const opponentCountdown = getAuthoritativePickingCountdownSeconds(deadline, nowMs);
+
+  assert.equal(selfCountdown, 70);
+  assert.equal(opponentCountdown, 70);
+});
+
+test("getAuthoritativePickingCountdownSeconds does not synthesize a fallback countdown", () => {
+  const nowMs = Date.parse("2026-03-08T00:00:50.000Z");
+
+  assert.equal(getAuthoritativePickingCountdownSeconds(null, nowMs), null);
+  assert.equal(getAuthoritativePickingCountdownSeconds(undefined, nowMs), null);
+  assert.equal(getAuthoritativePickingCountdownSeconds("not-a-date", nowMs), null);
+});
+
+test("getAuthoritativePickingCountdownSeconds clamps expired deadlines to zero", () => {
+  const nowMs = Date.parse("2026-03-08T00:02:01.000Z");
+  const deadline = "2026-03-08T00:02:00.000Z";
+
+  assert.equal(getAuthoritativePickingCountdownSeconds(deadline, nowMs), 0);
+});
+
+test("getAuthoritativePickingCountdownSeconds keeps PLAYING music select duration separate", () => {
+  const nowMs = Date.parse("2026-03-08T00:00:00.000Z");
+
+  assert.equal(ROUND_MUSIC_SELECT_SECONDS, 45);
+  assert.equal(getAuthoritativePickingCountdownSeconds(null, nowMs), null);
+});

--- a/apps/client/src/features/room/picking-countdown.ts
+++ b/apps/client/src/features/room/picking-countdown.ts
@@ -1,0 +1,15 @@
+export function getAuthoritativePickingCountdownSeconds(
+  pickingDeadline: string | null | undefined,
+  nowMs: number,
+): number | null {
+  if (!pickingDeadline) {
+    return null;
+  }
+
+  const deadlineMs = Date.parse(pickingDeadline);
+  if (Number.isNaN(deadlineMs)) {
+    return null;
+  }
+
+  return Math.max(0, Math.ceil((deadlineMs - nowMs) / 1_000));
+}

--- a/apps/client/src/pages/RoomPage.tsx
+++ b/apps/client/src/pages/RoomPage.tsx
@@ -1,13 +1,11 @@
 import {
   AUTO_REMATCH_RESULT_SECONDS,
-  BPL4_PICKING_TTL_SECONDS,
   BPL4_ROUNDS,
   BPL_ROUNDS,
   CHART_DIFFICULTIES,
   CHART_SEARCH_PAGE_SIZE,
   HOST_SKIP_UNLOCK_SECONDS,
   MATCH_TTL_MINUTES,
-  PICKING_TTL_SECONDS,
   ROUND_MUSIC_SELECT_SECONDS,
   ROUND_PLAY_BEGIN_AT_SECONDS,
   type ChartSearchEntry,
@@ -52,6 +50,7 @@ import {
   buildArenaControlledProps,
   buildBplControlledProps,
 } from "../features/room/room-page-compose";
+import { getAuthoritativePickingCountdownSeconds } from "../features/room/picking-countdown";
 import {
   resolveSongVersionDbValue,
   resolveSongVersionLabel,
@@ -1453,7 +1452,7 @@ export function RoomPage() {
   const lobbyStartIssues = snapshot.room_state === "LOBBY" ? getLobbyStartIssues(snapshot) : [];
   const currentRoundDisplay =
     currentRound === null ? null : snapshot.frozen_rounds.find((round) => round.round_index === currentRound.round_index) ?? null;
-  const pickingCountdown = getRemainingSeconds(getIsoTimeMs(snapshot.timers.picking_deadline), clockNowMs);
+  const pickingCountdown = getAuthoritativePickingCountdownSeconds(snapshot.timers.picking_deadline, clockNowMs);
   const playingCountdown = currentRound === null ? null : getPlayingCountdown(currentRound, clockNowMs);
   const resultCountdown = getRemainingSeconds(getIsoTimeMs(snapshot.timers.result_deadline), clockNowMs);
   const privateAutoRematchEnabled =
@@ -1953,12 +1952,7 @@ export function RoomPage() {
             }
           : {}
       )}
-      timeLeft={
-        pickingCountdown ??
-        (snapshot && isBplFourStageMode(snapshot.settings.mode)
-          ? BPL4_PICKING_TTL_SECONDS
-          : PICKING_TTL_SECONDS)
-      }
+      timeLeft={pickingCountdown}
       displayedSongs={pickerSongs}
       totalSongs={pickerSongs.length}
       hasMore={chartNextCursor !== null}
@@ -2780,7 +2774,7 @@ export function RoomPage() {
       battleModeLabel: arenaBattleModeLabel,
       regCount: arenaRegCount,
       isPrivateRoom: snapshot.settings.visibility === "PRIVATE",
-      pickingCountdownSeconds: pickingCountdown ?? 0,
+      pickingCountdownSeconds: pickingCountdown,
       logs: arenaLobbyLogs,
       matchInfoItems: arenaMatchInfoItems,
       publicSharePanel,

--- a/tasks/issue-170-picking-countdown-display.md
+++ b/tasks/issue-170-picking-countdown-display.md
@@ -1,0 +1,57 @@
+# issue-170-picking-countdown-display
+
+## Purpose
+- Fix divergent song-pick wait countdown display from Issue #170 while preserving the existing timer contract.
+
+## Non-goals
+- Do not change PICKING TTL values.
+- Do not change WS schema, `RoomStateSnapshot`, shared timer constants, Worker FSM, or Worker deadline authority.
+- Do not redefine `ROUND_MUSIC_SELECT_SECONDS=45` as PICKING wait time.
+
+## Current Request Boundary
+- Ceiling: implementation ready
+- Allowed outputs now: task artifact, bounded client implementation, focused tests, validation evidence
+- Forbidden outputs now: commit, PR, release, unrelated refactors
+- Next unlock condition: none
+
+## Changes
+- Derive the client pick-wait countdown only from authoritative `snapshot.timers.picking_deadline`.
+- Use the same derived countdown for picker modal and room selection display.
+- Avoid presenting a fallback TTL as an authoritative countdown when `picking_deadline` is absent.
+- Add focused regression tests for the countdown derivation.
+
+## Impact
+- Users: pick-wait countdown should no longer diverge between player views for the same snapshot deadline.
+- Data: none.
+- Compatibility: no schema or persisted-data change planned.
+- Cloudflare: no Worker deployment behavior change planned.
+
+## Target Files / Layers
+- Files: `apps/client/src/pages/RoomPage.tsx`, `apps/client/src/components/SongSearchModalView.tsx`, focused client room helper/test files.
+- Layers: client.
+
+## Test Focus
+- Same deadline and clock input yields the same remaining seconds regardless of consuming surface.
+- Missing `picking_deadline` returns no authoritative countdown instead of a fallback TTL.
+- Expired deadlines clamp to zero.
+- PLAYING `MUSIC SELECT:45` remains separate from PICKING countdown.
+
+## Rollback Plan
+- Revert the client helper, display wiring, and tests to restore the previous UI fallback behavior.
+
+## Commit Split Plan
+1. Client countdown derivation and display wiring.
+2. Focused regression tests.
+
+## Delegation Packet
+- task label: issue-170-picking-countdown-display
+- objective: make client pick-wait countdown display consistently reflect Worker-authoritative `picking_deadline`.
+- success criteria: modal and room display consume the same derived countdown; null deadline does not show a fallback authoritative-looking countdown; tests cover same-deadline, null-deadline, and expired-deadline cases.
+- in-scope files/layer: client files listed above.
+- non-goals: Worker/shared/schema/timer contract changes.
+- forbidden scope: unrelated UI redesign, lockfile changes, generated artifacts.
+- allowed side effects: focused client tests and minimal type updates.
+- expected output: implementation diff plus validation results.
+- validation: `npm run lint`, `npm run typecheck`, `npm run test:worker`, focused client test command.
+- continue-without-escalation boundary: client-only display and test changes.
+- escalation: any need to change Worker deadline generation, shared constants, WS payload/schema, snapshot compatibility, or PICKING TTL semantics.


### PR DESCRIPTION
## Purpose
- Fix Issue #170 where PICKING song-pick wait countdown display could diverge between players, for example self showing 45s while opponent shows 70s.
- Keep the existing timer contract: Worker-authored `snapshot.timers.picking_deadline` is authoritative, while `ROUND_MUSIC_SELECT_SECONDS=45` remains PLAYING-only.

## Changes
- Added a client helper that derives PICKING countdown seconds only from `snapshot.timers.picking_deadline`.
- Updated `RoomPage` so picker modal and ARENA selection display consume the same authoritative derived countdown.
- Changed missing/invalid PICKING deadline display to `--:--` instead of synthesizing a fallback TTL countdown.
- Added focused helper and render-level regression tests, and included them in the standard client test script.
- Added the Phase C task artifact at `tasks/issue-170-picking-countdown-display.md`.

## Non-Changes
- No PICKING TTL value changes.
- No Worker/DO FSM or deadline authority changes.
- No WS schema, `RoomStateSnapshot`, shared timer constants, or persisted data changes.
- No docs/design semantic update; existing docs already distinguish PICKING TTL from PLAYING `MUSIC SELECT:45`.

## Impact
- User impact: PICKING countdown display now consistently reflects the authoritative deadline and avoids misleading fallback countdowns.
- Data impact: none.
- Compatibility impact: none; client-only display behavior and tests.
- Cloudflare/infra impact: none; no Worker or resource configuration changes.

## Validation
- Commands run:
  - `npm run check:agents`: pass
  - `npm run lint`: pass
  - `npm run typecheck`: pass
  - `npm run test:client-stats`: pass
  - `npm run test:worker`: pass
  - `npm --workspace @infinitas/client run test`: pass
  - `npm --workspace @infinitas/client run build`: pass
  - `npm run check:design-contracts`: pass
  - `git diff --check`: pass
- Validation surface parity:
  - PR CI quick runs `check:agents`, lint, root typecheck, client stats tests, and worker tests; all were run locally.
  - New client tests are included in `apps/client/package.json` standard `test` script, and root `npm run typecheck` includes `apps/client/src/**/*.tsx` test files.

## Regression Checks
- [x] Same authoritative `picking_deadline` yields the same countdown value for consuming surfaces.
- [x] Missing/invalid `picking_deadline` renders unavailable (`--:--`) instead of fallback TTL.
- [x] Expired deadlines clamp to zero.
- [x] PLAYING `MUSIC SELECT:45` remains separate from PICKING countdown.
- [x] Existing Worker BPL(3)/BPL4 PICKING TTL tests still pass.
- [x] Lobby summary/freshness/cleanup matrix: N/A for this PR because no Worker/DO lobby summary, freshness, cleanup, or helper-state code changed.

## Risk and Rollback
- Risk level: high by governance classification because room-state timer display is contract-sensitive; implementation is client-only and intentionally does not alter server/shared contracts.
- Rollback plan: revert the two commits in this PR to restore previous client fallback display behavior.

## High-Risk Notes
- Rollback policy: standard git revert of this PR; no data migration or Cloudflare rollback required.
- Compatibility impact: none; no payload/schema/constant/persistence change.
- Cloudflare resources impact: none.
- docs/design update: none required; current docs already define PICKING TTL as 120s/180s and PLAYING `MUSIC SELECT` as 45s.

## Related
- Issue: #170
- Plan item/task label: `issue-170-picking-countdown-display`