### PR TITLE
docs(governance): 日本語出力と監査証跡を必須化

### DIFF
--- a/.codex/agents/contract-auditor.toml
+++ b/.codex/agents/contract-auditor.toml
@@ -26,20 +26,24 @@ developer_instructions = """
 5. compatibility classification（additive/breaking/unclear）
 6. missing updates
 7. validation gaps
-8. 監査 verdict（pass/pass-with-followups/fail）
-9. 状態（COMPLETE/BLOCKED/ESCALATION）
+8. findings disposition ledger（既存 findings がある場合: finding / disposition / evidence / remaining risk）
+9. 監査 verdict（pass/pass-with-followups/fail）
+10. 状態（COMPLETE/BLOCKED/ESCALATION）
 
 ## Prohibited behavior
 - 根拠なく「問題なし」を返さない。
 - 契約無関係のスタイル指摘を主軸にしない。
 - 互換保証を暗黙推定しない。
 - 仕様再定義や実装修正案の主担当へすり替わらない。
+- `Blocker` / `Must fix` findings の disposition がない状態で pass を返さない。
+- user-facing output を、user の明示指示なしに英語中心へ寄せない。
 
 ## Success condition
 - 契約リスクが具体根拠付きで示される。
 - 必要更新漏れが明示される。
 - 修正アクションが実行可能な形で返る。
 - findings が契約面の判断に集中し、手順論でぼかされない。
+- 既存 findings がある場合、disposition と残リスクが追跡できる。
 
 ## Escalation conditions
 - 規範仕様の記述不足で整合判定が不能。

--- a/.codex/agents/execution-coordinator.toml
+++ b/.codex/agents/execution-coordinator.toml
@@ -52,6 +52,7 @@ developer_instructions = """
 - workspace validation が CI より狭いのに、その差分を黙って見逃さない。
 - placeholder task path を concrete execution boundary として implementer へ渡さない。
 - user の広い動詞だけで、正本 artifact のより狭い current request ceiling を拡張しない。
+- user-facing な Plan / task artifact summary / handoff summary を、user の明示指示なしに英語中心へ寄せない。
 - user がすでに同一 request で downstream 実装を明示許可しているのに、synthetic な explicit unlock を task artifact へ差し込まない。
 - missing artifact を補う same turn で、明示 unlock なしに downstream 実装許可を付与しない。ただし同一 request が downstream 実装をすでに明示許可し、正本 artifact により狭い ceiling がない場合は除く。
 
@@ -65,6 +66,7 @@ developer_instructions = """
 - 別ターンの Phase C/D へ渡す場合、concrete な `tasks/*.md` を正本として示せる。
 - task artifact に allowed outputs / forbidden outputs / next unlock condition があり、実装担当が phase ceiling を踏み越えない。
 - implementation-ready で進められる request では、task artifact が synthetic な explicit implementation authorization を要求しない。
+- user-facing 出力は日本語を既定とし、固定ステータス語彙やコード識別子だけを必要に応じて英語で保持する。
 
 ## Escalation conditions
 - 仕様未確定で分割が安全に行えない。

--- a/.codex/agents/front-implementer.toml
+++ b/.codex/agents/front-implementer.toml
@@ -22,15 +22,17 @@ developer_instructions = """
 - implementation authorized (`yes/no`)
 - current request ceiling / next unlock condition（あれば）
 - allowed side effects / continue-without-escalation boundary（あれば）
+- UI 正本（wireframe / screenshot / design doc / visual reference）がある場合、その path / URL / identifier と必須準拠観点
 
 ## Required outputs
 1. 変更ファイル
 2. 振る舞い変更サマリ
 3. 実施検証
 4. validation surface note（local と CI の差があれば明記）
-5. shared/contract 影響
-6. follow-up が必要な論点
-7. 状態（COMPLETE/BLOCKED/ESCALATION）
+5. UI design source evidence（該当する場合: 参照元、反映点、確認方法）
+6. shared/contract 影響
+7. follow-up が必要な論点
+8. 状態（COMPLETE/BLOCKED/ESCALATION）
 
 ## Prohibited behavior
 - worker logic を変更しない。
@@ -41,6 +43,8 @@ developer_instructions = """
 - `implementation authorized != yes` のまま code edit を開始しない。
 - kickoff-only / task-authoring-only / planning-only request ceiling から product 実装へ進まない。
 - 長い作業手順に従ったことを理由に、objective 外の変更を正当化しない。
+- UI 正本が指定されているのに未確認のまま「準拠済み」と報告しない。
+- user-facing output を、user の明示指示なしに英語中心へ寄せない。
 
 ## Success condition
 - bounded client 変更が最小差分で実装される。
@@ -48,6 +52,7 @@ developer_instructions = """
 - 検証結果が reviewable に報告される。
 - 新規/変更 test file が type surface と standard test surface で取りこぼされない。
 - current request ceiling 内で自走継続できる範囲と、停止すべき境界が守られる。
+- UI 正本がある場合、参照元と実装確認証跡が残る。
 
 ## Escalation conditions
 - shared/worker 変更なしでは成立しない。
@@ -55,4 +60,5 @@ developer_instructions = """
 - 想定外の既存不整合を検出した。
 - implementation authorized が `yes` でない。
 - objective / success criteria / continue boundary だけでは安全に判断できなくなった。
+- 指定された UI 正本を確認できず、見た目準拠の判断ができない。
 """

--- a/.codex/agents/implementation-auditor.toml
+++ b/.codex/agents/implementation-auditor.toml
@@ -18,6 +18,8 @@ developer_instructions = """
 - 変更差分または変更ファイル
 - 意図された変更説明
 - 影響レイヤ
+- UI 正本（wireframe / screenshot / design doc / visual reference）がある場合、その参照情報
+- 既存 audit / review findings と対応状況（あれば）
 
 ## Required outputs
 1. 監査スコープ
@@ -27,9 +29,11 @@ developer_instructions = """
 5. validation gaps
 6. validation surface parity findings
 7. boundary violations
-8. 推奨追加検証
-9. 監査 verdict（pass/pass-with-followups/fail）
-10. 状態（COMPLETE/BLOCKED/ESCALATION）
+8. UI design source parity findings（該当する場合）
+9. findings disposition ledger（finding / disposition / evidence / remaining risk）
+10. 推奨追加検証
+11. 監査 verdict（pass/pass-with-followups/fail）
+12. 状態（COMPLETE/BLOCKED/ESCALATION）
 
 ## Prohibited behavior
 - 根拠なく「looks good」を返さない。
@@ -37,6 +41,9 @@ developer_instructions = """
 - 未検証の高リスク変更を完了扱いしない。
 - CI より狭い validation を十分とみなして見逃さない。
 - 仕様再定義や実装主担当へすり替わらない。
+- UI 正本があるのに未確認のまま見た目準拠を pass しない。
+- `Blocker` / `Must fix` findings の disposition がない状態で pass を返さない。
+- user-facing output を、user の明示指示なしに英語中心へ寄せない。
 
 ## Success condition
 - 重大リスクが優先順位付きで明示される。
@@ -44,9 +51,12 @@ developer_instructions = """
 - 修正/追加検証の次アクションが明確。
 - local pass と CI pass のズレがある場合、監査結果で明示される。
 - findings が evidence-first で返り、手順論だけで完了判断を代替しない。
+- findings disposition ledger により、未処理項目と残リスクが追跡できる。
+- UI 正本がある場合、実装との一致/差分が証跡付きで示される。
 
 ## Escalation conditions
 - 実行証跡不足で品質判定が不能。
 - 回帰リスクが高く現状では完了判定不可。
 - 責務境界違反が複数層に波及している。
+- UI 正本を確認できず、指定された見た目要件の合否を判定できない。
 """

--- a/.codex/agents/strategy-orchestrator.toml
+++ b/.codex/agents/strategy-orchestrator.toml
@@ -49,6 +49,7 @@ developer_instructions = """
 - open-ended 委譲をしない。非委譲時に理由を省略しない。
 - Entry Protocol 相当の出力を省略したまま次工程へ渡さない。
 - user が再指摘した制約を後続工程で取り落とさない。
+- user-facing な Plan / Entry Protocol / final routing summary を、user の明示指示なしに英語中心へ寄せない。
 - placeholder の `tasks/issue-<issue>-<name>.md` を concrete artifact とみなして Phase C/D を開始しない。
 - user の広い動詞だけを根拠に、正本 artifact のより狭い phase ceiling / stop condition を上書きしない。
 - user がすでに同一 request で downstream 実装を明示許可しているのに、synthetic な explicit unlock を挿入して implementation-ready boundary を縮めない。
@@ -62,6 +63,7 @@ developer_instructions = """
 - cross-turn の実装着手条件として concrete task artifact が必要な場合、それが明確に判定される。
 - current request ceiling と next unlock condition が明示され、広い verb による phase 踏み越えが起きない。
 - implementation-ready で進められる request では、余計な explicit implementation authorization を要求せず downstream へ渡せる。
+- user-facing 出力は日本語を既定とし、固定ステータス語彙やコード識別子だけを必要に応じて英語で保持する。
 
 ## Escalation conditions
 - 人間判断が必要な pending decision が残る。

--- a/.codex/skills/commit-pr-flow/SKILL.md
+++ b/.codex/skills/commit-pr-flow/SKILL.md
@@ -21,6 +21,7 @@ Return publish-ready evidence and status, not broad workflow re-planning.
 - Base branch (default: `v1`)
 - CI/repo validation surface when relevant (`package.json` scripts, workspace `tsconfig`, `.github/workflows/*`)
 - If this flow opens a PR, post-publish read-back of `author.login` / `author.is_bot`
+- Audit/review findings that must be disposed before PR, if any
 
 ## Workflow
 
@@ -74,6 +75,8 @@ Return publish-ready evidence and status, not broad workflow re-planning.
 9. Final consistency gate:
 - Ensure diff remains within declared scope.
 - Ensure required validation evidence is present.
+- If audit/review findings exist, include a disposition ledger for each `Blocker`, `Must fix`, and relevant `Should fix`.
+- Do not continue to PR handoff while unresolved `Blocker` or `Must fix` findings remain without explicit rescope/defer evidence.
 - Ensure completion status is explicit (`complete` or `blocked`).
 
 Do not:
@@ -86,12 +89,15 @@ Always return:
 - Scope check result
 - Validation result summary
 - Validation surface parity note
+- Findings disposition ledger when audit/review findings exist
 - Source worktree reconciliation summary
 - Commit units created (hash + message)
 - PR title and body (or PR URL if created)
 - PR author/lane evidence when a PR was created
 - Open risks, if any
 - Final status: `complete` or `blocked`
+
+User-facing summaries should be written in Japanese unless the user explicitly requests another language. Keep fixed protocol labels, command names, and code identifiers unchanged.
 
 ## Escalation Conditions
 
@@ -106,6 +112,7 @@ Always return:
 - Do not open a PR with unresolved required checks unless explicitly approved.
 - Do not mix unrelated cleanup with scoped implementation.
 - Do not claim completion while `Blocker` or unresolved `Must fix` findings remain.
+- Do not omit disposition evidence for audit/review findings that affected the commit or PR decision.
 - Do not assume workspace `typecheck` covers touched test files.
 - Do not assume a newly added test file is already part of the standard test script without checking.
 - Do not assume a published PR is `bot-created PR` without read-back of `author.login` / `author.is_bot`.

--- a/.codex/skills/phase-c-kickoff-flow/SKILL.md
+++ b/.codex/skills/phase-c-kickoff-flow/SKILL.md
@@ -58,6 +58,9 @@ Always return these sections in this order:
 8. `delegation execution record`
 9. `Replan triggers`
 
+Write user-facing kickoff output in Japanese unless the user explicitly requests another language.
+Keep fixed protocol labels, role names, file paths, and status tokens unchanged.
+
 Use this template:
 
 ```text

--- a/.codex/skills/phase-c-review-response-flow/SKILL.md
+++ b/.codex/skills/phase-c-review-response-flow/SKILL.md
@@ -26,6 +26,8 @@ Return a bounded review-response artifact and write-back plan, not a broad redes
   - touched layer
   - execution profile
   - current branch / diff state
+- Design source / wireframe reference when the review concerns UI fidelity
+- Existing audit/review findings and disposition state, if any
 - Applicable governance:
   - `AGENTS.md`
   - `WORKFLOW.md`
@@ -46,12 +48,17 @@ Return a bounded review-response artifact and write-back plan, not a broad redes
 5. For `High-Risk` work, rerun required implementer / contract audit / implementation audit on the current state.
 6. Run required validation from `QUALITY.md`.
    - If the trigger was CI / validate output, rerun the same command surface or a broader one.
-7. Prepare GitHub write-back in this order:
+7. Build a findings disposition ledger:
+   - each actionable finding / review thread
+   - disposition (`fixed`, `deferred with explicit scope`, `not applicable`, or `blocked`)
+   - evidence
+   - remaining risk
+8. Prepare GitHub write-back in this order:
    - thread reply
    - resolve addressed thread
    - re-review request after no unresolved actionable thread remains
    - confirm each GitHub write via returned URL/id or read-back
-8. Use [references/review-response-checklist.md](references/review-response-checklist.md) to keep the loop stable.
+9. Use [references/review-response-checklist.md](references/review-response-checklist.md) to keep the loop stable.
 
 Do not:
 - replace the source-of-truth artifact with review-thread-local assumptions
@@ -65,8 +72,9 @@ Always return:
 3. `Actionable thread set`
 4. `Execution profile re-judgment`
 5. `Validation and audit plan`
-6. `GitHub write-back plan or completed actions`
-7. `Final status`
+6. `Findings disposition ledger`
+7. `GitHub write-back plan or completed actions`
+8. `Final status`
 
 Use this template:
 
@@ -85,6 +93,9 @@ Execution profile re-judgment:
 Validation and audit plan:
 - <required checks>
 
+Findings disposition ledger:
+- <finding/thread / disposition / evidence / remaining risk>
+
 GitHub write-back plan or completed actions:
 - reply: <planned|done|N/A>
 - resolve: <planned|done|N/A>
@@ -98,9 +109,11 @@ Final status:
 
 - Do not expand scope just because a review comment suggests a broader cleanup.
 - Do not mark review work complete while actionable unresolved threads remain unaddressed.
+- Do not mark review work complete while `Blocker` or `Must fix` disposition is missing.
 - Do not resolve a thread without a substantive response tied to the final implementation.
 - Do not request re-review while unresolved actionable threads remain.
 - If a review requires contract change, cross-layer expansion, dependency update, or CI change, stop with `ESCALATION`.
 - If there are no actionable unresolved threads, return a no-op `COMPLETE` with evidence instead of fabricating write-back work.
 - Do not treat a narrower local validation pass as equivalent to the originating CI failure surface.
 - Do not invent extra procedural gates when actionable threads, validation, and write-back confirmation already determine the next step.
+- User-facing review response summaries should be written in Japanese unless the user explicitly requests another language. Keep thread ids, commands, and fixed status tokens unchanged.

--- a/.codex/skills/plan-mode-gate/SKILL.md
+++ b/.codex/skills/plan-mode-gate/SKILL.md
@@ -68,6 +68,9 @@ These rules support orchestration. They do not replace orchestrator ownership of
 
 ## Output Formats
 
+Write user-facing output in Japanese unless the user explicitly requests another language.
+Keep fixed labels such as `Local-Fast`, `Standard`, `High-Risk`, and `Plan Mode` unchanged.
+
 Execution profile recommendation: <Local-Fast|Standard|High-Risk>
 Plan Mode recommendation: <required|not required>
 Basis: <matched trigger(s) or local-fast basis>

--- a/.codex/skills/plan-mode-gate/references/task-plan-template.md
+++ b/.codex/skills/plan-mode-gate/references/task-plan-template.md
@@ -2,6 +2,8 @@
 
 Use this template when `Plan Mode` is required.
 Create `tasks/<branch-or-pr-name>.md` before implementation.
+Write user-facing plan content in Japanese unless the user explicitly requests another language.
+Keep fixed section labels, status tokens, file paths, and command names unchanged.
 
 # <task-name>
 
@@ -52,6 +54,7 @@ Create `tasks/<branch-or-pr-name>.md` before implementation.
 ## Usage Notes
 
 * Keep the plan minimal and directly tied to the requested change.
+* Write user-facing descriptions in Japanese unless another language is explicitly requested.
 * Do not start implementation before this file exists.
 * Do not treat file existence alone as implementation authorization; honor the current request boundary.
 * If the same user request already authorizes `Phase C implementation` / `C〜D execution` and the source artifact does not declare a narrower ceiling, set `Ceiling` to `implementation ready` and `Next unlock condition` to `none` instead of synthesizing another explicit authorization step.

--- a/.codex/skills/quality-check-matrix/references/validation-output-template.md
+++ b/.codex/skills/quality-check-matrix/references/validation-output-template.md
@@ -1,6 +1,8 @@
 # Validation Output Template
 
 Use this template for validation planning and reporting.
+Write user-facing validation summaries in Japanese unless the user explicitly requests another language.
+Keep command names, file paths, and fixed status tokens unchanged.
 
 ## Validation Recommendation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 - 目的達成に必要な最小差分を優先
 - 目的外変更を混ぜない
 - 実装・監査・要約は reviewable な粒度で返す
+- user-facing な Plan / kickoff / audit summary / final result は、user が明示的に別言語を求めない限り日本語で返す
 
 ---
 
@@ -85,6 +86,14 @@
 - sticky constraint は、後続の Entry Protocol / delegation packet / validation plan / close plan に影響する場合、出力へ再掲または織り込む
 - ローカル判断や慣例で sticky constraint を黙って上書きしない。成立不能なら `BLOCKED` / `ESCALATION` を返す
 - `A〜C Kickoffまで` / `task作成まで` / `実装は開始しない` のような terminal phase 指示は sticky hard constraint として扱い、明示解除まで downstream phase を開始しない
+
+### 1.6 Output Language
+
+ルール:
+- user-facing な最終出力、Plan、kickoff、review response、closure evidence summary は日本語を既定とする
+- `READY` / `BLOCKED` / `COMPLETE`、ファイル名、コマンド名、API名、PR本文テンプレの固定ラベルなど、運用上の識別子は英語のまま保持してよい
+- sub-agent / skill から英語テンプレートが返った場合でも、親 agent は user-facing summary を日本語へ正規化する
+- user が英語出力、原文維持、または外部提出用テンプレートを明示した場合はその指示を優先する
 
 ---
 
@@ -208,6 +217,15 @@ Delegation packet 必須項目:
 - delegated 必須出力が返却済み
 - 未解決 `Blocker` がない
 - 未解決 `Must fix` は明示的な再スコープ/延期がある
+- audit findings がある場合、`finding -> disposition -> evidence -> remaining risk` が追跡され、未処理の `Blocker` / `Must fix` が残っていない
+
+### 6.4 UI / Design Source Evidence
+
+ルール:
+- 正本 artifact が wireframe / screenshot / design doc / visual reference を指定する UI 実装では、その参照は implementation boundary の一部として扱う
+- 実装担当は参照した design source、反映した差分、確認方法を output に残す
+- 監査担当は visual source と実装の差異を validation gap または finding として扱う
+- design source を確認できない場合、見た目準拠を完了扱いせず `BLOCKED` / `ESCALATION` または明示的な residual risk として返す
 
 ---
 

--- a/QUALITY.md
+++ b/QUALITY.md
@@ -96,6 +96,7 @@ Client 変更時:
 - root docs / agent 定義 / skill の間で `objective` / `success criteria` / `stop condition` の責務配置が矛盾していない
 - judgment を agent から skill へ不適切に移していない
 - implementer / auditor の `continue` vs `BLOCKED` / `ESCALATION` 境界が欠落していない
+- user-facing な Plan / kickoff / audit summary / final result が、user の明示指示がない限り日本語で返される規則になっている
 
 ### 3.6 Workflow Artifact / Closure Task 実行時
 必須確認:
@@ -133,6 +134,16 @@ Client 変更時:
 - `High-Risk` の post-approval merge では、approve に加えて explicit merge authorization または auto-merge 許可がある
 - post-approval merge 後は PR merged state が URL / merged flag / merge commit SHA で確認されている
 - `merge + close + cleanup` を行う場合、順序が `merge -> closure evidence -> Issue close -> local cleanup` になっている
+- audit findings がある場合、`finding -> disposition -> evidence -> remaining risk` が追跡され、未処理の `Blocker` / `Must fix` が残っていない
+
+### 3.7 UI design source / wireframe 準拠がある変更時
+
+必須確認:
+- 正本 artifact が指定する wireframe / screenshot / design doc / visual reference を確認している
+- 確認した design source の path / URL / identifier が output に残っている
+- 実装差分が design source の該当箇所と対応している
+- text / layout / visibility / placement / overflow / responsive behavior のうち、正本で指定された観点が検証されている
+- visual source を確認できない場合、準拠確認を完了扱いせず residual risk または `BLOCKED` / `ESCALATION` としている
 
 ---
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -28,6 +28,8 @@
 - `Issue` / `tasks/*.md` / design docs が正本指定されている場合、Entry Protocol でその正本を明記する
 - Entry Protocol の出力は短くてよいが、後続の Phase 判断を再現できる粒度で残す
 - user が同一スレッドで再指摘した制約や順序がある場合、sticky constraint として以後の Phase 出力にも反映する
+- user-facing な Entry Protocol / Plan / kickoff / close summary / final result は、user が明示的に別言語を求めない限り日本語で返す
+- 固定ステータス語彙、コード識別子、ファイル名、コマンド名は英語のまま保持してよい
 
 ### 0.2 Execution Boundary From Source Artifact
 
@@ -326,6 +328,7 @@ Phase C 開始前に次を必ず出力する:
 - 新たな contract-sensitive 変更が必要
 - in-scope 外への拡張が必須
 - `Blocker` / `Must fix` 解消に仕様判断が必要
+- UI 正本として wireframe / screenshot / design doc / visual reference が指定されているが、参照不能または準拠確認不能
 - 互換方針 / 依存 / CI 変更が必要
 
 ルール:
@@ -362,6 +365,8 @@ Phase D 終了時は、必要に応じて governance / agent / skill / prompt/sn
 - review / close の GitHub write-back で反映確認不足があったか
 - clean worktree / branch isolation 後の source worktree に in-scope residue が残らなかったか
 - default/base branch 最新化の際に dirty path 分類や stash disposition が曖昧でなかったか
+- UI 正本 / wireframe / visual reference の確認証跡不足で実機レビュー差し戻しが起きたか
+- audit findings の disposition が曖昧なまま PR / close / completion へ進もうとしたか
 - 同種の `P1` / `P2` 指摘や運用ミスが再発したか
 - prompt/snippet の文面不足で planning-only / placeholder handoff / close ordering miss が起きたか
 - 広い user verb に引っ張られて、正本 artifact のより狭い phase ceiling を踏み越えなかったか
@@ -402,6 +407,7 @@ PR review / inline thread への対応は、原則として元の `Issue` / `tas
 - review fix の完了報告には、どの thread をどう処理したかを明示する
 - actionable unresolved thread が存在しない場合は、その no-op 判定根拠と current validation state を記録し、不要な write-back を行わない
 - GitHub write-back を行った場合は、reply / resolve / re-review request の反映結果を URL/id または read-back で確認する
+- review / audit findings は、completion 前に `finding -> disposition -> evidence -> remaining risk` で潰し込む
 
 ---
 

--- a/tasks/codex-governance-output-and-audit-evidence.md
+++ b/tasks/codex-governance-output-and-audit-evidence.md
@@ -1,0 +1,59 @@
+# codex-governance-output-and-audit-evidence
+
+## Purpose
+- 今後の Plan / kickoff / final など user-facing output を日本語優先にする。
+- UI 実装に wireframe / screenshot / design doc / visual source of truth がある場合、準拠確認の証跡を必須化する。
+- audit findings の disposition tracking を必須化し、PR / close / completion 前に `Blocker` / `Must fix` / `Should fix` が取り落とされないようにする。
+
+## Non-goals
+- product code や runtime behavior は変更しない。
+- agent の rename や固定8役モデルの変更はしない。
+- evidence と output language の明確化を超えて workflow semantics を広げない。
+
+## Current Request Boundary
+- Ceiling: implementation ready
+- Allowed outputs now: task artifact creation, governance doc edits, agent definition edits, skill instruction edits, required validation
+- Forbidden outputs now: product implementation, dependency updates, CI workflow changes, commit / push / PR / release
+- Next unlock condition: none
+
+## Changes
+- user-facing な Plan / kickoff summary / review summary / final report は、user が明示的に別言語を求めない限り日本語で書く規則を追加する。
+- wireframe / screenshot / design doc / visual reference を正本に持つ UI work では、design-source evidence を required output にする。
+- completion / PR publication / review response completion / merge / close / cleanup の前に audit finding disposition を確認する規則を追加する。
+
+## Impact
+- Users: 英語のみの planning / final output を減らし、review evidence を追跡しやすくする。
+- Data: none.
+- Compatibility: instruction semantics only.
+- Cloudflare: none.
+
+## Target Files / Layers
+- Files:
+  - `AGENTS.md`
+  - `WORKFLOW.md`
+  - `QUALITY.md`
+  - `.codex/agents/front-implementer.toml`
+  - `.codex/agents/implementation-auditor.toml`
+  - `.codex/agents/contract-auditor.toml`
+  - `.codex/skills/commit-pr-flow/SKILL.md`
+  - `.codex/skills/phase-c-review-response-flow/SKILL.md`
+  - `.codex/skills/plan-mode-gate/SKILL.md`
+  - `.codex/skills/phase-c-kickoff-flow/SKILL.md`
+- Layers: governance / agent / skill docs
+
+## Test Focus
+- `npm run check:agents`
+- `npm run check:design-contracts`
+- product-code changes と unrelated wording churn がないことの diff review
+
+## Rollback Plan
+- この scoped governance / agent / skill documentation change を revert する。
+
+## Commit Split Plan
+1. output language と evidence rules の governance / agent / skill wording update
+
+## Checklist
+- [x] Impact scope identified
+- [x] Implementation completed
+- [x] Tests completed
+- [x] Regression checks completed


### PR DESCRIPTION
## 目的
- Plan / kickoff / audit summary / final result などの user-facing 出力を、明示がない限り日本語に寄せる。
- UI 正本がある実装で wireframe / screenshot / design doc / visual reference の確認証跡を残す。
- audit / review findings の disposition ledger を必須化し、未処理の `Blocker` / `Must fix` を残したまま完了扱いしない。

## 変更点
- `AGENTS.md` / `WORKFLOW.md` / `QUALITY.md` に日本語出力、UI 正本証跡、findings disposition のルールを追加。
- `strategy-orchestrator` / `execution-coordinator` / `front-implementer` / `contract-auditor` / `implementation-auditor` の出力契約を更新。
- `commit-pr-flow` / `phase-c-review-response-flow` / `plan-mode-gate` / `phase-c-kickoff-flow` と関連テンプレートを更新。
- 作業境界を `tasks/codex-governance-output-and-audit-evidence.md` に記録。

## 検証
- `npm run check:agents` 成功
- `npm run check:design-contracts` 成功
- `git diff --check` 成功

## 非変更点
- product code / runtime behavior 変更なし
- dependency / CI workflow 変更なし